### PR TITLE
Fix Autoload induced circular dependency

### DIFF
--- a/lib/tufts/changeset_application_strategy.rb
+++ b/lib/tufts/changeset_application_strategy.rb
@@ -12,9 +12,6 @@ module Tufts
   #   # => #[ChangesetPreserveStrategy...]
   #
   class ChangesetApplicationStrategy
-    SUBCLASSES = { overwrite: ChangesetOverwriteStrategy,
-                   preserve:  ChangesetPreserveStrategy }.freeze
-
     class << self
       ##
       # @param name      [#to_sym]
@@ -27,7 +24,17 @@ module Tufts
         opts[:changeset] = changeset if changeset
         opts[:model]     = model
 
-        (SUBCLASSES[name.to_sym] || ChangesetApplicationStrategy).new(**opts)
+        (@registry[name.to_sym] || ChangesetApplicationStrategy).new(**opts)
+      end
+
+      ##
+      # @param name  [#to_sym]
+      # @param klass [Class]
+      #
+      # @return [void]
+      def register(name, klass)
+        @registry ||= {}
+        @registry[name.to_sym] = klass
       end
     end
 
@@ -62,4 +69,7 @@ module Tufts
     # An error class for errors occurring during application of the chnageset
     class ApplicationError < RuntimeError; end
   end
+
+  require 'tufts/changeset_overwrite_strategy'
+  require 'tufts/changeset_preserve_strategy'
 end

--- a/lib/tufts/changeset_overwrite_strategy.rb
+++ b/lib/tufts/changeset_overwrite_strategy.rb
@@ -16,6 +16,8 @@ module Tufts
   #   not allow cardinality mismatches.
   #
   class ChangesetOverwriteStrategy < ChangesetApplicationStrategy
+    ChangesetApplicationStrategy.register(:overwrite, self)
+
     ##
     # @return [void] applies the changeset to the model
     # @raise [RuntimeError] when the changeset is invalid for the model

--- a/lib/tufts/changeset_preserve_strategy.rb
+++ b/lib/tufts/changeset_preserve_strategy.rb
@@ -11,6 +11,8 @@ module Tufts
   # | multi  | value1 | value2 | **value1+value2** |
   #
   class ChangesetPreserveStrategy < ChangesetApplicationStrategy
+    ChangesetApplicationStrategy.register(:preserve, self)
+
     ##
     # @see ChangesetApplicationStrategy#apply
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize


### PR DESCRIPTION
Something about the way Rails autoloader works makes the pattern used for the factory method in `ChangesetApplicationStrategy` run into circular dependencies. Asking subclasses to explicitly register themselves avoids this issue.