### PR TITLE
Handle Services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+*.log

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
+gem 'handle-system', '0.1.1'
 gem 'mysql2'
 gem 'rsolr', '>= 1.0'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    handle-system (0.1.1)
     hiredis (0.6.1)
     htmlentities (4.3.4)
     httmultiparty (0.3.16)
@@ -765,6 +766,7 @@ DEPENDENCIES
   devise-guests (~> 0.6)
   factory_girl_rails
   fcrepo_wrapper
+  handle-system (= 0.1.1)
   hyrax!
   jbuilder (~> 2.5)
   jquery-rails
@@ -788,4 +790,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/app/actors/hyrax/actors/handle_assurance_actor.rb
+++ b/app/actors/hyrax/actors/handle_assurance_actor.rb
@@ -1,0 +1,38 @@
+module Hyrax
+  module Actors
+    ##
+    # An actor that ensures a handle is registered and pointing at the correct
+    # object.
+    class HandleAssuranceActor < AbstractActor
+      ##
+      # @param env [Hyrax::Actors::Enviornment]
+      #
+      # @return [Boolean] true
+      def create(env)
+        ensure_handle(object: env.curation_concern)
+        true
+      end
+
+      ##
+      # @param env [Hyrax::Actors::Enviornment]
+      #
+      # @return [Boolean] true
+      def update(env)
+        ensure_handle(object: env.curation_concern)
+        true
+      end
+
+      ##
+      # @param object [ActiveFedora::Base]
+      #
+      # @return [void]
+      def ensure_handle(object:)
+        if object.identifier.empty?
+          HandleRegisterJob.perform_later(object)
+        else
+          HandleUpdateJob.perform_later(object)
+        end
+      end
+    end
+  end
+end

--- a/app/actors/hyrax/actors/handle_assurance_actor.rb
+++ b/app/actors/hyrax/actors/handle_assurance_actor.rb
@@ -3,35 +3,57 @@ module Hyrax
     ##
     # An actor that ensures a handle is registered and pointing at the correct
     # object.
+    #
+    # Enqueues a job to mint or update a handle. The `#create` and `#update`
+    # methods punt their work to `#ensure_handle`. If an actor lower in the
+    # middleware stack returns `false` (an error state), nothing will be
+    # equeued.
+    #
+    # @example use in middleware
+    #   stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+    #     # middleware.use OtherMiddleware
+    #     middleware.use HandleAssuranceActor
+    #     # middleware.use MoreMiddleware
+    #   end
+    #
+    #   env = Hyrax::Actors::Environment.new(object, ability, attributes)
+    #   last_actor = Hyrax::Actors::Terminator.new
+    #   stack.build(last_actor).create(env)
+    #
     class HandleAssuranceActor < AbstractActor
       ##
       # @param env [Hyrax::Actors::Enviornment]
       #
-      # @return [Boolean] true
+      # @return [Boolean]
       def create(env)
-        ensure_handle(object: env.curation_concern)
-        true
+        next_actor.create(env) && ensure_handle(object: env.curation_concern)
       end
 
       ##
       # @param env [Hyrax::Actors::Enviornment]
       #
-      # @return [Boolean] true
+      # @return [Boolean]
       def update(env)
-        ensure_handle(object: env.curation_concern)
-        true
+        next_actor.update(env) && ensure_handle(object: env.curation_concern)
       end
 
       ##
+      # Enqueue handle creation or update.
+      #
+      # If `object` has no exiting `identifier` a 'HandleRegisterJob` is
+      # enqueued. If an identifier exists, a `HandleUpdateJob` is enqueued
+      # instead.
+      #
       # @param object [ActiveFedora::Base]
       #
-      # @return [void]
+      # @return [Boolean] true
       def ensure_handle(object:)
         if object.identifier.empty?
           HandleRegisterJob.perform_later(object)
         else
           HandleUpdateJob.perform_later(object)
         end
+        true
       end
     end
   end

--- a/app/jobs/handle_register_job.rb
+++ b/app/jobs/handle_register_job.rb
@@ -1,0 +1,24 @@
+##
+# A job to register handles and save it to the object.
+#
+# @example
+#   object = Pdf.create(title: ['Moomin'])
+#   HandleRegisterJob.perform_later(object)
+#
+# @see ActiveJob::Base, HandleDispatcher.assign_for!
+class HandleRegisterJob < ApplicationJob
+  queue_as :handle
+
+  rescue_from(Handle::HandleError) do
+    Tufts::HandleRegistrar::LOGGER
+      .log(nil, object.id, "Retrying Handle registration for #{object.id}")
+    retry_job wait: 30.seconds, queue: :handle
+  end
+
+  ##
+  # @param object [ActiveFedora::Base]
+  def perform(object)
+    Tufts::HandleDispatcher.assign_for!(object: object)
+    object.save!
+  end
+end

--- a/app/jobs/handle_update_job.rb
+++ b/app/jobs/handle_update_job.rb
@@ -1,0 +1,23 @@
+##
+# A job to update handle metadata with the handle server.
+#
+# @example
+#   object = Pdf.create(title: ['Moomin'])
+#   HandleUpdateJob.perform_later(object)
+#
+# @see ActiveJob::Base, HandleRegistrar#update!
+class HandleUpdateJob < ApplicationJob
+  queue_as :handle
+
+  rescue_from(Handle::HandleError) do
+    Tufts::HandleRegistrar::LOGGER
+      .log(nil, object.id, "Retrying Handle update for #{object.id}")
+    retry_job wait: 30.seconds, queue: :handle
+  end
+
+  ##
+  # @param object [ActiveFedora::Base]
+  def perform(object)
+    Tufts::HandleRegistrar.new.update!(handle: object.identifier.first, object: object)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'handle' # manually require handle to address gem name autoload mismatch
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,9 @@ module Epigaea
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.to_prepare do
+      Hyrax::CurationConcern.actor_factory.use Hyrax::Actors::HandleAssuranceActor
+    end
   end
 end

