### PR TITLE
Template preserve strategy

### DIFF
--- a/app/jobs/template_update_job.rb
+++ b/app/jobs/template_update_job.rb
@@ -10,8 +10,8 @@
 class TemplateUpdateJob < ApplicationJob
   queue_as :batch
 
-  def perform(_behavior, id, template_name)
-    template = Tufts::Template.for(name: template_name)
+  def perform(behavior, id, template_name)
+    template = Tufts::Template.for(name: template_name, behavior: behavior)
     model    = ActiveFedora::Base.find(id)
 
     template.apply_to(model: model)

--- a/lib/tufts/changeset_application_strategy.rb
+++ b/lib/tufts/changeset_application_strategy.rb
@@ -7,7 +7,30 @@ module Tufts
   #                                               changeset: changeset)
   #   strategy.apply
   #
+  # @example Using the factory method
+  #   ChangesetApplicationStrategy.for(:preserve, model: model)
+  #   # => #[ChangesetPreserveStrategy...]
+  #
   class ChangesetApplicationStrategy
+    SUBCLASSES = { overwrite: ChangesetOverwriteStrategy,
+                   preserve:  ChangesetPreserveStrategy }.freeze
+
+    class << self
+      ##
+      # @param name      [#to_sym]
+      # @param changeset [ActiveFedora::Changeset]
+      # @param model     [ActiveFedora::Base]
+      #
+      # @return [ChangesetApplicationStrategy] a strategy built from the symbol
+      def for(name, changeset: nil, model:)
+        opts = {}
+        opts[:changeset] = changeset if changeset
+        opts[:model]     = model
+
+        (SUBCLASSES[name.to_sym] || ChangesetApplicationStrategy).new(**opts)
+      end
+    end
+
     ##
     # @!attribute changeset [rw]
     #   @return [ActiveFedora::Changeset]

--- a/lib/tufts/changeset_application_strategy.rb
+++ b/lib/tufts/changeset_application_strategy.rb
@@ -1,0 +1,42 @@
+module Tufts
+  ##
+  # @abstract Concrete implementions require an `#apply` method.
+  #
+  # @example Applying a changeset
+  #   strategy = ChangesetApplicationStrategy.new(model:     model,
+  #                                               changeset: changeset)
+  #   strategy.apply
+  #
+  class ChangesetApplicationStrategy
+    ##
+    # @!attribute changeset [rw]
+    #   @return [ActiveFedora::Changeset]
+    # @!attribute model [rw]
+    #   @return [ActiveFedora::Base]
+    attr_accessor :changeset, :model
+
+    ##
+    # @param changeset [ActiveFedora::ChangeSet]
+    # @param model     [ActiveFedora::Base]
+    def initialize(changeset: NullChangeSet.new, model:)
+      @changeset = changeset
+      @model     = model
+    end
+
+    ##
+    # @abstract
+    # @return [void] applies the changeset to the model
+    #
+    # @raise [ApplicationError] when the changeset is invalid for the model
+    # @raise [NotImplementedError] if this is an abstract strategy
+    def apply
+      raise NotImplementedError, "#{self.class} does not implement `#apply`; " \
+                                 'Should this be a concrete ' \
+                                 'ChangesetApplicationStrategy'
+    end
+
+    ##
+    # An error class for errors occurring during application of the chnageset
+    class ApplicationError < RuntimeError; end
+  end
+end

--- a/lib/tufts/changeset_overwrite_strategy.rb
+++ b/lib/tufts/changeset_overwrite_strategy.rb
@@ -1,20 +1,8 @@
 module Tufts
-  class ChangesetOverwriteStrategy
-    ##
-    # @!attribute changeset [rw]
-    #   @return [ActiveFedora::Changeset]
-    # @!attribute model [rw]
-    #   @return [ActiveFedora::Base]
-    attr_accessor :changeset, :model
-
-    ##
-    # @param changeset [ActiveFedora::ChangeSet]
-    # @param model     [ActiveFedora::Base]
-    def initialize(changeset: NullChangeSet.new, model:)
-      @changeset = changeset
-      @model     = model
-    end
-
+  ##
+  # A `ChangesetApplicationStrategy` that overwrites existing data in changed
+  # fields.
+  class ChangesetOverwriteStrategy < ChangesetApplicationStrategy
     ##
     # @return [void] applies the changeset to the model
     # @raise [RuntimeError] when the changeset is invalid for the model

--- a/lib/tufts/changeset_preserve_strategy.rb
+++ b/lib/tufts/changeset_preserve_strategy.rb
@@ -1,2 +1,53 @@
 module Tufts
