### PR TITLE
Implement template management

### DIFF
--- a/app/controllers/hyrax/templates_controller.rb
+++ b/app/controllers/hyrax/templates_controller.rb
@@ -12,5 +12,52 @@ module Hyrax
       @templates = Tufts::Template.all
       render action: :index
     end
+
+    def edit
+      object   = GenericObject.new
+      template = Tufts::Template.for(name: params[:id])
+
+      template.apply_to(model: object)
+
+      @form = Hyrax::TemplateForm.new(object,
+                                      current_ability,
+                                      self,
+                                      template: template)
+    end
+
+    def new
+      object   = GenericObject.new
+      template = Tufts::Template.new(name: 'New Template')
+
+      @form = Hyrax::TemplateForm.new(object,
+                                      current_ability,
+                                      self,
+                                      template: template)
+      render :edit
+    end
+
+    def update
+      old_template_name = params.require(:id)
+      template_name     = params.require(:generic_object).require(:template_name)
+      diff              = GenericObject.new(object_params)
+
+      unless old_template_name == template_name
+        old_template = Tufts::Template.new(name: old_template_name)
+        old_template.delete if old_template.exists?
+      end
+
+      Tufts::Template.from_object(diff, name: template_name).save
+      redirect_to main_app.templates_path, notice: "Saved #{template_name}"
+    end
+
+    def self.local_prefixes
+      [controller_path, 'hyrax/base']
+    end
+
+    private
+
+      def object_params
+        Hyrax::TemplateForm.model_attributes(params.require(:generic_object))
+      end
   end
 end

--- a/app/forms/hyrax/template_form.rb
+++ b/app/forms/hyrax/template_form.rb
@@ -1,0 +1,43 @@
+module Hyrax
+  class Template < ::GenericObject
+  end
+
+  class TemplateForm < Hyrax::Forms::WorkForm
+    self.model_class = ::GenericObject
+
+    self.terms += Tufts::Terms.shared_terms
+    self.terms.unshift(:template_name)
+
+    self.required_fields = []
+
+    ##
+    # @see Hyrax::Forms::WorkForm.permitted_params
+    def self.permitted_params
+      super - [:template_name]
+    end
+
+    ##
+    # @!attribute template [rw]
+    #   @return [Tufts::Template]
+    attr_accessor :template
+
+    ##
+    # @!method name
+    #   @return (see Tufts::Template#name)
+    delegate :name, to: :template, prefix: :template
+
+    ##
+    # @see Hyrax::Forms::WorkForm#initialize
+    def initialize(model,
+                   ability,
+                   controller,
+                   template: Tufts::Template.new(name: 'New Template'))
+      @template = template
+      super(model, ability, controller)
+    end
+
+    def action
+      "/templates/#{template_name}"
+    end
+  end
+end

--- a/app/views/hyrax/templates/_template.html.erb
+++ b/app/views/hyrax/templates/_template.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td> TK: EDIT <!-- link_to "Edit", hydra_editor.edit_record_path(template[:id]), class: "btn" --> </td>
+  <td> <%= link_to "Edit", main_app.edit_template_path(template.name), class: "btn btn-primary", id: "edit-#{template.name}" %></td>
   <td> <%= template.name %> </td>
   <td> <%= link_to "Delete", main_app.template_path(template.name), method: :delete, class: "btn btn-danger",  data: {confirm: "WARNING: this will permanently delete template #{template.name}! Are you sure you want to proceed?"} %> </td>
 </tr>

--- a/app/views/hyrax/templates/edit.html.erb
+++ b/app/views/hyrax/templates/edit.html.erb
@@ -1,5 +1,23 @@
 
 <%= simple_form_for [main_app, @form], html: { multipart: true }, url: @form.action, method: 'put' do |f| %>
-  <%= render 'hyrax/base/form_metadata', f: f, tabs: %w[metadata] %>
-  <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "submit", name: "template_submit" %>
+<div class="row">
+  <div class="col-xs-12 col-sm-8">
+    <div class="panel" role="main">
+      <div class="tab-content">
+        <%= render 'hyrax/base/form_metadata', f: f, tabs: %w[metadata] %>
+      </div>
+    </div>
+  </div>
+  <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
+    <aside id="form-progress" class="form-progress">
+      <div class="panel-heading">
+        <h3 class="panel-title">Save Template: <strong><%= @form.template_name %></strong></h3>
+      </div>
+      <div>
+        <%= f.submit class: 'btn btn-primary', onclick:
+            "confirmation_needed = false;", id: "submit", name: "template_submit" %>
+      </div>
+    </aside>
+  </div>
+</div>
 <% end %>

--- a/app/views/hyrax/templates/edit.html.erb
+++ b/app/views/hyrax/templates/edit.html.erb
@@ -1,0 +1,5 @@
+
+<%= simple_form_for [main_app, @form], html: { multipart: true }, url: @form.action, method: 'put' do |f| %>
+  <%= render 'hyrax/base/form_metadata', f: f, tabs: %w[metadata] %>
+  <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "submit", name: "template_submit" %>
+<% end %>

--- a/app/views/hyrax/templates/index.html.erb
+++ b/app/views/hyrax/templates/index.html.erb
@@ -3,7 +3,7 @@
 <table class="table">
   <thead>
   <tr>
-    <th> "New Template" <!-- button_to "New Template", templates_path, class: "btn btn-primary" --></th>
+    <th><%= link_to "New Template", main_app.new_template_path, class: "btn btn-primary" %></th>
     <th>Template Name</th>
     <th></th>
   </tr>
