### PR TITLE
Fix RSpec deprecations

### DIFF
--- a/spec/controllers/contribute_controller_spec.rb
+++ b/spec/controllers/contribute_controller_spec.rb
@@ -2,90 +2,119 @@ require 'rails_helper'
 
 describe ContributeController do
   let(:deposit_type) { FactoryGirl.create(:deposit_type) }
-  describe "for a not-signed in user" do
-    describe "new" do
-      it "redirects to sign in", :no_ci do
+
+  describe 'for a not-signed in user' do
+    describe 'GET #new' do
+      it 'redirects to sign in' do
         pending('waiting for role solution')
         get :new
-        response.should redirect_to new_user_session_path(locale: :en)
+
+        expect(response).to redirect_to new_user_session_path(locale: :en)
       end
     end
-    describe "create" do
-      it "redirects to sign in", :no_ci do
-        post :create
+
+    describe 'POST #create' do
+      it 'redirects to sign in' do
         pending('waiting for role solution')
-        response.should redirect_to new_user_session_path(locale: :en)
+        post :create
+
+        expect(response).to redirect_to new_user_session_path(locale: :en)
       end
     end
   end
 
-  describe "for a signed in user" do
+  describe 'for a signed in user' do
     let(:user) { FactoryGirl.create(:user) }
+
     before { sign_in user }
 
-    describe "GET '/'" do
-      it "returns http success", :no_ci do
+    describe 'GET #index' do
+      it 'returns http success' do
         get :index
-        response.should be_success
+
+        expect(response).to be_success
       end
     end
 
-    describe "GET 'license'" do
-      it "returns http success", :no_ci do
+    describe 'GET #license' do
+      it 'returns http success' do
         get 'license'
-        response.should be_success
+
+        expect(response).to be_success
       end
     end
 
-    describe "GET 'new'" do
-      it "redirects to contribute home when no deposit type is specified", :no_ci do
+    describe 'GET #new' do
+      it 'redirects to contribute home when no deposit type is specified' do
         get 'new'
-        response.should redirect_to contributions_path
+
+        expect(response).to redirect_to contributions_path
       end
 
       describe 'with valid deposit_type' do
-        let(:deposit_type) { FactoryGirl.create(:deposit_type, display_name: 'Test Option', deposit_view: 'generic_deposit') }
+        let(:deposit_type) do
+          FactoryGirl.create(:deposit_type,
+                             display_name: 'Test Option',
+                             deposit_view: 'generic_deposit')
+        end
 
         render_views
 
-        it 'renders the correct template', :no_ci do
+        it 'renders the correct template' do
           get 'new', params: { deposit_type: deposit_type.id }
-          response.should render_template('contribute/deposit_view/_generic_deposit')
+
+          expect(response)
+            .to render_template('contribute/deposit_view/_generic_deposit')
         end
 
-        it 'includes deposit license text', :no_ci do
+        it 'includes deposit license text' do
           get 'new', params: { deposit_type: deposit_type.id }
-          response.body.should have_content deposit_type.deposit_agreement
+
+          expect(response.body)
+            .to have_content deposit_type.deposit_agreement
         end
 
-        it 'sets deposit_type and contribution', :no_ci do
+        it 'sets deposit_type and contribution' do
           get :new, params: { deposit_type: deposit_type }
-          assigns(:deposit_type).should eq(deposit_type)
-          assigns(:contribution).should_not be_nil
+
+          expect(assigns(:deposit_type)).to eq(deposit_type)
+          expect(assigns(:contribution)).not_to be_nil
         end
       end
     end
 
-    describe "GET 'redirect'" do
-      it "redirects to contribute", :no_ci do
+    describe 'GET #redirect' do
+      it 'redirects to contribute' do
         pending('waiting for role solution')
         get 'redirect'
+
         response.should redirect_to contributions_path
       end
     end
 
-    describe "POST 'create'" do
-      it "redirects when no deposit type is specified", :no_ci do
-        post :create, params: { contribution: { title: 'Sample', description: 'Description', creator: user.display_name } }
-        response.should redirect_to contributions_path
+    describe 'POST #create' do
+      let(:params) do
+        { contribution: { title:       'Sample',
+                          description: 'Description',
+                          creator:     user.display_name } }
+      end
+
+      it 'redirects when no deposit type is specified' do
+        post :create, params: params
+
+        expect(response).to redirect_to contributions_path
       end
 
       describe 'with valid deposit_type' do
         before { Pdf.destroy_all }
 