+  ##
+  # A changeset application strategy that preserves existing data.
+  #
+  # |type| source | template | result |
+  # |---|---|---|---|
+  # | single / multi | null | null | null |
+  # | single / multi | value1 | null | value1 |
+  # | single / multi | null | value2 | value2 |
+  # | single  | value1 | value2 | **value1** |
+  # | multi  | value1 | value2 | **value1+value2** |
+  #
+  class ChangesetPreserveStrategy < ChangesetApplicationStrategy
+    ##
+    # @see ChangesetApplicationStrategy#apply
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def apply
+      changeset.changes.each do |predicate, graph|
+        config = config_for(predicate: predicate)
+
+        if config.nil?
+          raise "Invalid ChangeSet. Property for #{predicate} does not " \
+                "exist on #{model}"
+        end
+
+        property, config = config
+
+        graph.group_by(&:subject).each do |subject, statements|
+          if subject == model.rdf_subject
+            values = statements.map(&:object).to_a
+
+            if config.multiple?
+              values += model.public_send(property).to_a
+              model.public_send("#{property}=".to_sym, values)
+            else
+              old_value = model.public_send(property)
+              model.public_send("#{property}=".to_sym, values.first) unless
+                old_value
+            end
+          else
+            model.resource.insert(*statements)
+          end
+        end
+      end
+    end
+
+    private
+
+      def config_for(predicate:)
+        model.class.properties.find { |_, v| v.predicate == predicate }
+      end
+  end
 end

--- a/lib/tufts/changeset_preserve_strategy.rb
+++ b/lib/tufts/changeset_preserve_strategy.rb
@@ -1,0 +1,2 @@
+module Tufts
+end

--- a/spec/lib/tufts/changeset_application_strategy_spec.rb
+++ b/spec/lib/tufts/changeset_application_strategy_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::ChangesetApplicationStrategy do
+  it_behaves_like 'a ChangesetApplicationStrategy'
+end

--- a/spec/lib/tufts/changeset_application_strategy_spec.rb
+++ b/spec/lib/tufts/changeset_application_strategy_spec.rb
@@ -1,5 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Tufts::ChangesetApplicationStrategy do
+  let(:changeset) { Tufts::NullChangeSet.new }
+  let(:model)     { FakeWork.new }
+
   it_behaves_like 'a ChangesetApplicationStrategy'
+
+  describe '.for' do
+    it 'returns an instance of itself if' do
+      expect(described_class.for(:overwrite, model: model))
+        .to be_a described_class
+    end
+
+    it 'returns instances of subclasses' do
+      expect(described_class.for(:overwrite, model: model))
+        .to be_a Tufts::ChangesetOverwriteStrategy
+    end
+
+    it 'sets the model' do
+      expect(described_class.for(:overwrite, model: model).model)
+        .to eql model
+    end
+
+    it 'sets the changeset' do
+      strategy = described_class.for(:overwrite,
+                                     model:     model,
+                                     changeset: changeset)
+      expect(strategy.changeset).to eql changeset
+    end
+  end
 end

--- a/spec/lib/tufts/changeset_overwrite_strategy_spec.rb
+++ b/spec/lib/tufts/changeset_overwrite_strategy_spec.rb
@@ -4,30 +4,11 @@ RSpec.describe Tufts::ChangesetOverwriteStrategy do
   subject(:strategy) { described_class.new(model: model) }
   let(:model)        { FakeWork.new }
 
-  it { is_expected.to have_attributes(model: model, changeset: be_empty) }
-
-  shared_context 'with changes' do
-    subject(:strategy) do
-      described_class.new(model: model, changeset: changeset)
-    end
-
-    let(:changeset) do
-      new_model = FakeWork.new(title: ['moomin', 'moominmama', 'snork'],
-                               subject: ['too-ticky'])
-      ActiveFedora::ChangeSet
-        .new(new_model, new_model.resource, new_model.changed_attributes.keys)
-    end
-  end
+  it_behaves_like 'a ChangesetApplicationStrategy'
 
   describe '#apply' do
-    context 'with no changes' do
-      it 'leaves the model unchanged' do
-        expect { strategy.apply }.not_to change { model.resource.statements }
-      end
-    end
-
     context 'with changes' do
-      include_context 'with changes'
+      include_context 'strategy with changes'
 
       it 'applies the changes' do
         expect { strategy.apply }

