### PR TITLE
Fix for license field and remove dupe rights fields

### DIFF
--- a/app/models/concerns/tufts/metadata/adminstrative.rb
+++ b/app/models/concerns/tufts/metadata/adminstrative.rb
@@ -27,10 +27,7 @@ module Tufts
         property :accrual_policy, predicate: ::RDF::Vocab::DC.accrualPolicy, multiple: false do |index|
           index.as :stored_searchable
         end
-        property :rights_note, predicate: ::RDF::Vocab::DC.rights, multiple: false do |index|
-          index.as :stored_searchable
-        end
-        property :rights, predicate: ::RDF::Vocab::EDM.rights, multiple: false do |index|
+        property :rights_note, predicate: ::RDF::Vocab::DC11.rights, multiple: false do |index|
           index.as :stored_searchable
         end
         property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|

--- a/app/services/hyrax/license_service.rb
+++ b/app/services/hyrax/license_service.rb
@@ -1,0 +1,5 @@
+module Hyrax
+  # Short-circuit autoloading so this doesn't get called for our license field
+  class LicenseService
+  end
+end

--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -1,5 +1,0 @@
-<% rights = Hyrax::RightsStatements.new %>
-<%= f.input :rights,
-    collection: rights.select_active_options,
-    include_blank: true,
-    input_html: { class: 'form-control' } %>

--- a/lib/tufts/terms.rb
+++ b/lib/tufts/terms.rb
@@ -3,7 +3,7 @@ module Tufts
     SHARED_TERMS = [:displays_in, :geographic_name, :held_by, :alternative_title,
                     :abstract, :table_of_contents, :primary_date, :date_accepted,
                     :date_available, :date_copyrighted, :date_issued, :steward, :created_by,
-                    :internal_note, :audience, :embargo_note, :end_date, :accrual_policy, :rights_note, :license, :rights, :resource_type].freeze
+                    :internal_note, :audience, :embargo_note, :end_date, :accrual_policy, :rights_note, :resource_type].freeze
     def self.shared_terms
       SHARED_TERMS
     end

--- a/spec/controllers/tufts/draft_controller_spec.rb
+++ b/spec/controllers/tufts/draft_controller_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Tufts::DraftController, type: :controller do
     model.delete
   end
 
-  describe 'PATCH #save_draft' do
+  describe 'POST #save_draft' do
     it "saves a draft for the model" do
-      patch :save_draft, params: { "id" => model.id, "pdf" => { "title" => "another test thing ", "displays_in" => ["", "nowhere"],
+      patch :save_draft, params: { "id" => model.id, "pdf" => { "title" => "another test thing ", "displays_in" => ["nowhere"],
                                                                 "representative_id" => "0z708w40c", "thumbnail_id" => "0z708w40c",
                                                                 "creator" => [""], "contributor" => [""], "description" => [""], "keyword" => [""],
                                                                 "license" => "#<ActiveTriples::Relation:0x007faba5ea15c0>", "rights_statement" => "",
@@ -25,7 +25,7 @@ RSpec.describe Tufts::DraftController, type: :controller do
                                                                 "primary_date" => [""], "date_accepted" => [""], "date_available" => [""],
                                                                 "date_copyrighted" => [""], "date_issued" => [""], "steward" => "", "created_by" => "",
                                                                 "internal_note" => "", "audience" => "", "embargo_note" => "", "end_date" => "",
-                                                                "accrual_policy" => "", "rights_note" => "", "rights" => "", "resource_type" => [""],
+                                                                "accrual_policy" => "", "rights_note" => "", "resource_type" => [""],
                                                                 "admin_set_id" => "admin_set/default", "member_of_collection_ids" => [""],
                                                                 "visibility_during_embargo" => "restricted", "embargo_release_date" => "2017-07-19",
                                                                 "visibility_after_embargo" => "open", "visibility_during_lease" => "open",

--- a/spec/support/shared_admin_metadata_examples.rb
+++ b/spec/support/shared_admin_metadata_examples.rb
@@ -27,16 +27,12 @@ shared_examples 'and has admin metadata attributes' do
     work.accrual_policy = 'an accrual policy'
     expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/accrualPolicy/)
   end
-  it 'has rights' do
-    work.rights = 'DCA Detailed Rights'
-    expect(work.resource.dump(:ttl)).to match(/europeana.eu\/schemas\/edm\/rights/)
-  end
   it 'has license' do
     work.license = ['A license DCA Detailed Rights']
     expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/rights/)
   end
   it 'has rights note' do
     work.rights_note = 'A note about DCA Detailed Rights'
-    expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/rights/)
+    expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/rights/)
   end
 end


### PR DESCRIPTION
This is a fix for issue #89 

Tufts wants license to be a free-text field, but by default it uses a controlled vocab. This overrides that so the field is just a string. 

I also misunderstood what to do with the rights field, and this remove a duplicate rights field in favor of the rights_statement field that's in Hyrax (w/ the Tufts vocab).