-        let(:uploaded_file) { fixture_file_upload('/local_object_store/data01/tufts/central/dca/MISS/archival_pdf/MISS.ISS.IPPI.archival.pdf', 'application/pdf') }
+        let(:uploaded_file) do
+          path = '/local_object_store/data01/tufts/central/dca/MISS/' \
+                 'archival_pdf/MISS.ISS.IPPI.archival.pdf'
+          fixture_file_upload(path, 'application/pdf')
+        end
 
-        it 'succeeds and stores file attachments', :no_ci do
+        it 'succeeds and stores file attachments' do
           pending 'Waiting for roles solution'
           post :create, params: { contribution: { title: 'Sample', description: 'Description goes here',
                                                   creator: 'Someone', attachment: uploaded_file }, deposit_type: deposit_type }
@@ -93,7 +122,7 @@ describe ContributeController do
           expect(Pdf.all.length).to eq(1)
         end
 
-        it 'automaticallies populate static fields', :no_ci do
+        it 'automaticallies populate static fields' do
           pending 'Waiting for roles solution'
           post :create, params: { contribution: { title: 'Sample', description: 'User supplied brief description',
                                                   creator: 'John Doe', attachment: uploaded_file }, deposit_type: deposit_type }
@@ -106,12 +135,19 @@ describe ContributeController do
           expect(contribution.format).to eq ['application/pdf']
         end
 
-        it "lists deposit_method as self deposit", :no_ci do
+        it 'lists deposit_method as self deposit' do
           pending 'Waiting for roles solution'
           now = Time.zone.now
           Time.stub(:now).and_return(now)
-          post :create, params: { contribution: { title: 'Sample', description: 'Description of goes here',
-                                                  creator: 'Mickey Mouse', attachment: uploaded_file }, deposit_type: deposit_type }
+
+          post :create, params: {
+            contribution: { title:       'Sample',
+                            description: 'Description of goes here',
+                            creator:     'Mickey Mouse',
+                            attachment:  uploaded_file },
+            deposit_type: deposit_type
+          }
+
           contribution = Pdf.find(assigns[:contribution].id)
           expect(contribution.note.first).to eq "Mickey Mouse self-deposited on #{now.strftime('%Y-%m-%d at %H:%M:%S %Z')} using the Deposit Form for the Tufts Digital Library"
           expect(contribution.date_available).to eq [now.to_s]
@@ -119,9 +155,15 @@ describe ContributeController do
           expect(contribution.createdby).to eq Contribution::SELFDEP
         end
 
-        it 'requires a file attachments', :no_ci do
-          post :create, params: { contribution: { title: 'Sample', description: 'Description of uploaded file goes here', creator: user.display_name }, deposit_type: deposit_type }
-          response.should render_template('new')
+        it 'requires a file attachments' do
+          params = { contribution: { title:       'Sample',
+                                     description: 'Description of uploaded file goes here',
+                                     creator:      user.display_name },
+                     deposit_type: deposit_type }
+
+          post :create, params: params
+
+          expect(response).to render_template('new')
         end
       end
     end

--- a/spec/controllers/deposit_types_controller_spec.rb
+++ b/spec/controllers/deposit_types_controller_spec.rb
@@ -1,24 +1,24 @@
 require 'rails_helper'
 require 'import_export/deposit_type_exporter'
 
+# rubocop:disable RSpec/MultipleExpectations
 describe DepositTypesController do
   let(:dt) { FactoryGirl.create(:deposit_type, display_name: 'DT') }
 
-  before do
-    DepositType.destroy_all
-  end
+  before { DepositType.destroy_all }
 
   context 'a non-admin user' do
     let(:user) { FactoryGirl.create(:user) }
+
     before { sign_in user }
 
     def assert_access_denied(http_command, action, opts = {})
       send(http_command, action, opts)
-      flash[:alert].should =~ /You are not authorized/
-      response.should redirect_to(root_url)
+      expect(flash[:alert]).to match(/You are not authorized/)
+      expect(response).to redirect_to(root_url)
     end
 