--- a/config/handle.yml
+++ b/config/handle.yml
@@ -1,6 +1,7 @@
 development:
   base_url: "http://dl.tufts.edu/catalog/"
   email: "brian.goodmon@tufts.edu"
+  prefix: 'tufts.dev'
   admin: "0.NA/10427.TEST"
   index: 300
   private_key: 'path/to/key_file'
@@ -10,6 +11,7 @@ test:
   base_url: "http://dl.tufts.edu/catalog/"
   email: "brian.goodmon@tufts.edu"
   admin: "0.NA/10427.TEST"
+  prefix: 'tufts.test'
   index: 300
   private_key: 'path/to/key_file'
   handle_passphrase: 'passphrase'
@@ -17,6 +19,7 @@ test:
 production:
   base_url: "http://dl.tufts.edu/catalog/"
   email: "brian.goodmon@tufts.edu"
+  prefix: 'real.prefix'
   admin: "0.NA/10427.TEST"
   index: 300
   private_key: ENV["HANDLE_PKEY_FILE"]

--- a/config/handle.yml
+++ b/config/handle.yml
@@ -1,5 +1,5 @@
 development:
-  base_url: "http://dl.tufts.edu/catalog/"
+  hostname: "dl.tufts.edu"
   email: "brian.goodmon@tufts.edu"
   prefix: 'tufts.dev'
   admin: "0.NA/10427.TEST"
@@ -8,7 +8,7 @@ development:
   handle_passphrase: 'passphrase'
 
 test:
-  base_url: "http://dl.tufts.edu/catalog/"
+  hostname: "dl.tufts.edu"
   email: "brian.goodmon@tufts.edu"
   admin: "0.NA/10427.TEST"
   prefix: 'tufts.test'
@@ -17,7 +17,7 @@ test:
   handle_passphrase: 'passphrase'
 
 production:
-  base_url: "http://dl.tufts.edu/catalog/"
+  hostname: "dl.tufts.edu"
   email: "brian.goodmon@tufts.edu"
   prefix: 'real.prefix'
   admin: "0.NA/10427.TEST"

--- a/config/handle.yml
+++ b/config/handle.yml
@@ -1,0 +1,23 @@
+development:
+  base_url: "http://dl.tufts.edu/catalog/"
+  email: "brian.goodmon@tufts.edu"
+  admin: "0.NA/10427.TEST"
+  index: 300
+  private_key: 'path/to/key_file'
+  handle_passphrase: 'passphrase'
+
+test:
+  base_url: "http://dl.tufts.edu/catalog/"
+  email: "brian.goodmon@tufts.edu"
+  admin: "0.NA/10427.TEST"
+  index: 300
+  private_key: 'path/to/key_file'
+  handle_passphrase: 'passphrase'
+
+production:
+  base_url: "http://dl.tufts.edu/catalog/"
+  email: "brian.goodmon@tufts.edu"
+  admin: "0.NA/10427.TEST"
+  index: 300
+  private_key: ENV["HANDLE_PKEY_FILE"]
+  handle_passphrase: ENV["HANDLE_PASSPHRASE"]

--- a/config/handle.yml
+++ b/config/handle.yml
@@ -1,11 +1,12 @@
 development:
-  hostname: "dl.tufts.edu"
-  email: "brian.goodmon@tufts.edu"
-  prefix: 'tufts.dev'
-  admin: "0.NA/10427.TEST"
-  index: 300
-  private_key: 'path/to/key_file'
-  handle_passphrase: 'passphrase'
+  hostname: "localhost:3000"
+  email: "contact@example.com"
+  prefix: '1234.DEV'
+  admin: "1234.TEST/ADMIN"
+  index: 301
+  secret_key: 'password'
+  # use secret_key for secret key auth;
+  # secret_key preempts pkey authentication if configured.
 
 test:
   hostname: "dl.tufts.edu"
@@ -13,8 +14,9 @@ test:
   admin: "0.NA/10427.TEST"
   prefix: 'tufts.test'
   index: 300
-  private_key: 'path/to/key_file'
-  handle_passphrase: 'passphrase'
+  # this is a dummy entry, we use a fake connection in testing
+  private_key: '/path/to/pkey'
+  pkey_passphrase: ''
 
 production:
   hostname: "dl.tufts.edu"
@@ -23,4 +25,4 @@ production:
   admin: "0.NA/10427.TEST"
   index: 300
   private_key: ENV["HANDLE_PKEY_FILE"]
-  handle_passphrase: ENV["HANDLE_PASSPHRASE"]
+  pkey_passphrase: ENV["HANDLE_PKEY_PASSPHRASE"]

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -24,6 +24,7 @@ Hyrax.config do |config|
 
   # Injected via `rails g hyrax:work VotingRecord`
   config.register_curation_concern :voting_record
+
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.
   # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES

--- a/lib/tasks/handle.rake
+++ b/lib/tasks/handle.rake
@@ -1,0 +1,23 @@
+require 'rake'
+
+namespace :tufts do
+  namespace :handle do
+    desc 'Registers a handle for the object. Supply an id.'
+    task :register, [:id] => :environment do |_, args|
+      begin
+        object = ActiveFedora::Base.find(args[:id])
+      rescue ActiveFedora::ObjectNotFoundError
+        $stderr.puts "Unable to find the object for #{args[:id]}"
+        next
+      end
+
+      if object.identifier.empty?
+        handle = Tufts::HandleDispatcher.assign_for!(object: object)
+        object.save!
+        puts "Registered a handle #{handle} for #{args[:id]}"
+      else
+        puts "Identifier(s) exist for #{args[:id]}: #{object.identifier}"
+      end
+    end
+  end
+end