--- a/spec/lib/tufts/changeset_preserve_strategy_spec.rb
+++ b/spec/lib/tufts/changeset_preserve_strategy_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::ChangesetPreserveStrategy do
+  subject(:strategy) { described_class.new(model: model) }
+  let(:model)        { FakeWork.new }
+
+  it_behaves_like 'a ChangesetApplicationStrategy'
+
+  describe '#apply' do
+    context 'with changes' do
+      include_context 'strategy with changes'
+
+      it 'applies the changes to empty field' do
+        expect { strategy.apply }
+          .to change { model.title.to_a }
+          .to contain_exactly('moomin', 'moominmama', 'snork')
+      end
+
+      it 'updates changed attributes' do
+        expect { strategy.apply }
+          .to change { model.changed_attributes }
+          .to include('title', 'subject')
+      end
+
+      it 'merges existing values' do
+        model.title = ['snufkin']
+
+        expect { strategy.apply }
+          .to change { model.title.to_a }
+          .to contain_exactly('moomin', 'moominmama', 'snork', 'snufkin')
+      end
+
+      it 'leaves existing values unchanged for fields not in the changeset' do
+        model.relation = ['snufkin']
+
+        expect { strategy.apply }
+          .not_to change { model.relation.to_a }
+          .from contain_exactly('snufkin')
+      end
+
+      it 'applies the changes to empty single-valued field' do
+        expect { strategy.apply }
+          .to change { model.single_value }
+          .to eq 'moomin'
+      end
+
+      it 'retains the value in an existing single-valued field' do
+        model.single_value = 'snufkin'
+
+        expect { strategy.apply }
+          .not_to change { model.single_value }
+          .from 'snufkin'
+      end
+    end
+  end
+end

--- a/spec/lib/tufts/template_spec.rb
+++ b/spec/lib/tufts/template_spec.rb
@@ -33,10 +33,17 @@ RSpec.describe Tufts::Template do
     end
 
     context 'with saved templates' do
+      let(:behavior) { :preserve }
+
       before { template.save }
 
-      it 'raises an error for wrong name' do
+      it 'returns a template with the correct name' do
         expect(described_class.for(name: name).name).to eq template.name
+      end
+
+      it 'builds a template with the given behavior' do
+        expect(described_class.for(name: name, behavior: behavior).behavior)
+          .to eq behavior
       end
     end
   end

--- a/spec/support/fakes/fake_work.rb
+++ b/spec/support/fakes/fake_work.rb
@@ -1,7 +1,11 @@
 class FakeWork < ActiveFedora::Base
   PREDICATES = [::RDF::Vocab::DC.title,
-                ::RDF::Vocab::DC.subject].freeze
+                ::RDF::Vocab::DC.subject,
+                ::RDF::Vocab::DC.relation,
+                ::RDF::Vocab::DC.format].freeze
 
-  property :title,   predicate: PREDICATES[0]
-  property :subject, predicate: PREDICATES[1]
+  property :title,        predicate: PREDICATES[0]
+  property :subject,      predicate: PREDICATES[1]
+  property :relation,     predicate: PREDICATES[2]
+  property :single_value, predicate: PREDICATES[3], multiple: false
 end

--- a/spec/support/shared_examples/changeset_application_strategy.rb
+++ b/spec/support/shared_examples/changeset_application_strategy.rb
@@ -22,8 +22,9 @@ RSpec.shared_context 'strategy with changes' do
   end
 
   let(:changeset) do
-    new_model = FakeWork.new(title: ['moomin', 'moominmama', 'snork'],
-                             subject: ['too-ticky'])
+    new_model = FakeWork.new(title:        ['moomin', 'moominmama', 'snork'],
+                             subject:      ['too-ticky'],
+                             single_value: 'moomin')
     ActiveFedora::ChangeSet
       .new(new_model, new_model.resource, new_model.changed_attributes.keys)
   end

--- a/spec/support/shared_examples/changeset_application_strategy.rb
+++ b/spec/support/shared_examples/changeset_application_strategy.rb
@@ -1,0 +1,30 @@
+# rubocop:disable Lint/HandleExceptions
+RSpec.shared_examples 'a ChangesetApplicationStrategy' do
+  subject(:strategy) { described_class.new(model: model) }
+  let(:model)        { FakeWork.new }
+
+  it { is_expected.to have_attributes(model: model, changeset: be_empty) }
+
+  describe '#apply' do
+    context 'with no changes' do
+      it 'leaves the model unchanged' do
+        begin
+          expect { strategy.apply }.not_to change { model.resource.statements }
+        rescue NotImplementedError; end
+      end
+    end
+  end
+end
+
+RSpec.shared_context 'strategy with changes' do
+  subject(:strategy) do
+    described_class.new(model: model, changeset: changeset)
+  end
+
+  let(:changeset) do
+    new_model = FakeWork.new(title: ['moomin', 'moominmama', 'snork'],
+                             subject: ['too-ticky'])
+    ActiveFedora::ChangeSet
+      .new(new_model, new_model.resource, new_model.changed_attributes.keys)
+  end
+end


### PR DESCRIPTION
The first commit (189d505) completes a refactor of the existing template application strategy to extract an abstract interface.

The second (9997fc1):

  - Implements the `TemplatePreserveStrategy` and adds a factory method to the abstract strategy class to dispatch strategy instances.
  - Adds a `#behavior` accessor to the `Tufts::Template` class and its factory, which they use to build a strategy on demand during apply.
  - Finally, forwards the behavior sent to `TemplateApplyJob` by the template application form to the `Template` on build. This causes the correct strategy to be used when `Template#apply` is called by the job.

Closes #121