-    it 'denies access', :no_ci do
+    it 'denies access' do
       pending('waiting for login')
       assert_access_denied :get, :index
       assert_access_denied :get, :export
@@ -30,11 +30,11 @@ describe DepositTypesController do
       # Edit is tested below, since it has different behavior
     end
 
-    it 'denies access to edit deposit types', :no_ci do
+    it 'denies access to edit deposit types' do
       pending('waiting for login')
       get :edit, params: { id: dt.id }
-      flash[:alert].should =~ /You do not have sufficient privilege/
-      response.should redirect_to(contributions_path)
+      expect(flash[:alert]).to match(/You do not have sufficient privilege/)
+      expect(response).to redirect_to(contributions_path)
     end
   end
 
@@ -44,149 +44,166 @@ describe DepositTypesController do
     before { sign_in user }
 
     describe 'get index' do
-      it 'succeeds', :no_ci do
+      it 'succeeds' do
         get :index
-        response.should be_successful
-        response.should render_template(:index)
-        assigns(:deposit_types).should eq([dt])
+
+        expect(response).to be_successful
+        expect(response).to render_template(:index)
+        expect(assigns(:deposit_types)).to contain_exactly(dt)
       end
     end
 
     describe 'get export' do
-      it 'succeeds', :no_ci do
-        DepositTypeExporter.any_instance.should_receive(:export_to_csv)
+      it 'succeeds' do
         get :export
