### PR TITLE
Introduce handle update rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ Metrics/BlockLength:
     - 'app/controllers/catalog_controller.rb'
     - 'spec/rails_helper.rb'
     - 'spec/**/*'
+    - 'lib/tasks/**/*'
     - 'app/models/concerns/tufts/**/*'
 Metrics/ClassLength:
   Exclude:
@@ -26,7 +27,7 @@ RSpec/ExampleLength:
 RSpec/NestedGroups:
   Exclude:
    - 'spec/controllers/deposit_types_controller_spec.rb'
-   - 'spec/controllers/contribute_controller_spec.rb'     
+   - 'spec/controllers/contribute_controller_spec.rb'
 RSpec/AnyInstance:
   Exclude:
    - 'spec/controllers/deposit_types_controller_spec.rb'

--- a/lib/tasks/handle.rake
+++ b/lib/tasks/handle.rake
@@ -2,14 +2,22 @@ require 'rake'
 
 namespace :tufts do
   namespace :handle do
+    ##
+    # @example using control-flow-or to exit a rake task when no object is found
+    #   object = find_or_warn('not_an_id') || next
+    #
+    # @param id [String]
+    # @return [ActiveFedora::Base, false]
+    def find_or_warn(id)
+      ActiveFedora::Base.find(id)
+    rescue ActiveFedora::ObjectNotFoundError
+      $stderr.puts "Unable to find an ActiveFedora::Base object for id: #{id}"
+      false
+    end
+
     desc 'Registers a handle for the object. Supply an id.'
     task :register, [:id] => :environment do |_, args|
-      begin
-        object = ActiveFedora::Base.find(args[:id])
-      rescue ActiveFedora::ObjectNotFoundError
-        $stderr.puts "Unable to find the object for #{args[:id]}"
-        next
-      end
+      object = find_or_warn(args[:id]) || next
 
       if object.identifier.empty?
         handle = Tufts::HandleDispatcher.assign_for!(object: object)
@@ -17,6 +25,19 @@ namespace :tufts do
         puts "Registered a handle #{handle} for #{args[:id]}"
       else
         puts "Identifier(s) exist for #{args[:id]}: #{object.identifier}"
+      end
+    end
+
+    desc 'Ensures that the handle for the object is up to date. Supply an id.'
+    task :update, [:id] => :environment do |_, args|
+      object = find_or_warn(args[:id]) || next
+
+      if object.identifier.empty?
+        $stderr.puts "No handle is registered for the object: #{object.uri}"
+        next
+      else
+        Tufts::HandleRegistrar.new.update!(handle: object.identifier.first,
+                                           object: object)
       end
     end
   end


### PR DESCRIPTION
Adds a rake task for updating handles. See: `Tufts::HandleRegistrar#update!`.

Usage: `$ bundle exec rake tufts:handle:update[an_id]`.

Closes #137 