--- a/lib/tufts/handle_builder.rb
+++ b/lib/tufts/handle_builder.rb
@@ -16,9 +16,20 @@ module Tufts
     end
 
     ##
+    # @note this default builder requires a `hint` which it appends to the
+    #   prefix to generate the handle string.
+    #
+    # @param hint [#to_s] a string-able object which may be used by the builder
+    #   to generate a handle. Hints may be required by some builders, while
+    #   others may ignore them to generate a handle by other means.
+    #
     # @return [String]
-    def build
-      "#{prefix}/1"
+    # @raise [ArgumentError] if a handle can't be built from the provided hint.
+    def build(hint: nil)
+      raise(ArgumentError, "No hint provided to #{self.class}#build") if
+        hint.nil?
+
+      "#{prefix}/#{hint}"
     end
   end
 end

--- a/lib/tufts/handle_builder.rb
+++ b/lib/tufts/handle_builder.rb
@@ -1,0 +1,24 @@
+require 'handle'
+
+module Tufts
+  ##
+  # Builds `HandleRecord`s from Tufts models
+  class HandleBuilder
+    ##
+    # @!attribute prefix [rw]
+    #   @return [String] the handle prefix to use when building handles
+    attr_accessor :prefix
+
+    ##
+    # @param prefix [String] the handle prefix to use when building handles
+    def initialize(prefix: 'pfx')
+      @prefix = prefix
+    end
+
+    ##
+    # @return [String]
+    def build
+      "#{prefix}/1"
+    end
+  end
+end

--- a/lib/tufts/handle_builder.rb
+++ b/lib/tufts/handle_builder.rb
@@ -29,7 +29,7 @@ module Tufts
       raise(ArgumentError, "No hint provided to #{self.class}#build") if
         hint.nil?
 
-      "#{prefix}/#{hint}"
+      "#{prefix}/#{hint}".upcase
     end
   end
 end

--- a/lib/tufts/handle_dispatcher.rb
+++ b/lib/tufts/handle_dispatcher.rb
@@ -38,7 +38,7 @@ module Tufts
       # @return [AciveFedora::Base] the object
       def assign_for(object:,
                      attribute: :identifier,
-                     registrar: HandleRegistrar.new)
+                     registrar: Tufts::HandleRegistrar.new)
         new(registrar: registrar)
           .assign_for(object: object, attribute: attribute)
       end
@@ -52,7 +52,7 @@ module Tufts
       # @return [AciveFedora::Base] the object
       def assign_for!(object:,
                       attribute: :identifier,
-                      registrar: HandleRegistrar.new)
+                      registrar: Tufts::HandleRegistrar.new)
         new(registrar: registrar)
           .assign_for!(object: object, attribute: attribute)
       end

--- a/lib/tufts/handle_dispatcher.rb
+++ b/lib/tufts/handle_dispatcher.rb
@@ -1,0 +1,91 @@
+module Tufts
+  ##
+  # Assigns and registers handles to objects.
+  #
+  # @example Assigning a handle for an object (default registrar)
+  #   pdf = Pdf.new(id: 'moomin')
+  #
+  #   dispatcher = HandleDispatcher.new
+  #   dispatcher.assign_for(object: pdf)
+  #   pdf.identifier # => ['hdl/some_handle']
+  #
+  # @example Assigning a handle with the class syntax
+  #   pdf = Pdf.new(id: 'moomin')
+  #
+  #   HandleDispatcher.assign_for(object: pdf)
+  #   pdf.identifier # => ['hdl/some_handle']
+  #
+  # @see Tufts::HandleRegistrar
+  class HandleDispatcher
+    ##
+    # @!attribute [rw] registrar
+    #   @return [Tufts::HandleRegistrar]
+    attr_accessor :registrar
+
+    ##
+    # @param registrar [Tufts::HandleRegistrar]
+    def initialize(registrar: HandleRegistrar.new)
+      @registrar = registrar
+    end
+
+    class << self
+      ##
+      # @param attribute [Symbol] the attribute in which to store the handle. This
+      #   will be overwritten during assignment
+      # @param object    [AciveFedora::Base] the object to assign a handle.
+      # @param registrar [Tufts::HandleRegistrar]
+      #
+      # @return [AciveFedora::Base] the object
+      def assign_for(object:,
+                     attribute: :identifier,
+                     registrar: HandleRegistrar.new)
+        new(registrar: registrar)
+          .assign_for(object: object, attribute: attribute)
+      end
+
+      ##
+      # @param attribute [Symbol] the attribute in which to store the handle. This
+      #   will be overwritten during assignment
+      # @param object    [AciveFedora::Base] the object to assign a handle.
+      # @param registrar [Tufts::HandleRegistrar]
+      #
+      # @return [AciveFedora::Base] the object
+      def assign_for!(object:,
+                      attribute: :identifier,
+                      registrar: HandleRegistrar.new)
+        new(registrar: registrar)
+          .assign_for!(object: object, attribute: attribute)
+      end
+    end
+
+    ##
+    # Assigns a handle to the object.
+    #
+    # This involves two steps:
+    #   - Registering the handle with the handle server via `registrar`.
+    #   - Storing the new handle on the object, in the provided `attribute`.
+    #
+    # @note the attribute for handle storage must be multi-valued, and will be
+    #   overwritten during assignment.
+    #
+    # @param attribute [Symbol] the attribute in which to store the handle. This
+    #   will be overwritten during assignment
+    # @param object    [AciveFedora::Base] the object to assign a handle.
+    #
+    # @return [AciveFedora::Base] the object
+    def assign_for(object:, attribute: :identifier)
+      record = registrar.register!(object: object)
+      object.public_send("#{attribute}=".to_sym, [record.handle])
+      object
+    end
+
+    ##
+    # Assigns a handle and saves the object.
+    #
+    # @see #assign_for
+    def assign_for!(object:, attribute: :identifier)
+      assign_for(object: object, attribute: attribute).save!
+      object
+    end
+  end
+end

