### PR TITLE
Pare down .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,18 @@
-sudo: required
-dist: trusty
 language: ruby
-cache: bundler
 sudo: false
-services:
-  - redis-server
+cache: bundler
+dist: trusty
+
 jdk:
   - oraclejdk8
 rvm:
   - 2.3.3
   - 2.3.4
+
 before_script:
   - bundle exec rake db:create
 script:
-  - bundle exec rubocop
-  - xvfb-run -a bundle exec rake ci
-env:
-  - QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
-addons:
-  apt:
-    packages:
-      - qt5-default
-      - libqt5webkit5-dev
-      - gstreamer1.0-plugins-base
-      - gstreamer1.0-tools gstreamer1.0-x
+  - bundle exec rake
+
+services:
+  - redis-server


### PR DESCRIPTION
`apt-get` was causing problems in the CI environment. At this point we don't need it.

This removes this and a number of other unneeded complexities.

Fixes #25.