### PR TITLE
Implement Savable Drafts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ Metrics/BlockLength:
     - 'config/**/*'
     - 'app/controllers/catalog_controller.rb'
     - 'spec/rails_helper.rb'
+    - 'spec/**/*'
     
 Metrics/ClassLength:
   Exclude:

--- a/lib/tufts/draft.rb
+++ b/lib/tufts/draft.rb
@@ -1,0 +1,219 @@
+require 'active_fedora'
+require 'sparql'
+
+module Tufts
+  ##
+  # A set of draft metadata edits
+  class Draft
+    ##
+    # @!attribute [rw] changeset
+    #   @return [ActiveFedora::Changeset]
+    # @!attribute [rw] id
+    #   @return [String]
+    # @!attribute [rw] model
+    #   @return [Tufts::Draftable]
+    attr_accessor :changeset, :id, :model
+
+    ##
+    # @param model [ActiveFedora::Base]
+    # @return [Draft] A draft including the unsaved changes from the model
+    def self.from_model(model)
+      draft = new(model: model)
+      draft.id = model.id if model.id
+
+      draft.changeset =
+        ActiveFedora::ChangeSet.new(model,
+                                    model.resource,
+                                    model.changed_attributes.keys)
+      # Force cache of changeset#changes. We don't want the draft's change
+      # list to change if the in-memory model is edited
+      draft.changeset.changes
+      draft
+    end
+
+    ##
+    # @param changeset [ActiveFedora::ChangeSet]
+    # @param id        [String]
+    # @param model     [ActiveFedora::Base]
+    def initialize(model:, changeset: NullChangeSet.new, id: SecureRandom.uuid)
+      self.changeset = changeset
+      self.id        = id
+      self.model     = model
+    end
+
+    ##
+    # @return [void] applies the changeset to the model
+    def apply # rubocop:disable Metrics/MethodLength
+      changeset.changes.each do |predicate, graph|
+        config = config_for_predicate(predicate)
+
+        if config.nil?
+          raise "Invalid ChangeSet. Property for #{predicate} does not " \
+                "exist on #{model}"
+        end
+
+        property, config = config
+
+        graph.group_by(&:subject).each do |subject, statements|
+          if subject == model.rdf_subject
+            values = statements.map(&:object)
+            values = values.first unless config.multiple?
+            model.send("#{property}=".to_sym, values)
+          else
+            model.resource.insert(*statements)
+          end
+        end
+      end
+
+      delete
+    end
+
+    ##
+    # Deletes the draft and empties the changeset. Calling #apply after delete
+    # is a no-op.
+    #
+    # @example
+    #   draft = Draft.new(model: a_draftable)
+    #   draft.exists # => false
+    #
+    #   draft.save
+    #   draft.exists # => true
+    #
+    #   draft.delete
+    #   draft.exists           # => false
+    #   draft.changeset.empty? # => true
+    #
+    # @return [Draft] self
+    def delete
+      File.delete(path) if exists?
+      load
+    end
+
+    ##
+    # @return [Boolean]
+    def exists?
+      File.exist? path
+    end
+
+    ##
+    # Loads the changeset from the saved version.
+    # @return [Draft] self
+    def load
+      return @changeset = NullChangeSet.new unless exists?
+
+      File.open(path) { |f| from_sparql(f.read) }
+      self
+    end
+
+    ##
+    # Saves the draft.
+    #
+    # @example
+    #   draft = Draft.new(model: a_draftable)
+    #   draft.exists # => false
+    #
+    #   draft.save
+    #   draft.exists # => true
+    #
+    # @return [Draft] self
+    def save
+      File.open(path, 'w') { |f| f.write(to_sparql) }
+      self
+    end
+
+    ##
+    # An empty changeset
+    #
+    # @exmaple
+    #   cs = NullChangeSet.new(object, graph, changed_attributes)
+    #   cs.empty?  # => true
+    #   cs.changes # => {}
+    #
+    # @see https://en.wikipedia.org/wiki/Null_Object_pattern
+    # @see ActiveFedora::ChangeSet
+    class NullChangeSet
+      def initialize(*); end
+
+      def empty?
+        true
+      end
+
+      def changes
+        {}
+      end
+    end
+
+    private
+
+      ##
+      # We can't just apply the sparql string, because <> (null relative uri's)
+      # used by ActiveFedora is unsupported in SPARQL, so we need to parse and
+      # reconstruct the insert set manually.
+      #
+      # @return [void]
+      def from_sparql(update_string)
+        statements = extract_insert_statements(update_string)
+
+        self.changeset =
+          ActiveFedora::ChangeSet.new(model,
+                                      changed_graph(statements),
+                                      changed_attribute_keys(statements))
+        # cache the changes
+        changeset.changes
+      end
+
+      ##
+      # @return [RDF::Graph]
+      def changed_graph(statements)
+        graph = model.resource.dup
+
+        grouped = statements.group_by do |statement|
+          statement.subject.to_base + statement.predicate.to_base
+        end
+
+        grouped.each do |_, sts|
+          graph.update(sts.pop)
+          graph.insert(*sts)
+        end
+
+        graph
+      end
+
+      ##
+      # @return [Array<Symbol>]
+      def changed_attribute_keys(statements)
+        statements.map(&:predicate).uniq.map do |predicate|
+          config_for_predicate(predicate)
+        end.compact.map(&:first)
+      end
+
+      def config_for_predicate(predicate)
+        model.class.properties.find { |_, v| v.predicate == predicate }
+      end
+
+      ##
+      # @return [Array<RDF::Statement>)
+      def extract_insert_statements(update_string)
+        inserts = SPARQL.parse(update_string, update: true).each_descendant.select do |op|
+          op.is_a? SPARQL::Algebra::Operator::Insert
+        end
+
+        inserts.flat_map do |insert|
+          insert.operand.map do |pattern|
+            RDF::Statement(pattern.subject, pattern.predicate, pattern.object)
+          end
+        end
+      end
+
+      ##
+      # @return [String] a SPARQL Update string
+      def to_sparql
+        return '' if changeset.empty?
+        ActiveFedora::SparqlInsert.new(changeset.changes, model.rdf_subject).build
+      end
+
+      def path
+        Rails.root.join('tmp', 'drafts', id)
+      end
+  end
+end

