### PR TITLE
Draft Interface

### DIFF
--- a/lib/tufts/draft.rb
+++ b/lib/tufts/draft.rb
@@ -123,28 +123,6 @@ module Tufts
       self
     end
 
-    ##
-    # An empty changeset
-    #
-    # @exmaple
-    #   cs = NullChangeSet.new(object, graph, changed_attributes)
-    #   cs.empty?  # => true
-    #   cs.changes # => {}
-    #
-    # @see https://en.wikipedia.org/wiki/Null_Object_pattern
-    # @see ActiveFedora::ChangeSet
-    class NullChangeSet
-      def initialize(*); end
-
-      def empty?
-        true
-      end
-
-      def changes
-        {}
-      end
-    end
-
     private
 
       ##
@@ -196,6 +174,8 @@ module Tufts
       ##
       # @return [Array<RDF::Statement>)
       def extract_insert_statements(update_string)
+        return [] if update_string.nil? || update_string.empty?
+
         inserts = SPARQL.parse(update_string, update: true).each_descendant.select do |op|
           op.is_a? SPARQL::Algebra::Operator::Insert
         end

--- a/lib/tufts/draftable.rb
+++ b/lib/tufts/draftable.rb
@@ -1,4 +1,59 @@
 module Tufts
+  ##
+  # A  Mixin for making `ActiveFedora::Base`-like objects able to manage draft
+  # versions.
+  #
+  # @example saving a draft
+  #   class MyModel < ActiveFedora::Base
+  #     include Draftable
+  #     property :title,   predicate: RDF::Vocab::DC.title
+  #     property :subject, predicate: RDF::Vocab::DC.subject
+  #   end
+  #
+  #   object = MyModel.create(title: ['temporary title'])
+  #   object.title   = ['Draft Title']
+  #   object.subject = ['Draft Subject']
+  #   object.save_draft
+  #
+  #   object.reload      # empty the unsaved changes
+  #   object.apply_draft # recover the changes from the draft
+  #
   module Draftable
+    ##
+    # @return [void]
+    def delete_draft
+      draft.delete
+    end
+
+    ##
+    # Gives a draft object based on this model. If a draft exists for the model
+    # (`#draft_saved?`), that draft is loaded; otherwise a new draft is created
+    # reflecting the current state of this object.
+    #
+    # @return [Draft] a draft version of this object
+    def draft
+      draft = Draft.from_model(self)
+      draft.load if draft.exists?
+      draft
+    end
+
+    ##
+    # @note A saved draft may be empty.
+    # @return [Boolean] true if a draft hs been saved for this object
+    def draft_saved?
+      draft.exists?
+    end
+
+    ##
+    # @see Draft#apply
+    def apply_draft
+      draft.apply
+    end
+
+    ##
+    # @see Draft#save
+    def save_draft
+      draft.save
+    end
   end
 end

--- a/lib/tufts/null_change_set.rb
+++ b/lib/tufts/null_change_set.rb
@@ -1,0 +1,23 @@
+module Tufts
+  ##
+  # An empty changeset
+  #
+  # @exmaple
+  #   cs = NullChangeSet.new(object, graph, changed_attributes)
+  #   cs.empty?  # => true
+  #   cs.changes # => {}
+  #
+  # @see https://en.wikipedia.org/wiki/Null_Object_pattern
+  # @see ActiveFedora::ChangeSet
+  class NullChangeSet
+    def initialize(*); end
+
+    def empty?
+      true
+    end
+
+    def changes
+      {}
+    end
+  end
+end

--- a/spec/lib/tufts/draft_spec.rb
+++ b/spec/lib/tufts/draft_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Tufts::Draft do
 
       it 'reloads saved changes' do
         saved_changes   = draft.changeset
-        draft.changeset = described_class::NullChangeSet.new
+        draft.changeset = Tufts::NullChangeSet.new
 
         expect { draft.load }
           .to change { draft.changeset }

--- a/spec/lib/tufts/draftable_spec.rb
+++ b/spec/lib/tufts/draftable_spec.rb
@@ -1,9 +1,25 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'tufts/draftable'
 
 RSpec.describe Tufts::Draftable do
-  subject(:model)   { model_class.new }
-  let(:model_class) { Class.new }
+  subject(:model) { model_class.create }
+
+  let(:model_class) do
+    klass = Class.new(ActiveFedora::Base)
+    klass.include described_class
+    klass.property :subject,    predicate: RDF::URI('http://example.com/s')
+    klass.property :characters, predicate: RDF::URI('http://example.com/c')
+    klass.property :title,
+                   predicate: RDF::URI('http://example.com/t'),
+                   multiple: false
+    klass
+  end
+
+  let(:change_map) do
+    { title:      'Comet in Moominland',
+      subject:    ['Moomins', 'Snorks'],
+      characters: ['Moomin', 'Moominpapa', 'Snorkmaiden', 'Little My'] }
+  end
 
   it_behaves_like 'a draftable model'
 end

