### PR TITLE
Move rake tasks from epigaea to tufts namespace

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,4 @@ require File.expand_path('../config/application', __FILE__)
 Rails.application.load_tasks
 
 task(:default).clear
-task default: ['epigaea:ci']
+task default: ['tufts:ci']

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,3 +1,3 @@
-namespace :epigaea do
-  task ci: ['epigaea:rubocop', 'epigaea:spec']
+namespace :tufts do
+  task ci: ['tufts:rubocop', 'tufts:spec']
 end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,5 +1,5 @@
 require 'rubocop/rake_task'
-namespace :epigaea do
+namespace :tufts do
   desc 'Run style checker'
   RuboCop::RakeTask.new(:rubocop) do |task|
     task.requires << 'rubocop-rspec'

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,6 +1,6 @@
 require 'solr_wrapper/rake_task'
 
-namespace :epigaea do
+namespace :tufts do
   task :spec do
     with_server 'test' do
       Rake::Task['spec'].invoke


### PR DESCRIPTION
The epigaea name is ephemeral, so we're moving the tasks to `tufts`.