--- a/lib/tufts/draft.rb
+++ b/lib/tufts/draft.rb
@@ -14,6 +14,8 @@ module Tufts
     #   @return [Tufts::Draftable]
     attr_accessor :changeset, :id, :model
 
+    STORAGE_DIR = Rails.root.join('tmp', 'drafts').freeze
+
     ##
     # @param model [ActiveFedora::Base]
     # @return [Draft] A draft including the unsaved changes from the model
@@ -213,7 +215,7 @@ module Tufts
       end
 
       def path
-        Rails.root.join('tmp', 'drafts', id)
+        STORAGE_DIR.join(id)
       end
   end
 end

--- a/lib/tufts/draftable.rb
+++ b/lib/tufts/draftable.rb
@@ -1,0 +1,4 @@
+module Tufts
+  module Draftable
+  end
+end

--- a/spec/lib/tufts/draft_spec.rb
+++ b/spec/lib/tufts/draft_spec.rb
@@ -1,0 +1,199 @@
+require 'rails_helper'
+require 'tufts/draft'
+
+RSpec.describe Tufts::Draft do
+  subject(:draft)   { described_class.new(model: model) }
+  let(:model)       { model_class.new }
+  let(:predicate)   { RDF::Vocab::DC.title }
+
+  let(:model_class) do
+    fake_draftable = Class.new(ActiveFedora::Base)
+    fake_draftable.property(:title,   predicate: predicate)
+    fake_draftable.property(:subject, predicate: RDF::Vocab::DC.subject)
+    fake_draftable
+  end
+
+  define :have_changes do |expected|
+    match do |actual|
+      expected.changes.each do |key, value|
+        expect(actual.changes[key].to_a).to contain_exactly(*value.to_a)
+      end
+    end
+  end
+
+  shared_context 'with changes' do
+    subject(:draft) { described_class.new(model: model, changeset: changeset) }
+
+    let(:changeset) do
+      new_model = model_class.new(title: ['moomin', 'moominmama', 'snork'],
+                                  subject: ['too-ticky'])
+      ActiveFedora::ChangeSet
+        .new(new_model, new_model.resource, new_model.changed_attributes.keys)
+    end
+  end
+
+  describe '.from_model' do
+    subject(:draft) { described_class.from_model(model) }
+
+    it 'generates a draft with the correct model' do
+      expect(draft.model).to eql model
+    end
+
+    it 'has an empty changeset when model is unchanged' do
+      expect(draft.changeset).to be_empty
+    end
+
+    context 'when model has changes' do
+      before { model.title = ['moomin'] }
+
+      it 'has a non-empty changeset' do
+        expect(draft.changeset).not_to be_empty
+      end
+
+      it 'has the correct changes' do
+        expect(draft.changeset.changes.keys).to contain_exactly predicate
+      end
+
+      it 'remains unchanged when the model changes again' do
+        expect { model.title = ['Snorkmaiden'] }
+          .not_to change { draft.changeset.changes }
+      end
+    end
+  end
+
+  describe '#apply' do
+    context 'with no changes' do
+      it 'leaves the model unchanged' do
+        expect { draft.apply }.not_to change { model.resource.statements }
+      end
+    end
+
+    context 'with changes' do
+      include_context 'with changes'
+
+      it 'applies the changes' do
+        expect { draft.apply }
+          .to change { model.title.to_a }
+          .to contain_exactly('moomin', 'moominmama', 'snork')
+      end
+
+      it 'updates changed attributes' do
+        expect { draft.apply }
+          .to change { model.changed_attributes }
+          .to include('title', 'subject')
+      end
+    end
+
+    context 'when saved' do
+      before { draft.save }
+
+      it 'deletes the draft' do
+        expect { draft.apply }
+          .to change { draft.exists? }
+          .from(true)
+          .to(false)
+      end
+    end
+
+    context 'with changes' do
+      include_context 'with changes'
+
+      it 'empties the changeset' do
+        expect { draft.apply }
+          .to change { draft.changeset.empty? }
+          .from(false)
+          .to(true)
+      end
+    end
+  end
+
+  describe '#changeset accessor' do
+    it 'has an empty changeset on initalize' do
+      expect(draft.changeset).to be_empty
+    end
+  end
+
+  describe '#delete' do
+    it 'does not change when not saved' do
+      expect { draft.delete }
+        .not_to change { draft.exists? }
+        .from(false)
+    end
+
+    context 'when saved' do
+      before { draft.save }
+
+      it 'flips #exists? to false' do
+        expect { draft.delete }
+          .to change { draft.exists? }
+          .from(true)
+          .to(false)
+      end
+    end
+  end
+
+  describe '#id' do
+    it 'gives the same value repeatably' do
+      expect { draft.id }           # this actually calls #id 3 times,
+        .not_to change { draft.id } # but it's cute so I'm keeping it.
+    end
+  end
+
+  describe '#load' do
+    it 'loads empty when unsaved' do
+      expect { draft.load }
+        .not_to change { draft.changeset.empty? }
+        .from true
+    end
+
+    context 'with unsaved changes' do
+      include_context 'with changes'
+
+      it 'reloads empty' do
+        expect { draft.load }
+          .to change { draft.changeset.empty? }
+          .from(false)
+          .to(true)
+      end
+    end
+
+    context 'with saved changes' do
+      include_context 'with changes'
+
+      before { draft.save }
+
+      it 'retains the changes' do
+        expect { draft.load }
+          .not_to change { draft.changeset.changes }
+      end
+
+      it 'reloads saved changes' do
+        saved_changes   = draft.changeset
+        draft.changeset = described_class::NullChangeSet.new
+
+        expect { draft.load }
+          .to change { draft.changeset }
+          .to have_changes(saved_changes)
+      end
+    end
+  end
+
+  describe '#model accessor' do
+    let(:new_model) { model_class.new }
+
+    it 'sets the model' do
+      expect { draft.model = new_model }
+        .to change { draft.model }
+        .from(model).to(new_model)
+    end
+  end
+
+  describe '#save' do
+    it 'exists after save' do
+      expect { draft.save }
+        .to change { draft.exists? }
+        .from(false)
+        .to(true)
+    end
+  end
+end