--- a/lib/tufts/handle_registrar.rb
+++ b/lib/tufts/handle_registrar.rb
@@ -121,7 +121,14 @@ module Tufts
       ##
       # @return [String]
       def url_for(object:)
-        "#{config['base_url']}#{object.id}"
+        ActionDispatch::Routing::PolymorphicRoutes::HelperMethodBuilder
+          .polymorphic_method(Rails.application.routes.url_helpers,
+                              object.class.model_name.singular_route_key,
+                              nil,
+                              :url,
+                              id:     object.id,
+                              host:   config['hostname'],
+                              anchor: nil)
       end
 
       ##

--- a/lib/tufts/handle_registrar.rb
+++ b/lib/tufts/handle_registrar.rb
@@ -22,7 +22,7 @@ module Tufts
     LOGGER = Logger.new(Rails.root.join('log', 'handle.log'))
 
     ##
-    # @param object     [ActiveFedora::Base]
+    # @param object     [#id]
     # @param connection [Handle::Connection] defaults to a connection as
     #   configured in `Settings`
     def initialize(connection: Handle::Connection.new(*connection_args),
@@ -53,9 +53,9 @@ module Tufts
       record.save
       record
     rescue Handle::HandleError, NullIdError => err
-      message = "Unable to register handle #{handle} for #{object.uri}\n" \
+      message = "Unable to register handle #{handle} for #{object.id}\n" \
                 "#{err.message}"
-      LOGGER.log(nil, object.uri, message)
+      LOGGER.log(nil, object.id, message)
       raise err
     end
 
@@ -69,7 +69,7 @@ module Tufts
     # @todo Avoid save calls when the record is unchanged.
     #
     # @param handle [String]
-    # @param object [ActiveFedora::Base]
+    # @param object [#id]
     #
     # @return [Handle::Record] the updated handle record
     #
@@ -86,7 +86,7 @@ module Tufts
     ##
     # Aligns the fields of `record` with those of `object`.
     #
-    # @param object [ActiveFedora::Base]
+    # @param object [#id]
     # @param record [Handle::Record]
     # @return [void]
     def update_record(object:, record:)

--- a/lib/tufts/handle_registrar.rb
+++ b/lib/tufts/handle_registrar.rb
@@ -1,0 +1,98 @@
+require 'handle'
+
+module Tufts
+  ##
+  # A handle registration service
+  #
+  # @example Registering a Handle to Server from Settings
+  #   pdf = Pdf.create(title: ['moomin'])
+  #   registrar = HandleRegistrar.new(pdf)
+  #   registrar.register!
+  #
+  # @example Registering a Handle to a custom server connection
+  #   connection = Handle::Connection.new(admin, 300, pk, pass)
+  #   pdf        = Pdf.create(title: ['moomin'])
+  #   registrar  = HandleRegistrar.new(pdf, connection: connection)
+  #
+  # @see Handle::Connection
+  # @see Tufts::HandleBuilder
+  class HandleRegistrar
+    ##
+    # A logger for handle errors
+    LOGGER = Logger.new(Rails.root.join('log', 'handle.log'))
+
+    ##
+    # @param object     [ActiveFedora::Base]
+    # @param connection [Handle::Connection] defaults to a connection as
+    #   configured in `Settings`
+    def initialize(connection: Handle::Connection.new(*connection_args),
+                   builder:    HandleBuilder.new)
+      @connection = connection
+      @builder    = builder
+    end
+
+    ##
+    # Registers a Handle with the connected handle server.
+    #
+    # @param builder [#build] an object that returns a handle string from `#build`
+    #
+    # @return [Handle::Record] the registered handle
+    #
+    # @raise Handle::HandleError when the handle server fails to register
+    # @raise NullIdError when the object has no stable id
+    def register!(object:)
+      handle = @builder.build
+      record = @connection.create_record(handle)
+      record.add(:URL, url_for(object: object)).index = 2
+      record.add(:Email, email).index = 6
+      record << Handle::Field::HSAdmin.new(admin)
+      record.save
+      record
+    rescue Handle::HandleError, NullIdError => err
+      message = "Unable to register handle #{handle} for #{object.uri}\n" \
+                "#{err.message}"
+      LOGGER.log(nil, object.uri, message)
+      raise err
+    end
+
+    class NullIdError < RuntimeError; end
+
+    private
+
+      ##
+      # @todo make admin string configurable
+      #
+      # @return [String]
+      def admin
+        '0.NA/10427.TEST'
+      end
+
+      ##
+      # @return [Array] the arguments for the default handle connection;
+      def connection_args
+        [:handle_admin, 300, :handle_private_key, :handle_passphrase]
+      end
+
+      ##
+      # @todo make email configurable
+      #
+      # @return [String]
+      def email
+        'brian.goodmon@tufts.edu'
+      end
+
+      ##
+      # @todo make the base URL configurable
+      #
+      # @return [String]
+      #
+      # @raise NullIdError
+      def url_for(object:)
+        unless object.id
+          raise NullIdError,
+                "Tried to assign a Handle to an object with nil `#id`: #{object}."
+        end
+        "http://dl.tufts.edu/catalog/#{object.id}"
+      end
+  end
+end

--- a/lib/tufts/handle_registrar.rb
+++ b/lib/tufts/handle_registrar.rb
@@ -44,8 +44,8 @@ module Tufts
     #
     # @return [Handle::Record] the registered handle
     #
-    # @raise Handle::HandleError when the handle server fails to register
-    # @raise NullIdError when the object has no stable id
+    # @raise [Handle::HandleError] when the handle server fails to register
+    # @raise [NullIdError] when the object has no stable id
     def register!(object:)
       handle = @builder.build
       record = @connection.create_record(handle)
@@ -75,6 +75,7 @@ module Tufts
     #
     # @raise [Handle::NotFound] if the Conncetion returns not found
     # @raise [Handle::HandleError] for other server errors
+    # @raise [NullIdError] when the object has no stable id
     def update!(handle:, object:)
       record = @connection.resolve_handle(handle)
       update_record(object: object, record: record)
@@ -83,6 +84,8 @@ module Tufts
     end
 
     ##
+    # Aligns the fields of `record` with those of `object`.
+    #
     # @param object [ActiveFedora::Base]
     # @param record [Handle::Record]
     # @return [void]

--- a/lib/tufts/handle_registrar.rb
+++ b/lib/tufts/handle_registrar.rb
@@ -110,7 +110,12 @@ module Tufts
       # @return [Array] the arguments for the default handle connection;
       def connection_args
         c = config
-        [c['admin'], c['index'], c['private_key'], c['passphrase']]
+
+        if c.fetch('secret_key', false)
+          [c['admin'], c['index'], c['secret_key']]
+        else
+          [c['admin'], c['index'], c['private_key'], c['passphrase']]
+        end
       end
 
       ##

--- a/lib/tufts/handle_registrar.rb
+++ b/lib/tufts/handle_registrar.rb
@@ -26,7 +26,7 @@ module Tufts
     # @param connection [Handle::Connection] defaults to a connection as
     #   configured in `Settings`
     def initialize(connection: Handle::Connection.new(*connection_args),
-                   builder:    HandleBuilder.new)
+                   builder:    HandleBuilder.new(prefix: config['prefix']))
       @connection = connection
       @builder    = builder
     end