@@ -14,7 +14,7 @@
   <%= render partial: 'template', collection: @templates, as: :template %>
 
   <tr>
-    <td> "New Template" <!-- button_to "New Template", templates_path, class: "btn btn-primary" --></td>
+    <td><%= link_to "New Template", main_app.new_template_path, class: "btn btn-primary" %></td>
     <td></td>
   </tr>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,8 @@ Rails.application.routes.draw do
   end
 
   resources :templates,
-            controller: 'hyrax/templates', only: [:index, :destroy]
+            controller: 'hyrax/templates',
+            only:       [:index, :destroy, :edit, :update, :new]
   resources :template_updates,
             controller: 'hyrax/template_updates'
 

--- a/lib/tufts/template.rb
+++ b/lib/tufts/template.rb
@@ -43,6 +43,20 @@ module Tufts
         all.find { |template| template.name == name } ||
           raise("No Template found for #{name}.")
       end
+
+      ##
+      # @param object [ActiveFedora::Base]
+      # @param name   [String]
+      #
+      # @return [Template] a new template with a changeset generated from the
+      #   object given
+      def from_object(object, name:)
+        changeset = ActiveFedora::ChangeSet
+                    .new(object,
+                         object.resource,
+                         object.changed_attributes.keys)
+        new(name: name, changeset: changeset)
+      end
     end
 
     ##

--- a/spec/features/template_spec.rb
+++ b/spec/features/template_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Apply a Template', :clean, js: true do
   let(:object)   { build(:pdf) }
   let(:template) { create(:template) }
 
-  after { template.delete }
+  after { Tufts::Template.all.each(&:delete) }
 
   context 'with logged in user' do
     let(:user_attributes) { { email: 'test@example.com' } }
@@ -39,11 +39,43 @@ RSpec.feature 'Apply a Template', :clean, js: true do
       expect(page).to have_content template.name
     end
 
+    scenario 'create a template' do
+      visit '/templates'
+      first(:link, 'New Template').click
+
+      fill_in 'Template name', with: 'Moomin Template'
+      fill_in 'Title', with: 'Moomin Title'
+
+      click_button 'Save'
+      expect(page).to have_content 'Moomin Template'
+    end
+
     scenario 'delete a template' do
       visit '/templates'
       click_link 'Delete'
 
       expect(page).not_to have_content template.name
+    end
+
+    scenario 'edit a template' do
+      visit '/templates'
+
+      click_link 'Edit', id: "edit-#{template.name}"
+
+      fill_in 'Title', with: 'Moomin Title'
+      click_button 'Save'
+
+      expect(Tufts::Template.for(name: template.name).changeset)
+        .not_to be_empty
+    end
+
+    scenario 'edit a template name' do
+      visit "/templates/#{URI.encode(template.name)}/edit"
+
+      fill_in 'Template name', with: 'Moomin Template'
+      click_button 'Save'
+
+      expect(template.name).to eq 'Moomin Template'
     end
   end
 end

--- a/spec/forms/hyrax/template_form_spec.rb
+++ b/spec/forms/hyrax/template_form_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::TemplateForm do
+  subject(:form)   { described_class.new(model, ability, controller) }
+  let(:ability)    { nil }
+  let(:controller) { nil }
+  let(:model)      { FactoryGirl.create(:pdf) }
+
+  shared_context 'with a template' do
+    subject(:form) do
+      described_class.new(model, ability, controller, template: template)
+    end
+
+    let(:template) { FactoryGirl.build(:template) }
+  end
+
+  describe '.terms' do
+    it 'has template_name as its first term' do
+      expect(described_class.terms.first).to eq :template_name
+    end
+  end
+
+  describe '.required_fields' do
+    it 'has no required fields' do
+      expect(described_class.required_fields).to be_empty
+    end
+  end
+
+  describe '#template' do
+    let(:new_template) { :new_template }
+
+    it 'is a setter that defaults to a template' do
+      expect { form.template = new_template }
+        .to change { form.template }
+        .from(an_instance_of(Tufts::Template))
+        .to new_template
+    end
+  end
+
+  describe '#template_name' do
+    it 'has a non-empty default name' do
+      expect(form.template_name).not_to be_empty
+    end
+
+    context 'with a template' do
+      include_context 'with a template'
+
+      it 'matches the name of the given template' do
+        expect(form.template_name).to eq template.name
+      end
+    end
+  end
+end

--- a/spec/lib/tufts/template_spec.rb
+++ b/spec/lib/tufts/template_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe Tufts::Template do
     end
   end
 
+  describe '.from_object' do
+    before { model.title = ['moomin'] }
+
+    it 'creates a template with the name' do
+      expect(described_class.from_object(model, name: name))
+        .to have_attributes name: name
+    end
+
+    it 'creates a template with the changes' do
+      expect(described_class.from_object(model, name: name).changeset.changes)
+        .to have_key predicate
+    end
+  end
+
   describe '#changeset' do
     it 'is empty by default' do
       expect(template.changeset).to be_empty


### PR DESCRIPTION
Allows users to create new templates and edit existing templates.

The index view provides a _New Template_ button which takes the user to a
form. For existing templates an _Edit_ button is also provided. Users can change
the name of the template, or the values for a changed object from this form;
submission for both is dispatched to the `TemplatesController#update` action.

Not a lot of time has been spent polishing the form, at this point. It's
probable we will want to separate descriptive terms from administrative terms,
and otherwise sharpen up the UI.

Closes #96.