### PR TITLE
Make FITS config friendlier to multiple environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ rvm:
   - 2.3.3
   - 2.3.4
 before_script:
-  - pwd=$(pwd)
-  - wget https://projects.iq.harvard.edu/files/fits/files/fits-1.1.1.zip -O /tmp/fits-1.1.1.zip
-  - cd /tmp && unzip fits-1.1.1.zip
-  - chmod +x /tmp/fits-1.1.1/fits.sh
-  - cd $pwd
   - bundle exec sidekiq -d -l /tmp/sidekiq.log
   - bundle exec rails db:setup
 script:

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -102,7 +102,7 @@ Hyrax.config do |config|
   # config.redis_namespace = "hyrax"
 
   # Path to the file characterization tool
-  config.fits_path = " /tmp/fits-1.1.1/fits.sh"
+  config.fits_path = "fits.sh"
 
   # Path to the file derivatives creation tool
   # config.libreoffice_path = "soffice"


### PR DESCRIPTION
FITS is not required for the CI suite, so don't have
Travis install it.  Make setting the path for FITS a local
path issue so that all environements can use the same settings.

Closes #132 