--- a/lib/tufts/handle_registrar.rb
+++ b/lib/tufts/handle_registrar.rb
@@ -32,6 +32,12 @@ module Tufts
     end
 
     ##
+    # @return [Hash<String, Object>]
+    def config
+      Rails.application.config_for(:handle)
+    end
+
+    ##
     # Registers a Handle with the connected handle server.
     #
     # @param builder [#build] an object that returns a handle string from `#build`
@@ -44,8 +50,8 @@ module Tufts
       handle = @builder.build
       record = @connection.create_record(handle)
       record.add(:URL, url_for(object: object)).index = 2
-      record.add(:Email, email).index = 6
-      record << Handle::Field::HSAdmin.new(admin)
+      record.add(:Email, config['email']).index = 6
+      record << Handle::Field::HSAdmin.new(config['admin'])
       record.save
       record
     rescue Handle::HandleError, NullIdError => err
@@ -60,30 +66,13 @@ module Tufts
     private
 
       ##
-      # @todo make admin string configurable
-      #
-      # @return [String]
-      def admin
-        '0.NA/10427.TEST'
-      end
-
-      ##
       # @return [Array] the arguments for the default handle connection;
       def connection_args
-        [:handle_admin, 300, :handle_private_key, :handle_passphrase]
+        c = config
+        [c['admin'], c['index'], c['private_key'], c['passphrase']]
       end
 
       ##
-      # @todo make email configurable
-      #
-      # @return [String]
-      def email
-        'brian.goodmon@tufts.edu'
-      end
-
-      ##
-      # @todo make the base URL configurable
-      #
       # @return [String]
       #
       # @raise NullIdError
@@ -92,7 +81,7 @@ module Tufts
           raise NullIdError,
                 "Tried to assign a Handle to an object with nil `#id`: #{object}."
         end
-        "http://dl.tufts.edu/catalog/#{object.id}"
+        "#{config['base_url']}#{object.id}"
       end
   end
 end

--- a/lib/tufts/handle_registrar.rb
+++ b/lib/tufts/handle_registrar.rb
@@ -114,7 +114,7 @@ module Tufts
         if c.fetch('secret_key', false)
           [c['admin'], c['index'], c['secret_key']]
         else
-          [c['admin'], c['index'], c['private_key'], c['passphrase']]
+          [c['admin'], c['index'], c['private_key'], c['pkey_passphrase']]
         end
       end
 

