### PR TITLE
Fix Hyrax linking issue on front-page when logged in

### DIFF
--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -21,24 +21,12 @@
         <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
       <% end %></p>
 
-      <p><a href="http://uit.tufts.edu/?pid=744">
-        <img src="https://library.tufts.edu/screens/Logo2-35pxNoText.png" alt="Tufts Simplified Sign-On" height="35" width="35" />
-        Tufts Simplified Sign-On Enabled</a></p>
-
-
+  <p><a href="http://uit.tufts.edu/?pid=744">Tufts Simplified Sign-On Enabled</a></p>
+       
   <%# Display the following options for logged in users %>
   <% else %>
     <p>From this page you may deposit your scholarly work to the Tufts Digital Library.</p>
 
-    <div class="row">
-      <div class="col-sm-6">
-        <%= form_tag({controller: :contribute, action: :new}, method: :get, class: 'well') do %>
-          <div class="form-group">
-           
-          <%= submit_tag "Begin", class: 'btn-primary btn'  %>
-        <% end %>
-      </div>
-    </div>
 
     <p>Depositing your material to the Tufts Digital Library will require you to upload your file(s) and agree to
     the <a href='contribute/license'>Tufts Digital Library terms and conditions</a>.</p>


### PR DESCRIPTION
This bit of old code in our frontpage breaks when logging in: 
`<%= form_tag({controller: :contribute, action: :new}, method: :get, class: 'well') do %>`

This PR removes it and the external image link from #36 for now.