### PR TITLE
Improve template delete redirect

### DIFF
--- a/app/controllers/hyrax/templates_controller.rb
+++ b/app/controllers/hyrax/templates_controller.rb
@@ -10,7 +10,7 @@ module Hyrax
       Tufts::Template.for(name: name).delete
 
       @templates = Tufts::Template.all
-      render action: :index
+      redirect_to main_app.templates_path notice: "Deleted #{name}"
     end
   end
 end

--- a/spec/controllers/hyrax/templates_controller_spec.rb
+++ b/spec/controllers/hyrax/templates_controller_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Hyrax::TemplatesController, type: :controller do
       it 'redirects to index' do
         delete :destroy, params: { id: template.name }
 
-        expect(response).to render_template :index
+        expect(response)
+          .to redirect_to "/templates?locale=en&notice=Deleted+#{template.name}"
       end
 
       it 'deletes the template' do


### PR DESCRIPTION
The `TemplatesController#destroy` action previously used `render` rather than `redirect_to` to show the index view after destroy. It is better to redirect, so refresh will work as expected in browsers. We also add a notice for the successful destroy.