--- a/spec/actors/hyrax/actors/handle_assurance_actor_spec.rb
+++ b/spec/actors/hyrax/actors/handle_assurance_actor_spec.rb
@@ -1,10 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::Actors::HandleAssuranceActor do
-  subject(:actor) { described_class.new(Hyrax::Actors::Terminator.new) }
-  let(:object)    { create(:pdf) }
+  subject(:actor)  { described_class.new(next_actor) }
+  let(:next_actor) { Hyrax::Actors::Terminator.new }
+  let(:object)     { create(:pdf) }
+  let(:user)       { User.new }
+
+  let(:env) do
+    Hyrax::Actors::Environment.new(object, Ability.new(user), {})
+  end
+
+  let(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(next_actor)
+  end
+
+  let(:failing_middleware) do
+    Class.new do
+      def create(*)
+        false
+      end
+
+      def update(*)
+        false
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'enqueues a job' do
+      ActiveJob::Base.queue_adapter = :test
+
+      expect { middleware.create(env) }
+        .to enqueue_job.with(object)
+    end
+
+    context 'when the next middleware fails' do
+      let(:next_actor) { failing_middleware.new }
+
+      it 'does not equeue a job' do
+        ActiveJob::Base.queue_adapter = :test
+        expect { middleware.create(env) }.not_to enqueue_job
+      end
+    end
+  end
 
   describe '#ensure_handle' do
+    it 'returns true' do
+      expect(actor.ensure_handle(object: object)).to be true
+    end
+
     context 'without existing handle' do
       it 'queues a job to register the handle' do
         ActiveJob::Base.queue_adapter = :test
@@ -24,6 +71,24 @@ RSpec.describe Hyrax::Actors::HandleAssuranceActor do
         expect { actor.ensure_handle(object: object) }
           .to enqueue_job(HandleUpdateJob)
           .with(object)
+      end
+    end
+  end
+
+  describe '#update' do
+    it 'enqueues a job' do
+      ActiveJob::Base.queue_adapter = :test
+
+      expect { middleware.create(env) }
+        .to enqueue_job.with(object)
+    end
+
+    context 'when the next middleware fails' do
+      let(:next_actor) { failing_middleware.new }
+
+      it 'does not equeue a job' do
+        ActiveJob::Base.queue_adapter = :test
+        expect { middleware.create(env) }.not_to enqueue_job
       end
     end
   end

--- a/spec/actors/hyrax/actors/handle_assurance_actor_spec.rb
+++ b/spec/actors/hyrax/actors/handle_assurance_actor_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::HandleAssuranceActor do
+  subject(:actor) { described_class.new(Hyrax::Actors::Terminator.new) }
+  let(:object)    { create(:pdf) }
+
+  describe '#ensure_handle' do
+    context 'without existing handle' do
+      it 'queues a job to register the handle' do
+        ActiveJob::Base.queue_adapter = :test
+
+        expect { actor.ensure_handle(object: object) }
+          .to enqueue_job(HandleRegisterJob)
+          .with(object)
+      end
+    end
+
+    context 'with an existing handle' do
+      before { object.identifier = ['hdl/hdl1'] }
+
+      it 'queues a job to update the handle' do
+        ActiveJob::Base.queue_adapter = :test
+
+        expect { actor.ensure_handle(object: object) }
+          .to enqueue_job(HandleUpdateJob)
+          .with(object)
+      end
+    end
+  end
+end

--- a/spec/jobs/handle_register_job_spec.rb
+++ b/spec/jobs/handle_register_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe HandleRegisterJob, type: :job do
+  subject(:job) { described_class }
+  let(:pdf)     { create(:pdf) }
+
+  describe '#perform_later' do
+    it 'enqueues the job' do
+      ActiveJob::Base.queue_adapter = :test
+      expect { job.perform_later(pdf) }
+        .to enqueue_job(described_class)
+        .with(pdf)
+        .on_queue('handle')
+    end
+  end
+end

--- a/spec/jobs/handle_update_job_spec.rb
+++ b/spec/jobs/handle_update_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe HandleUpdateJob, type: :job do
+  subject(:job) { described_class }
+  let(:pdf)     { create(:pdf) }
+
+  describe '#perform_later' do
+    it 'enqueues the job' do
+      ActiveJob::Base.queue_adapter = :test
+      expect { job.perform_later(pdf) }
+        .to enqueue_job(described_class)
+        .with(pdf)
+        .on_queue('handle')
+    end
+  end
+end

--- a/spec/lib/tufts/handle_builder_spec.rb
+++ b/spec/lib/tufts/handle_builder_spec.rb
@@ -17,7 +17,7 @@ describe Tufts::HandleBuilder do
 
   describe '#build' do
     it 'uses the prefix' do
-      expect(builder.build(hint: 'blah')).to start_with "#{builder.prefix}/"
+      expect(builder.build(hint: 'blah')).to start_with "#{builder.prefix.upcase}/"
     end
 
     context 'with a custom prefix' do
@@ -25,8 +25,16 @@ describe Tufts::HandleBuilder do
       let(:prefix)      { 'fake_prefix' }
 
       it 'uses the prefix' do
-        expect(builder.build(hint: 'blah')).to start_with "#{prefix}/"
+        expect(builder.build(hint: 'blah')).to start_with "#{prefix.upcase}/"
       end
+    end
+
+    it 'raises an error with no hint' do
+      expect { builder.build }.to raise_error ArgumentError
+    end
+
+    it 'uses the hint exactly, cast to uppercase' do
+      expect(builder.build(hint: 'moomin')).to eq 'PFX/MOOMIN'
     end
   end
 end

--- a/spec/lib/tufts/handle_builder_spec.rb
+++ b/spec/lib/tufts/handle_builder_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe Tufts::HandleBuilder do
+  subject(:builder) { described_class.new }
+
+  describe '#prefix' do
+    it 'defaults to configured prefix'
+  end
+
+  describe '#build' do
+    it 'uses the prefix' do
+      expect(builder.build).to start_with "#{builder.prefix}/"
+    end
+
+    xit 'builds different handle for sequential calls' do
+      handles = (0..2).map { builder.build }.uniq
+      expect(handles.count).to eq 3
+    end
+
+    context 'with a custom prefix' do
+      subject(:builder) { described_class.new(prefix: prefix) }
+      let(:prefix)      { 'fake_prefix' }
+
+      it 'uses the prefix' do
+        expect(builder.build).to start_with "#{prefix}/"
+      end
+    end
+  end
+end

--- a/spec/lib/tufts/handle_builder_spec.rb
+++ b/spec/lib/tufts/handle_builder_spec.rb
@@ -17,12 +17,7 @@ describe Tufts::HandleBuilder do
 
   describe '#build' do
     it 'uses the prefix' do
-      expect(builder.build).to start_with "#{builder.prefix}/"
-    end
-
-    xit 'builds different handle for sequential calls' do
-      handles = (0..2).map { builder.build }.uniq
-      expect(handles.count).to eq 3
+      expect(builder.build(hint: 'blah')).to start_with "#{builder.prefix}/"
     end
 
     context 'with a custom prefix' do
@@ -30,7 +25,7 @@ describe Tufts::HandleBuilder do
       let(:prefix)      { 'fake_prefix' }
 
       it 'uses the prefix' do
-        expect(builder.build).to start_with "#{prefix}/"
+        expect(builder.build(hint: 'blah')).to start_with "#{prefix}/"
       end
     end
   end

--- a/spec/lib/tufts/handle_builder_spec.rb
+++ b/spec/lib/tufts/handle_builder_spec.rb
@@ -4,7 +4,15 @@ describe Tufts::HandleBuilder do
   subject(:builder) { described_class.new }
 
   describe '#prefix' do
-    it 'defaults to configured prefix'
+    it 'has a default prefix' do
+      expect(builder.prefix).not_to be_empty
+    end
+
+    it 'accepts a prefix' do
+      prefix = 'my_pfx'
+      builder = described_class.new(prefix: prefix)
+      expect(builder.prefix).to eq prefix
+    end
   end
 
   describe '#build' do

--- a/spec/lib/tufts/handle_dispatcher_spec.rb
+++ b/spec/lib/tufts/handle_dispatcher_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe Tufts::HandleDispatcher do
+  subject(:dispatcher) { described_class.new(registrar: fake_registrar.new) }
+  let(:object)         { build(:pdf) }
+  let(:handle)         { 'hdl/tufts_1' }
+
+  let(:fake_registrar) do
+    Class.new do
+      def initialize(*); end
+
+      def register!(*)
+        record        = Handle::Record.new
+        record.handle = 'hdl/tufts_1'
+        record
+      end
+    end
+  end
+
+  shared_examples 'performs handle assignment' do |method|
+    it 'returns the same object' do
+      expect(dispatcher.public_send(method, object: object)).to eql object
+    end
+
+    it 'assigns to the identifier attribute by default' do
+      dispatcher.public_send(method, object: object)
+      expect(object.identifier).to contain_exactly(handle)
+    end
+
+    it 'assigns to specified attribute when requested' do
+      dispatcher.public_send(method, object: object, attribute: :keyword)
+      expect(object.keyword).to contain_exactly(handle)
+    end
+  end
+
+  it 'has a registrar' do
+    expect(dispatcher.registrar).to be_a fake_registrar
+  end
+
+  describe '#assign_for' do
+    include_examples 'performs handle assignment', :assign_for
+  end
+
+  describe '#assign_for!' do
+    let(:id)     { ActiveFedora::Noid::Service.new.mint }
+    let(:object) { Pdf.new(id: id, title: ['Moomin']) }
+
+    include_examples 'performs handle assignment', :assign_for!
+
+    it 'saves the object' do
+      expect { dispatcher.assign_for!(object: object) }
+        .to change { object.new_record? }
+        .from(true)
+        .to(false)
+    end
+  end
+end

--- a/spec/lib/tufts/handle_registrar_spec.rb
+++ b/spec/lib/tufts/handle_registrar_spec.rb
@@ -1,0 +1,140 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/MessageSpies, Lint/HandleExceptions
+describe Tufts::HandleRegistrar do
+  subject(:service) { described_class.new }
+  let(:object)      { build(:pdf) }
+  let(:admin)       { '0.NA/10427.TEST' }
+  let(:email)       { 'brian.goodmon@tufts.edu' }
+  let(:url)         { "http://dl.tufts.edu/catalog/#{object.id}" }
+
+  let(:fake_builder) do
+    # a builder that always returns the same handle
+    Class.new do
+      def build
+        'hdl/hdl1'
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/InstanceVariable
+  describe '#register!' do
+    subject(:service) do
+      described_class.new(connection: spoonfed_connection.new(record: record))
+    end
+
+    # rubocop:disable Style/MethodMissing
+    let(:spoonfed_connection) do
+      # A connection that returns the handle record given on initialzation
+      Class.new do
+        def initialize(*, record:)
+          @record = record
+        end
+
+        def create_record(handle)
+          @record.handle     = handle
+          @record.connection = self
+          @record
+        end
+
+        def method_missing(*); end # no-op
+
+        def respond_to_missing?(*)
+          true
+        end
+      end
+    end
+
+    let(:record) { Handle::Record.new }
+
+    before { allow(record).to receive(:save).and_return(true) }
+
+    context 'when the object lacks a stable id' do
+      let(:object) { Pdf.new }
+
+      it 'logs an error' do
+        expect(described_class::LOGGER).to receive(:log)
+
+        begin
+          service.register!(object: object)
+        rescue described_class::NullIdError; end # no-op
+      end
+
+      it 'reraises the error' do
+        expect { service.register!(object: object) }
+          .to raise_error described_class::NullIdError
+      end
+    end
+
+    context 'when there is an error registering the handle' do
+      subject(:service) do
+        described_class.new(connection: error_connection.new,
+                            builder:    fake_builder.new)
+      end
+
+      let(:error_connection) do
+        # a connection that returns an error for any methods
+        Class.new do
+          def method_missing(*)
+            raise Handle::HandleError, 'Invalid admin'
+          end
+
+          def respond_to_missing?(*)
+            true
+          end
+        end
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it 'logs errors' do
+        message = "Unable to register handle hdl/hdl1 for #{object.uri}\n" \
+                  "Invalid admin"
+
+        expect(described_class::LOGGER)
+          .to receive(:log).with(nil, object.uri, message)
+
+        begin
+          service.register!(object: object)
+        rescue Handle::HandleError; end # no-op
+      end
+
+      it 're-raises errors' do
+        expect { service.register!(object: object) }
+          .to raise_error Handle::HandleError, "Invalid admin"
+      end
+
+      it 'results in blank identifier' do
+        begin
+          service.register!(object: object)
+        rescue Handle::HandleError; end # no-op
+
+        expect(object.identifier).to be_blank
+      end
+    end
+
+    it 'returns a record with a handle' do
+      record = service.register!(object: object)
+      expect(record.handle).to match(/.+\/.+/)
+    end
+
+    it 'saves the record' do
+      expect(record).to receive(:save).and_return(true)
+      service.register!(object: object)
+    end
+
+    it 'has url metadata' do
+      expect(service.register!(object: object).to_batch)
+        .to include "2 URL 86400 1110 UTF8 #{url}"
+    end
+
+    it 'has email metadata' do
+      expect(service.register!(object: object).to_batch)
+        .to include "6 EMAIL 86400 1110 UTF8 #{email}"
+    end
+
+    it 'has hs_admin metadata' do
+      expect(service.register!(object: object).to_batch)
+        .to include "100 HS_ADMIN 86400 1110 ADMIN 300:111111111111:#{admin}"
+    end
+  end
+end

--- a/spec/lib/tufts/handle_registrar_spec.rb
+++ b/spec/lib/tufts/handle_registrar_spec.rb
@@ -15,7 +15,7 @@ describe Tufts::HandleRegistrar do
   let(:fake_builder) do
     # a builder that always returns the same handle
     Class.new do
-      def build
+      def build(*)
         'hdl/hdl1'
       end
     end
@@ -121,6 +121,13 @@ describe Tufts::HandleRegistrar do
     it 'returns a record with a handle using the configured prefix' do
       record = service.register!(object: object)
       expect(record.handle).to match(/tufts\.test\/.+/)
+    end
+
+    it 'generates different handles for different objects' do
+      other = build(:pdf)
+
+      expect(service.register!(object: object).handle)
+        .not_to eq service.register!(object: other).handle
     end
 
     it 'saves the record' do

--- a/spec/lib/tufts/handle_registrar_spec.rb
+++ b/spec/lib/tufts/handle_registrar_spec.rb
@@ -120,7 +120,7 @@ describe Tufts::HandleRegistrar do
 
     it 'returns a record with a handle using the configured prefix' do
       record = service.register!(object: object)
-      expect(record.handle).to match(/tufts\.test\/.+/)
+      expect(record.handle).to match(/TUFTS\.TEST\/.+/)
     end
 
     it 'generates different handles for different objects' do

--- a/spec/lib/tufts/handle_registrar_spec.rb
+++ b/spec/lib/tufts/handle_registrar_spec.rb
@@ -93,11 +93,11 @@ describe Tufts::HandleRegistrar do
 
       # rubocop:disable RSpec/ExampleLength
       it 'logs errors' do
-        message = "Unable to register handle hdl/hdl1 for #{object.uri}\n" \
+        message = "Unable to register handle hdl/hdl1 for #{object.id}\n" \
                   "Invalid admin"
 
         expect(described_class::LOGGER)
-          .to receive(:log).with(nil, object.uri, message)
+          .to receive(:log).with(nil, object.id, message)
 
         begin
           service.register!(object: object)

--- a/spec/lib/tufts/handle_registrar_spec.rb
+++ b/spec/lib/tufts/handle_registrar_spec.rb
@@ -153,17 +153,17 @@ describe Tufts::HandleRegistrar do
     end
 
     context 'without changes' do
-      let(:record) do
-        service.update_record(object: object, record: Handle::Record.new)
-      end
+      before { service.update_record(object: object, record: record) }
 
-      xit 'does not save the record' do
+      it 'does not save the record' do
         expect(record).not_to receive(:save)
         service.update!(handle: 'hdl/hdl1', object: object)
       end
     end
 
     context 'when changes have been made' do
+      before { record.add(:URL, 'http://example.com/fake').index = 2 }
+
       it 'saves the record' do
         expect(record).to receive(:save).and_return(true)
         service.update!(handle: 'hdl/hdl1', object: object)
@@ -182,6 +182,11 @@ describe Tufts::HandleRegistrar do
       it 'updates URL' do
         expect(service.update!(handle: 'hdl/hdl1', object: object).to_batch)
           .to include "2 URL 86400 1110 UTF8 #{url}"
+      end
+
+      it 'deletes old fields URL' do
+        expect(service.update!(handle: 'hdl/hdl1', object: object).to_batch)
+          .not_to include "2 URL 86400 1110 UTF8 http://example.com/fake"
       end
     end
   end

--- a/spec/lib/tufts/handle_registrar_spec.rb
+++ b/spec/lib/tufts/handle_registrar_spec.rb
@@ -10,7 +10,7 @@ describe Tufts::HandleRegistrar do
   let(:admin)  { '0.NA/10427.TEST' }
   let(:email)  { 'brian.goodmon@tufts.edu' }
   let(:record) { Handle::Record.new }
-  let(:url)    { "http://dl.tufts.edu/catalog/#{object.id}" }
+  let(:url)    { "http://dl.tufts.edu/concern/pdfs/#{object.id}" }
 
   let(:fake_builder) do
     # a builder that always returns the same handle

--- a/spec/lib/tufts/handle_registrar_spec.rb
+++ b/spec/lib/tufts/handle_registrar_spec.rb
@@ -118,9 +118,9 @@ describe Tufts::HandleRegistrar do
       end
     end
 
-    it 'returns a record with a handle' do
+    it 'returns a record with a handle using the configured prefix' do
       record = service.register!(object: object)
-      expect(record.handle).to match(/.+\/.+/)
+      expect(record.handle).to match(/tufts\.test\/.+/)
     end
 
     it 'saves the record' do


### PR DESCRIPTION
Closes #23.

The key pieces are:

 - A `HandleBuilder` that generates handles given a `prefix` and a `hint`.

 - A `HandleRegistrar` which can `#register!` and `#update!` handles. This class is unaware of anything about `ActiveFedora::Base` objects, including whether they already have a registered handle. It knows only enough to ask about `#id`, talk to a `Handle::Connection` and use `HandleBuilder#build`.

 - A `HandleDispatcher` which knows how to assign handles to `ActiveFedora::Base#objects`. It uses an injected Registrar to register a handle and assigns it to a property on the object (default: `identifier`).

 - Two Jobs. The first to register handles, and the second to update them.

 - An Actor (`HandleAsssuranceActor`) which is appended to the actor stack and queues the delayed jobs to register a handle.

I've checked off the relevant parts of #23. I need a review to confirm that "Handles should not be created until a work is published" is satisfied. ~~The final check box (the rake task) is incoming.~~

This is ready for review, but requires a change to the configuration to point to a development handle server; so far all of this is untested against a real handle server.