### PR TITLE
Switch locales to all caps for our work type acronyms

### DIFF
--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -12,7 +12,7 @@
             <% create_work_presenter.each do |row_presenter| %>
             <option class="work-type-title" name="<%= row_presenter.concern %>" value="<%= row_presenter.concern %>"
                     data-single="<%= new_polymorphic_path([main_app, row_presenter.concern]) %>"
-                    data-batch="<%= hyrax.new_batch_upload_path(payload_concern: row_presenter.concern) %>"><%= row_presenter.name.titleize %></option>
+                    data-batch="<%= hyrax.new_batch_upload_path(payload_concern: row_presenter.concern) %>"><%= row_presenter.name %></option>
             <% end %>
           </select>
         </div>

--- a/config/locales/ead.en.yml
+++ b/config/locales/ead.en.yml
@@ -4,5 +4,5 @@ en:
       ead:     'fa fa-file-text-o'
     select_type:
       ead:
-        name:               "Ead"
-        description:        "Ead works"
+        name:               "EAD"
+        description:        "EAD works"

--- a/config/locales/pdf.en.yml
+++ b/config/locales/pdf.en.yml
@@ -4,5 +4,5 @@ en:
       pdf:     'fa fa-file-text-o'
     select_type:
       pdf:
-        name:               "Pdf"
-        description:        "Pdf works"
+        name:               "PDF"
+        description:        "PDF works"

--- a/config/locales/rcr.en.yml
+++ b/config/locales/rcr.en.yml
@@ -4,5 +4,5 @@ en:
       rcr:     'fa fa-file-text-o'
     select_type:
       rcr:
-        name:               "Rcr"
-        description:        "Rcr works"
+        name:               "RCR"
+        description:        "RCR works"

--- a/config/locales/tei.en.yml
+++ b/config/locales/tei.en.yml
@@ -4,5 +4,5 @@ en:
       tei:     'fa fa-file-text-o'
     select_type:
       tei:
-        name:               "Tei"
-        description:        "Tei works"
+        name:               "TEI"
+        description:        "TEI works"

--- a/spec/features/create_ead_spec.rb
+++ b/spec/features/create_ead_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Ead', :clean, js: true do
+RSpec.feature 'Create a EAD', :clean, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }
@@ -22,7 +22,7 @@ RSpec.feature 'Create a Ead', :clean, js: true do
       visit '/dashboard'
       click_link "Works"
       click_link "Add new work"
-      select 'Ead', from: 'work-type-select-box'
+      select 'EAD', from: 'work-type-select-box'
       click_button "Create work"
     end
   end

--- a/spec/features/create_pdf_spec.rb
+++ b/spec/features/create_pdf_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Pdf', :clean, js: true do
+RSpec.feature 'Create a PDF', :clean, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }
@@ -22,7 +22,7 @@ RSpec.feature 'Create a Pdf', :clean, js: true do
       visit '/dashboard'
       click_link "Works"
       click_link "Add new work"
-      select 'Pdf', from: 'work-type-select-box'
+      select 'PDF', from: 'work-type-select-box'
       click_button "Create work"
     end
   end

--- a/spec/features/create_rcr_spec.rb
+++ b/spec/features/create_rcr_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Rcr', :clean, js: true do
+RSpec.feature 'Create an RCR', :clean, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }
@@ -22,7 +22,7 @@ RSpec.feature 'Create a Rcr', :clean, js: true do
       visit '/dashboard'
       click_link "Works"
       click_link "Add new work"
-      select 'Rcr', from: 'work-type-select-box'
+      select 'RCR', from: 'work-type-select-box'
       click_button "Create work"
     end
   end

--- a/spec/features/create_tei_spec.rb
+++ b/spec/features/create_tei_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Tei', :clean, js: true do
+RSpec.feature 'Create a TEI', :clean, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }
@@ -22,7 +22,7 @@ RSpec.feature 'Create a Tei', :clean, js: true do
       visit '/dashboard'
       click_link "Works"
       click_link "Add new work"
-      select 'Tei', from: 'work-type-select-box'
+      select 'TEI', from: 'work-type-select-box'
       click_button "Create work"
     end
   end


### PR DESCRIPTION
This is for #75 , but there are still many instances of 'Tei' and hanging around in the views. I think 
we'll need to override `curation_concerns.human_readable_type` .