### PR TITLE
Document ChangesetOverwriteStrategy

### DIFF
--- a/lib/tufts/changeset_overwrite_strategy.rb
+++ b/lib/tufts/changeset_overwrite_strategy.rb
@@ -2,6 +2,19 @@ module Tufts
   ##
   # A `ChangesetApplicationStrategy` that overwrites existing data in changed
   # fields.
+  #
+  # |type| source | template | result |
+  # |---|---|---|---|
+  # | single / multi | null | null | null |
+  # | single / multi  | value1 | null | value1 |
+  # | single / multi  | null | value2 | value2 |
+  # | single / multi  | value1 | value2 | value2 |
+  #
+  # @note If multiple values are given to a single valued field, the first
+  #   value is used. Which value is first may be arbitrary, (e.g. if represented
+  #   by an `RDF::Enumerable`). In general, data submitted through forms should
+  #   not allow cardinality mismatches.
+  #
   class ChangesetOverwriteStrategy < ChangesetApplicationStrategy
     ##
     # @return [void] applies the changeset to the model


### PR DESCRIPTION
Add a table describing the behavior of the overwrite strategy, and a comment about the edge case where multiple values are submitted to a single valued field.