### PR TITLE
Pseudo-batch template

### DIFF
--- a/app/assets/javascripts/hyrax/batch_select_all.js
+++ b/app/assets/javascripts/hyrax/batch_select_all.js
@@ -13,6 +13,7 @@
         $('#batch-edit').addClass('hidden');
     }
     updateCheckedCounter(n);
+    updateButtonDisabledState(n);
     $("body").css("cursor", "auto");
   }
 
@@ -37,6 +38,10 @@
 
   function updateCheckedCounter(count){
     $('#selected_documents_count').text("Number of documents selected: " + count);
+  }
+
+  function updateButtonDisabledState(count){
+    $('.submits-batches').prop("disabled", (count < 1))
   }
 
   // check all the check boxes on the page

--- a/app/controllers/hyrax/template_updates_controller.rb
+++ b/app/controllers/hyrax/template_updates_controller.rb
@@ -8,7 +8,7 @@ module Hyrax
     end
 
     def new
-      ids = params[:ids] || []
+      ids = params[:ids] || params[:batch_document_ids] || []
       @update = TemplateUpdate.new(ids: ids)
     end
 
@@ -19,7 +19,9 @@ module Hyrax
     private
 
       def template_update_params
-        params.require(:template_update).permit(:behavior, :template_name, ids: [])
+        params
+          .require(:template_update)
+          .permit(:behavior, :template_name, ids: [])
       end
   end
 end

--- a/app/views/catalog/_batch_header.html.erb
+++ b/app/views/catalog/_batch_header.html.erb
@@ -1,2 +1,4 @@
 <%= check_box_tag 'check_all', 'yes', @all_checked %>
+<%= button_to "Apply Template", new_template_update_path, method: :get, class: "btn btn-primary submits-batches" %>
+
 <div id="selected_documents_count">Number of documents selected: 0</div>

--- a/app/views/hyrax/template_updates/new.html.erb
+++ b/app/views/hyrax/template_updates/new.html.erb
@@ -1,5 +1,7 @@
 <%= form_for [main_app, @update] do |f| %>
-  <%= f.hidden_field :ids, multiple: true, value: @update.ids %>
+  <% @update.ids.each do |id| %>
+    <%= f.hidden_field :ids, multiple: true, value: id %>
+  <% end %>
 
   <%= f.select :template_name, options_from_collection_for_select(Tufts::Template.all, :name, :name, @update.template_name), prompt: 'Select a Template' %>
 

--- a/spec/controllers/hyrax/template_updates_controller_spec.rb
+++ b/spec/controllers/hyrax/template_updates_controller_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Hyrax::TemplateUpdatesController, type: :controller do
         expect(assigns(:update))
           .to have_attributes(ids: a_collection_containing_exactly(*ids))
       end
+
+      it 'assigns update with batch_document_ids' do
+        get :new, params: { batch_document_ids: ids }
+
+        expect(assigns(:update))
+          .to have_attributes(ids: a_collection_containing_exactly(*ids))
+      end
     end
 
     describe 'POST #create' do

--- a/spec/features/batch_spec.rb
+++ b/spec/features/batch_spec.rb
@@ -21,7 +21,13 @@ RSpec.feature 'Apply a Template', :clean, js: true do
   scenario 'select items for batch' do
     visit '/catalog'
 
-    find("#document_#{object.id}").check "batch_document_#{object.id}"
+    objects.each do |obj|
+      find("#document_#{obj.id}").check "batch_document_#{obj.id}"
+    end
+
+    click_on 'Apply Template'
+
+    expect(page).to have_content 'Template Behavior'
   end
 
   scenario 'select all' do


### PR DESCRIPTION
This adds a template apply button to the batch dashboard, disables it when no items are selected, and allows the template update form to work with multiple ids. This allows us to enqueue many template update jobs through the batch form, but not explicitly "in batch", yet.

This partially fulfills #157 