--- a/spec/lib/tufts/draft_spec.rb
+++ b/spec/lib/tufts/draft_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'tufts/draft'
+require 'fileutils'
 
 RSpec.describe Tufts::Draft do
   subject(:draft)   { described_class.new(model: model) }
@@ -12,6 +13,14 @@ RSpec.describe Tufts::Draft do
     fake_draftable.property(:subject, predicate: RDF::Vocab::DC.subject)
     fake_draftable
   end
+
+  before(:context) do
+    unless File.directory?(described_class::STORAGE_DIR)
+      FileUtils.mkdir_p(described_class::STORAGE_DIR)
+    end
+  end
+
+  after { draft.delete }
 
   define :have_changes do |expected|
     match do |actual|

--- a/spec/lib/tufts/draftable_spec.rb
+++ b/spec/lib/tufts/draftable_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+require 'tufts/draftable'
+
+RSpec.describe Tufts::Draftable do
+  subject(:model)   { model_class.new }
+  let(:model_class) { Class.new }
+
+  it_behaves_like 'a draftable model'
+end

--- a/spec/support/shared_examples/draftable.rb
+++ b/spec/support/shared_examples/draftable.rb
@@ -1,0 +1,11 @@
+RSpec.shared_examples 'a draftable model' do
+  before do
+    unless defined?(model)
+      raise 'Define `model` with `let(:model)` before using the ' \
+            'draftable model shared examples'
+    end
+  end
+
+  describe '#draft'
+  describe '#has_draft?'
+end


