### PR TITLE
Feature/singular title

### DIFF
--- a/app/forms/hyrax/audio_form.rb
+++ b/app/forms/hyrax/audio_form.rb
@@ -5,5 +5,16 @@ module Hyrax
     self.model_class = ::Audio
     self.terms += Tufts::Terms.shared_terms
     self.required_fields = [:title, :displays_in]
+    self.field_metadata_service = Tufts::MetadataService
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
   end
 end

--- a/app/forms/hyrax/ead_form.rb
+++ b/app/forms/hyrax/ead_form.rb
@@ -5,5 +5,16 @@ module Hyrax
     self.model_class = ::Ead
     self.terms += Tufts::Terms.shared_terms
     self.required_fields = [:title, :displays_in]
+    self.field_metadata_service = Tufts::MetadataService
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
   end
 end

--- a/app/forms/hyrax/generic_object_form.rb
+++ b/app/forms/hyrax/generic_object_form.rb
@@ -5,5 +5,16 @@ module Hyrax
     self.model_class = ::GenericObject
     self.terms += Tufts::Terms.shared_terms
     self.required_fields = [:title, :displays_in]
+    self.field_metadata_service = Tufts::MetadataService
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
   end
 end

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -5,5 +5,16 @@ module Hyrax
     self.model_class = ::Image
     self.terms += Tufts::Terms.shared_terms
     self.required_fields = [:title, :displays_in]
+    self.field_metadata_service = Tufts::MetadataService
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
   end
 end

--- a/app/forms/hyrax/pdf_form.rb
+++ b/app/forms/hyrax/pdf_form.rb
@@ -5,5 +5,16 @@ module Hyrax
     self.model_class = ::Pdf
     self.terms += Tufts::Terms.shared_terms
     self.required_fields = [:title, :displays_in]
+    self.field_metadata_service = Tufts::MetadataService
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
   end
 end

--- a/app/forms/hyrax/rcr_form.rb
+++ b/app/forms/hyrax/rcr_form.rb
@@ -5,5 +5,16 @@ module Hyrax
     self.model_class = ::Rcr
     self.terms += Tufts::Terms.shared_terms
     self.required_fields = [:title, :displays_in]
+    self.field_metadata_service = Tufts::MetadataService
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
   end
 end

--- a/app/forms/hyrax/tei_form.rb
+++ b/app/forms/hyrax/tei_form.rb
@@ -5,5 +5,16 @@ module Hyrax
     self.model_class = ::Tei
     self.terms += Tufts::Terms.shared_terms
     self.required_fields = [:title, :displays_in]
+    self.field_metadata_service = Tufts::MetadataService
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
   end
 end

--- a/app/forms/hyrax/video_form.rb
+++ b/app/forms/hyrax/video_form.rb
@@ -5,5 +5,16 @@ module Hyrax
     self.model_class = ::Video
     self.terms += Tufts::Terms.shared_terms
     self.required_fields = [:title, :displays_in]
+    self.field_metadata_service = Tufts::MetadataService
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
   end
 end

--- a/app/forms/hyrax/voting_record_form.rb
+++ b/app/forms/hyrax/voting_record_form.rb
@@ -5,5 +5,16 @@ module Hyrax
     self.model_class = ::VotingRecord
     self.terms += Tufts::Terms.shared_terms
     self.required_fields = [:title, :displays_in]
+    self.field_metadata_service = Tufts::MetadataService
+
+    def self.model_attributes(_)
+      attrs = super
+      attrs[:title] = Array(attrs[:title]) if attrs[:title]
+      attrs
+    end
+
+    def title
+      super.first || ""
+    end
   end
 end

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -8,6 +8,10 @@ class Audio < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :title, length: {
+    maximum: 1,
+    message: 'There can be only one title'
+  }
   self.human_readable_type = 'Audio'
 
   include ::Tufts::Metadata::Descriptive

--- a/app/models/ead.rb
+++ b/app/models/ead.rb
@@ -8,6 +8,10 @@ class Ead < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :title, length: {
+    maximum: 1,
+    message: 'There can be only one title'
+  }
   self.human_readable_type = 'EAD'
 
   include ::Tufts::Metadata::Descriptive

--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -8,6 +8,10 @@ class GenericObject < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :title, length: {
+    maximum: 1,
+    message: 'There can be only one title'
+  }
   self.human_readable_type = 'Generic Object'
 
   include ::Tufts::Metadata::Descriptive

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -8,6 +8,10 @@ class Image < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :title, length: {
+    maximum: 1,
+    message: 'There can be only one title'
+  }
   self.human_readable_type = 'Image'
 
   include Tufts::Metadata::Descriptive

--- a/app/models/pdf.rb
+++ b/app/models/pdf.rb
@@ -8,6 +8,10 @@ class Pdf < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :title, length: {
+    maximum: 1,
+    message: 'There can be only one title'
+  }
   self.human_readable_type = 'PDF'
 
   include ::Tufts::Metadata::Descriptive

--- a/app/models/rcr.rb
+++ b/app/models/rcr.rb
@@ -8,6 +8,10 @@ class Rcr < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :title, length: {
+    maximum: 1,
+    message: 'There can be only one title'
+  }
   self.human_readable_type = 'RCR'
 
   include ::Tufts::Metadata::Descriptive

--- a/app/models/tei.rb
+++ b/app/models/tei.rb
@@ -8,6 +8,10 @@ class Tei < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :title, length: {
+    maximum: 1,
+    message: 'There can be only one title'
+  }
   self.human_readable_type = 'TEI'
 
   include ::Tufts::Metadata::Descriptive

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -8,6 +8,10 @@ class Video < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :title, length: {
+    maximum: 1,
+    message: 'There can be only one title'
+  }
   self.human_readable_type = 'Video'
 
   include ::Tufts::Metadata::Descriptive

--- a/app/models/voting_record.rb
+++ b/app/models/voting_record.rb
@@ -8,6 +8,10 @@ class VotingRecord < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :title, length: {
+    maximum: 1,
+    message: 'There can be only one title'
+  }
   self.human_readable_type = 'Voting Record'
 
   include ::Tufts::Metadata::Descriptive

--- a/app/services/tufts/metadata_service.rb
+++ b/app/services/tufts/metadata_service.rb
@@ -1,0 +1,11 @@
+module Tufts
+  class MetadataService < HydraEditor::FieldMetadataService
+    def self.multiple?(model_class, field)
+      if [:title].include?(field.to_sym)
+        false
+      else
+        super
+      end
+    end
+  end
+end

--- a/spec/support/shared_metadata_examples.rb
+++ b/spec/support/shared_metadata_examples.rb
@@ -1,5 +1,6 @@
 shared_examples 'a work with Tufts metadata attributes' do
   it_behaves_like 'and has admin metadata attributes'
+  it_behaves_like 'a work with custom Tufts validations'
   context 'and the list of metadata attributes' do
     it 'has displays_in' do
       work.displays_in = ['nowhere', 'trove']

--- a/spec/support/shared_validation_examples.rb
+++ b/spec/support/shared_validation_examples.rb
@@ -1,0 +1,7 @@
+shared_examples 'a work with custom Tufts validations' do
+  it 'only has one title' do
+    work.title = ['title', 'another title']
+    work.valid?
+    expect(work.errors[:title]).to include('There can be only one title')
+  end
+end


### PR DESCRIPTION
Closes #76 

This will prevent the user from adding multiple titles and validate that the work only has 
a single title. It's still an Array so we'll avoid all the type errors that would be caused by
switching it to a String. 