### PR TITLE
Add `Templates#destroy` action and button

### DIFF
--- a/app/controllers/hyrax/templates_controller.rb
+++ b/app/controllers/hyrax/templates_controller.rb
@@ -3,5 +3,14 @@ module Hyrax
     def index
       @templates = Tufts::Template.all
     end
+
+    def destroy
+      name = params.delete(:id)
+
+      Tufts::Template.for(name: name).delete
+
+      @templates = Tufts::Template.all
+      render action: :index
+    end
   end
 end

--- a/app/views/hyrax/templates/_template.html.erb
+++ b/app/views/hyrax/templates/_template.html.erb
@@ -1,6 +1,5 @@
 <tr>
   <td> TK: EDIT <!-- link_to "Edit", hydra_editor.edit_record_path(template[:id]), class: "btn" --> </td>
   <td> <%= template.name %> </td>
-  <td> TK: DELETE <!-- link_to "Delete", template_path(template[:id]), method: :delete, class: "btn btn-danger",  data: {confirm: "WARNING: this will permanently delete template #{template[:id]}! Are you sure you want to proceed?"} --> </td>
+  <td> <%= link_to "Delete", main_app.template_path(template.name), method: :delete, class: "btn btn-danger",  data: {confirm: "WARNING: this will permanently delete template #{template.name}! Are you sure you want to proceed?"} %> </td>
 </tr>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   end
 
   resources :templates,
-            controller: 'hyrax/templates', only: [:index]
+            controller: 'hyrax/templates', only: [:index, :destroy]
   resources :template_updates,
             controller: 'hyrax/template_updates'
 

--- a/spec/controllers/hyrax/templates_controller_spec.rb
+++ b/spec/controllers/hyrax/templates_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::TemplatesController, type: :controller do
+  let(:template) { templates.first }
+
   let(:templates) do
     [Tufts::Template.new(name: 'template1'),
      Tufts::Template.new(name: 'template2')]
@@ -21,6 +23,21 @@ RSpec.describe Hyrax::TemplatesController, type: :controller do
 
         expect(assigns(:templates).map(&:name))
           .to contain_exactly('template1', 'template2')
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      it 'redirects to index' do
+        delete :destroy, params: { id: template.name }
+
+        expect(response).to render_template :index
+      end
+
+      it 'deletes the template' do
+        expect { delete :destroy, params: { id: template.name } }
+          .to change { template.exists? }
+          .from(true)
+          .to(false)
       end
     end
   end

--- a/spec/features/template_spec.rb
+++ b/spec/features/template_spec.rb
@@ -38,5 +38,12 @@ RSpec.feature 'Apply a Template', :clean, js: true do
       visit '/templates'
       expect(page).to have_content template.name
     end
+
+    scenario 'delete a template' do
+      visit '/templates'
+      click_link 'Delete'
+
+      expect(page).not_to have_content template.name
+    end
   end
 end


### PR DESCRIPTION
Adds a button to the template index view to delete a template.

Partial work on #96. This checks of the 'I can delete a "template"' box on that ticket.