### PR TITLE
Update bixby to 0.2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,13 +5,8 @@ Metrics/BlockLength:
   Exclude:
     - 'config/**/*'
     - 'app/controllers/catalog_controller.rb'
-    - 'spec/rails_helper.rb'
     - 'spec/**/*'
-    - 'lib/tasks/**/*'
     - 'app/models/concerns/tufts/**/*'
-Metrics/ClassLength:
-  Exclude:
-    - 'app/controllers/catalog_controller.rb'
 Metrics/LineLength:
    Exclude:
     - 'spec/controllers/tufts/draft_controller_spec.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       i18n
     bcrypt (3.1.11)
     bindex (0.5.0)
-    bixby (0.2.1)
+    bixby (0.2.2)
       rubocop (~> 0.49)
       rubocop-rspec (~> 1.15)
     blacklight (6.10.1)

--- a/lib/tasks/handle.rake
+++ b/lib/tasks/handle.rake
@@ -1,5 +1,6 @@
 require 'rake'
 
+# rubocop:disable Metrics/BlockLength
 namespace :tufts do
   namespace :handle do
     ##


### PR DESCRIPTION
Updates to the latest styles and removes some newly unnecessary local RuboCop configurations.