--- a/spec/lib/tufts/null_change_set_spec.rb
+++ b/spec/lib/tufts/null_change_set_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::NullChangeSet do
+  subject(:change_set) { described_class.new }
+
+  it 'eats arguments' do
+    expect(described_class.new(:some, :args, blah: :blah))
+      .to be_empty
+  end
+
+  describe '#empty' do
+    it { is_expected.to be_empty }
+  end
+
+  describe '#changes' do
+    it 'has empty changes' do
+      expect(change_set.changes).to eql({})
+    end
+  end
+end

--- a/spec/support/shared_examples/draftable.rb
+++ b/spec/support/shared_examples/draftable.rb
@@ -1,11 +1,156 @@
+##
+# To use the shared examples, define a `subject(:model)` and a
+# `let(:change_map). The `change_map` should be a map from attributes to
+# valid values that the tests will ensure are properly applied through the
+# draft interfaces.
 RSpec.shared_examples 'a draftable model' do
   before do
     unless defined?(model)
       raise 'Define `model` with `let(:model)` before using the ' \
             'draftable model shared examples'
     end
+    unless defined?(change_map)
+      raise 'Define `change_map` with `let(:change_map)` before using the ' \
+            'draftable model shared examples'
+    end
   end
 
-  describe '#draft'
-  describe '#has_draft?'
+  after { model.delete_draft }
+
+  define :have_changes do |expected|
+    match do |actual|
+      expected.each do |field, values|
+        predicate = model.class.properties[field.to_s].predicate
+
+        expect(actual.changeset.changes[predicate].each_object)
+          .to contain_exactly(*Array(values))
+      end
+    end
+  end
+
+  define :have_unordered_attributes do |expected|
+    match do |actual|
+      attributes = Hash[expected.map do |k, v|
+        v = contain_exactly(*v) if v.respond_to?(:each)
+        [k, v]
+      end]
+
+      expect(actual).to have_attributes(attributes)
+    end
+  end
+
+  shared_context 'with changes' do
+    before { change_map.each { |k, v| model.send("#{k}=", v) } }
+  end
+
+  describe '#apply_draft' do
+    context 'when empty' do
+      it 'leaves the model unchanged' do
+        expect { model.apply_draft }.not_to change { model.attributes }
+      end
+
+      it 'does not override model changes since draft save' do
+        model.save_draft
+        change_map.each { |k, v| model.send("#{k}=", v) }
+
+        expect { model.apply_draft }.not_to change { model.attributes }
+      end
+    end
+
+    context 'with changes' do
+      include_context 'with changes'
+
+      before do
+        model.save_draft
+        model.reload
+      end
+
+      it 'changes to the model attributes' do
+        expect { model.apply_draft }
+          .to change { model.attributes }
+      end
+
+      it 'results in the correct changes' do
+        model.apply_draft
+        expect(model).to have_unordered_attributes(change_map)
+      end
+
+      it 'no longer has a draft' do
+        expect { model.apply_draft }
+          .to change { model.draft_saved? }
+          .from(true).to(false)
+      end
+    end
+
+    context 'when model has existing properties' do
+      before do
+        ##
+        # split the changes into two sets, one we want to apply in draft,
+        # and one which will exist before application. We'll expect all to be
+        # present when we're done
+        draft_changes = change_map.except(change_map.keys.first)
+        prior_change  = change_map[change_map.keys.first]
+
+        # build and save a draft
+        draft_changes.each { |k, v| model.send("#{k}=", v) }
+        model.save_draft
+
+        # reload and update a property
+        model.reload
+        model.send("#{change_map.keys.first}=", prior_change)
+      end
+
+      it 'retains properties not changed in the draft' do
+        model.apply_draft
+        expect(model).to have_unordered_attributes(change_map)
+      end
+
+      it 'overwrites changes for properties in the draft' do
+        model.send("#{change_map.keys.last}=", ['I SHOULD BE DELETED'])
+        model.apply_draft
+        expect(model).to have_unordered_attributes(change_map)
+      end
+    end
+  end
+
+  describe '#draft' do
+    it 'has a model with the id' do
+      expect(model.draft.id).to eq model.id
+    end
+
+    context 'with changes' do
+      include_context 'with changes'
+
+      it 'has changes' do
+        expect(model.draft).to have_changes change_map
+      end
+    end
+
+    context 'after saving the draft' do
+      include_context 'with changes'
+
+      before do
+        model.save_draft
+        model.reload
+      end
+
+      it 'loads the saved changes' do
+        expect(model.draft).to have_changes change_map
+      end
+    end
+  end
+
+  describe '#draft_saved?' do
+    it 'does not exist before save' do
+      expect(model).not_to be_draft_saved
+    end
+  end
+
+  describe '#save_draft' do
+    it 'marks the draft as saved' do
+      expect { model.save_draft }
+        .to change { model.draft_saved? }
+        .from(false).to(true)
+    end
+  end
 end


### PR DESCRIPTION
For a draftable model, we can create a draft from the current state by calling `model#save_draft`. That draft can then be applied at any time by calling `model#apply_draft`. Public methods are also provided to
`#delete_draft`, access the `#draft` as the underlying `Draft` object, and check whether a draft exists `#draft_saved?`.

Tests added as unit tests on the behavior of this model-layer API also serve as integration tests for the basic `Draft` class.

Closes #8 