### PR DESCRIPTION
Drafts can be generated from an existing ActiveFedora-like model and
saved to disk as SPARQL Update queries.

Changes between the `Draft` and the saved model are tracked in memory
as `ActiveFedora::ChangeSet` objects, using the same tooling normally
used to make updates. When reserializing, we need to rebuild the
`ChangeSet` manually from the SPARQL Update request.

```ruby
image = Image.create(title: ['a title'])
image.title   = ['Comet in Moominland']
image.subject = ['moomins']

draft = Draft.from_model(image)
draft.save
draft.exists? # => true

same_image   = Image.find(id: image.id)
loaded_draft = Draft.from_model(same_image)
loaded_draft.load
loaded_draft.apply

same_image.title   # => ['Comet in Moominland']
same_image.subject # => ['moomins']
```

Unfortunately, `ActiveFedora` doesn't implement a
`ChangeSet#apply`. We may want to consider refactoring our version to
submit it back to the upstream library. On the other hand, `ChangeSet`
as a whole could probably be reworked to use `RDF::Changeset`, and
that is probably a better road to go down if we are contributing back.

A follow up PR will implement a `Draftable` interface for models
allowing, interactions directly on the model; e.g.:

```ruby
image = Image.create(title: ['a title'])
image.title   = ['Comet in Moominland']
image.subject = ['moomins']

image.has_draft? # => false

image.save_draft
image.has_draft? # => true

same_image = Image.find(id: image.id)

same_image.has_draft?  # => true
same_image.draft.apply

same_image.title   # => ['Comet in Moominland']
same_image.subject # => ['moomins']
```