-        response.should redirect_to(deposit_types_path)
-        flash[:notice].should =~ /exported the deposit types to: #{File.join(DepositTypeExporter::DEFAULT_EXPORT_DIR)}/
+
+        expect(response).to redirect_to(deposit_types_path)
+        expect(flash[:notice])
+          .to match(/exported the deposit types to: #{File.join(DepositTypeExporter::DEFAULT_EXPORT_DIR)}/)
       end
     end
 
     describe 'get new' do
-      it 'succeeds', :no_ci do
+      it 'succeeds' do
         get :new
-        assigns(:deposit_type).should_not be_nil
-        response.should render_template(:new)
+
+        expect(assigns(:deposit_type)).not_to be_nil
+        expect(response).to render_template(:new)
       end
     end
 
     describe 'get show' do
-      it 'succeeds', :no_ci do
+      it 'succeeds' do
         get :show, params: { id: dt.id }
-        response.should be_successful
-        response.should render_template(:show)
-        assigns(:deposit_type).should eq(dt)
+
+        expect(response).to be_successful
+        expect(response).to render_template(:show)
+        expect(assigns(:deposit_type)).to eq dt
       end
     end
 
     describe 'destroy' do
-      it 'succeeds', :no_ci do
+      it 'succeeds' do
         pending('waiting for login')
         get :edit, params: { id: dt.id }
-        flash[:alert].should =~ /You do not have sufficient privilege/
-        response.should redirect_to(contributions_path)
+        expect(flash[:alert]).to match(/You do not have sufficient privilege/)
+        expect(response).to redirect_to(contributions_path)
       end
     end
 
     context 'an admin user' do
       # TODO: switch this over to a real admin user
       let(:user) { FactoryGirl.create(:user) }
+
       before { sign_in user }
 
       describe 'get index' do
-        it 'succeeds', :no_ci do
+        it 'succeeds' do
           get :index
-          response.should be_successful
-          response.should render_template(:index)
-          assigns(:deposit_types).should eq([dt])
+
+          expect(response).to be_successful
+          expect(response).to render_template(:index)
+          expect(assigns(:deposit_types)).to contain_exactly(dt)
         end
       end
 
       describe 'get export' do
-        it 'succeeds', :no_ci do
-          DepositTypeExporter.any_instance.should_receive(:export_to_csv)
+        it 'succeeds' do
           get :export
-          response.should redirect_to(deposit_types_path)
-          flash[:notice].should =~ /exported the deposit types to: #{File.join(DepositTypeExporter::DEFAULT_EXPORT_DIR)}/
+
+          expect(response).to redirect_to(deposit_types_path)
+          expect(flash[:notice])
+            .to match(/exported the deposit types to: #{File.join(DepositTypeExporter::DEFAULT_EXPORT_DIR)}/)
         end
       end
 
       describe 'get new' do
-        it 'succeeds', :no_ci do
+        it 'succeeds' do
           get :new
-          assigns(:deposit_type).should_not be_nil
-          response.should render_template(:new)
+          expect(assigns(:deposit_type)).not_to be_nil
+          expect(response).to render_template(:new)
         end
       end
 
       describe 'get show' do
-        it 'succeeds', :no_ci do
+        it 'succeeds' do
           get :show, params: { id: dt.id }
-          response.should be_successful
-          response.should render_template(:show)
-          assigns(:deposit_type).should eq(dt)
+          expect(response).to be_successful
+          expect(response).to render_template(:show)
+          expect(assigns(:deposit_type)).to eq dt
         end
       end
 
       describe 'destroy' do
-        it 'succeeds', :no_ci do
+        it 'succeeds' do
           dt2 = FactoryGirl.create(:deposit_type, display_name: 'other type')
           delete :destroy, params: { id: dt2.id }
-          DepositType.count.should eq(0)
+          expect(DepositType.count).to eq 0
         end
       end
 
       describe 'create' do
-        it 'succeeds', :no_ci do
+        it 'succeeds' do
           post :create, params: { deposit_type: FactoryGirl.attributes_for(:deposit_type, display_name: 'New Type', deposit_view: 'generic_deposit') }
-          DepositType.count.should eq(1)
+          expect(DepositType.count).to eq 1
           new_type = DepositType.where(display_name: 'New Type').first
-          response.should redirect_to(deposit_type_path(new_type))
-          assigns(:deposit_type).should eq(new_type)
+          expect(response).to redirect_to(deposit_type_path(new_type))
+          expect(assigns(:deposit_type)).to eq new_type
         end
       end
 
       describe 'create with bad inputs' do
-        it 'renders the form', :no_ci do
+        it 'renders the form' do
           # Make it fail to validate:
           DepositType.any_instance.stub(:valid?).and_return(false)
           post :create, params: { deposit_type: { display_name: 'New Type' } }
-          response.should render_template(:new)
-          DepositType.count.should eq(0)
-          assigns(:deposit_type).should_not be_nil
+
+          expect(response).to render_template(:new)
+          expect(DepositType.count).to eq 0
+          expect(assigns(:deposit_type)).not_to be_nil
         end
       end
 
       describe 'edit' do
-        it 'succeeds', :no_ci do
+        it 'succeeds' do
           get :edit, params: { id: dt.id }
-          assigns(:deposit_type).should eq(dt)
-          response.should render_template(:edit)
+
+          expect(assigns(:deposit_type)).to eq dt
+          expect(response).to render_template(:edit)
         end
       end
 
       describe 'update' do
-        it 'succeeds', :no_ci do
-          dt.display_name.should eq('DT')
+        it 'succeeds' do
+          expect(dt.display_name).to eq 'DT'
+
           put :update, params: { id: dt.id, deposit_type: { display_name: 'New Name' } }
           dt.reload
-          dt.display_name.should eq('New Name')
-          assigns(:deposit_type).should eq(dt)
-          response.should redirect_to(deposit_type_path(dt))
+
+          expect(dt.display_name).to eq 'New Name'
+          expect(assigns(:deposit_type)).to eq dt
+          expect(response).to redirect_to(deposit_type_path(dt))
         end
       end
 
       describe 'update with bad inputs' do
-        it 'renders the form', :no_ci do
+        it 'renders the form' do
           pending 'not sure why this is failing'
           # Make it fail to validate:
           DepositType.any_instance.stub(:valid?).and_return(false)
-          dt.display_name.should eq('DT')
 
-          put :update, params: { id: dt.id, deposit_type: { display_name: 'New Name' } }
+          expect(dt.display_name).to eq('DT')
+
+          put :update, params: {
+            id:           dt.id,
+            deposit_type: { display_name: 'New Name' }
+          }
+
           dt.reload
-          dt.display_name.should eq('DT')
-          assigns(:deposit_type).should eq(dt)
-          response.should render_template(:edit)
+
+          expect(dt.display_name).to eq 'DT'
+          expect(assigns(:deposit_type)).to eq dt
+          expect(response).to render_template(:edit)
         end
       end
     end


### PR DESCRIPTION
Some code pulled in from old MIRA had some `should` syntax that needed to be cleaned up. Various other issues in the specs and style for the relevant files are cleaned up.