### PR TITLE
Batch Show

### DIFF
--- a/app/controllers/hyrax/batches_controller.rb
+++ b/app/controllers/hyrax/batches_controller.rb
@@ -1,0 +1,11 @@
+module Hyrax
+  class BatchesController < ApplicationController
+    def index
+      @batches = Batch.all.map { |batch| BatchPresenter.for(object: batch) }
+    end
+
+    def show
+      @batch = BatchPresenter.for(object: Batch.find(params[:id]))
+    end
+  end
+end

--- a/app/controllers/hyrax/template_updates_controller.rb
+++ b/app/controllers/hyrax/template_updates_controller.rb
@@ -1,10 +1,14 @@
 module Hyrax
   class TemplateUpdatesController < ApplicationController
     def create
-      update = TemplateUpdate.create(template_update_params)
+      update       = TemplateUpdate.new(template_update_params)
+      update.batch = Batch.create(batchable: update,
+                                  creator:   current_user,
+                                  ids:       update.ids)
+      update.save
       update.enqueue!
 
-      render plain: "OK: #{update.template_name}" # redirect_to action: 'show'
+      redirect_to main_app.batch_path(update.batch)
     end
 
     def new

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,0 +1,36 @@
+class Batch < ApplicationRecord
+  ##
+  # @!attribute creator [r]
+  #   @return [User]
+  belongs_to :user
+  alias_attribute :creator, :user
+
+  ##
+  # @!attribute ids [rw]
+  #   @return [Array<String>]
+  serialize :ids, Array
+
+  ##
+  # @return [Enumerator<ActiveFedora::Base>]
+  def items
+    ids.lazy.map { |id| Item.new(id) }
+  end
+
+  ##
+  # Items for the batch. Items are a composite of an `ActiveFedora::Base` object
+  # and its corresponding job.
+  class Item
+    ##
+    # @!attribute job    [rw]
+    # @!attribute object [rw]
+    #   @return [ActiveFedora::Base]
+    attr_accessor :job, :object
+
+    ##
+    # @param id [#to_s]
+    def initialize(id)
+      @object = ActiveFedora::Base.find(id)
+      @job    = :no_job
+    end
+  end
+end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -6,6 +6,11 @@ class Batch < ApplicationRecord
   alias_attribute :creator, :user
 
   ##
+  # @!attribute batchable [r]
+  #   @return [TemplateUpdate]
+  belongs_to :batchable, polymorphic: true
+
+  ##
   # @!attribute ids [rw]
   #   @return [Array<String>]
   serialize :ids, Array

--- a/app/models/template_update.rb
+++ b/app/models/template_update.rb
@@ -8,12 +8,15 @@
 # @see Tufts::Template
 # @see TemplateUpdateJob
 class TemplateUpdate < ApplicationRecord
+  # @!attribute batch [rw]
+  #   @return [Batch]
   # @!attribute behavior [rw]
   #   @return [String]
   # @!attribute ids [rw]
   #   @return [Array<String>]
   # @!attribute template_name [rw]
   #   @return [String]
+  has_one :batch, as: :batchable
 
   serialize :ids, Array
 

--- a/app/presenters/batch_presenter.rb
+++ b/app/presenters/batch_presenter.rb
@@ -1,0 +1,57 @@
+##
+# A presenter for the Batch model
+class BatchPresenter
+  ##
+  # @!attribute object [rw]
+  #   @return [Batch]
+  attr_accessor :object
+
+  ##
+  # @param object [Batch]
+  def initialize(object)
+    @object = object
+  end
+
+  class << self
+    ##
+    # @param object [Batch]
+    #
+    # @return [BatchPresenter] a batch presenter or subclass for the given
+    #   object.
+    def for(object:)
+      new(object)
+    end
+  end
+
+  delegate :created_at, :id, :items, to: :object
+
+  ##
+  # @return [String]
+  def count
+    object.ids.count.to_s
+  end
+
+  ##
+  # @return [String]
+  def creator
+    object.creator.email
+  end
+
+  ##
+  # @return [String]
+  def review_status
+    'Incomplete'
+  end
+
+  ##
+  # @return [String]
+  def status
+    'Queued'
+  end
+
+  ##
+  # @return [String]
+  def type
+    'Template Update'
+  end
+end

--- a/app/views/hyrax/batches/_batch_info.html.erb
+++ b/app/views/hyrax/batches/_batch_info.html.erb
@@ -1,0 +1,10 @@
+  <div class="batch_info">
+    <dl class="dl-horizontal">
+      <dt>Batch Id</dt><dd><%= batch.id %></dd>
+      <dt>Type</dt><dd><%= batch.type %></dd>
+      <dt>Record Count</dt><dd><%= batch.count %></dd>
+      <dt>Creator</dt><dd><%= batch.creator %></dd>
+      <dt>Created At</dt><dd><%= batch.created_at %></dd>
+      <dt>Status</dt><dd><%= batch.status %></dd>
+    </dl>
+  </div>

--- a/app/views/hyrax/batches/_batch_items.html.erb
+++ b/app/views/hyrax/batches/_batch_items.html.erb
@@ -1,0 +1,21 @@
+  <div class="batch-items">
+    <table class="table">
+      <tr>
+        <th>Item ID</th>
+        <th>Title</th>
+        <th>Status</th>
+        <th>Review Status</th>
+      </tr>
+
+      <% batch.items.each do |item| %>
+        <tr>
+          <!-- <td class="record_id">%= link_to item.title, catalog_path(item.item_id) %></td> -->
+          <!-- <td class="record_title">%= item.record_title %></td> -->
+          <!-- <td class="record_status">%= item.status %></td> -->
+          <!-- <td class="record_reviewed_status"> -->
+          <!--   %= check_box_tag :reviewed, :reviewed, item.reviewed?, type: :checkbox, disabled: true  %> -->
+          <!-- </td> -->
+        </tr>
+      <% end %>
+    </table>
+  </div>

--- a/app/views/hyrax/batches/index.html.erb
+++ b/app/views/hyrax/batches/index.html.erb
@@ -1,0 +1,26 @@
+<div class="col-sm-12">
+  <h1>Batches</h1>
+
+  <div class="batches">
+    <table class="table">
+      <tr>
+        <th>ID</th>
+        <th>Batch Type</th>
+        <th>Creator</th>
+        <th>Created at</th>
+        <th>Items</th>
+        <th>Status</th>
+      </tr>
+      <% @batches.each do |batch| %>
+        <tr>
+          <td class="batch_id"><%= link_to batch.id, main_app.batch_path(id: batch.id) %></td>
+          <td class="type"><%= batch.type%></td>
+          <td class="creator"><%= batch.creator %></td>
+          <td class="created_at"><%= batch.created_at %> ago</td>
+          <td class="count"><%= batch.count %></td>
+          <td class="status"><%= batch.status %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/hyrax/batches/show.html.erb
+++ b/app/views/hyrax/batches/show.html.erb
@@ -1,0 +1,8 @@
+<div class="col-sm-12">
+  <h1>Batch Status</h1>
+
+  <%= link_to "All batches", main_app.batches_path %>
+
+  <%= render 'batch_info',  batch: @batch %>
+  <%= render 'batch_items', batch: @batch %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
+  resources :batches, controller: 'hyrax/batches', only: [:index, :show]
+
   resources :bookmarks do
     concerns :exportable
 

--- a/db/migrate/20170823020717_create_batches.rb
+++ b/db/migrate/20170823020717_create_batches.rb
@@ -1,0 +1,10 @@
+class CreateBatches < ActiveRecord::Migration[5.0]
+  def change
+    create_table :batches do |t|
+      t.references :batchable, polymorphic: true, index: true
+      t.belongs_to :user
+      t.text       :ids
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170804153201) do
+ActiveRecord::Schema.define(version: 20170823020717) do
+
+  create_table "batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "batchable_type"
+    t.integer  "batchable_id"
+    t.integer  "user_id"
+    t.text     "ids",            limit: 65535
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.index ["batchable_type", "batchable_id"], name: "index_batches_on_batchable_type_and_batchable_id", using: :btree
+    t.index ["user_id"], name: "index_batches_on_user_id", using: :btree
+  end
 
   create_table "bookmarks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id",                     null: false

--- a/spec/controllers/hyrax/batches_controller_spec.rb
+++ b/spec/controllers/hyrax/batches_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::BatchesController, type: :controller do
+  let(:batch) { FactoryGirl.create(:batch) }
+
+  context 'as admin' do
+    include_context 'as admin'
+
+    describe 'GET #index' do
+      before { batch }
+
+      it 'assigns @batches' do
+        get :index
+
+        expect(assigns(:batches).map(&:object)).to contain_exactly(batch)
+      end
+    end
+
+    describe 'GET #show' do
+      let(:batch) { FactoryGirl.create(:batch) }
+
+      it 'assigns @batch' do
+        get :show, params: { id: batch.id }
+
+        expect(assigns(:batch).object).to eq batch
+      end
+    end
+  end
+end

--- a/spec/factories/batches.rb
+++ b/spec/factories/batches.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :batch do
+    association :batchable, factory: :template_update
     user
     ids ['abc', '123']
   end

--- a/spec/factories/batches.rb
+++ b/spec/factories/batches.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :batch do
+    user
+    ids ['abc', '123']
+  end
+end

--- a/spec/features/batch_spec.rb
+++ b/spec/features/batch_spec.rb
@@ -18,7 +18,9 @@ RSpec.feature 'Apply a Template', :clean, js: true do
     login_as user
   end
 
-  scenario 'select items for batch' do
+  scenario 'apply a template to selected items' do
+    template = create(:template)
+
     visit '/catalog'
 
     objects.each do |obj|
@@ -27,10 +29,14 @@ RSpec.feature 'Apply a Template', :clean, js: true do
 
     click_on 'Apply Template'
 
-    expect(page).to have_content 'Template Behavior'
+    select template.name, from: 'template_update_template_name'
+    choose id: 'template_update_behavior_overwrite'
+
+    click_on 'Apply Template'
+    expect(page).to have_content 'Batch'
   end
 
-  scenario 'select all' do
+  scenario 'using select all' do
     visit '/catalog'
     check 'check_all'
 

--- a/spec/features/batch_spec.rb
+++ b/spec/features/batch_spec.rb
@@ -37,3 +37,26 @@ RSpec.feature 'Apply a Template', :clean, js: true do
     expect(find('#selected_documents_count')).to have_content objects.count
   end
 end
+
+RSpec.feature 'Manage batches', :clean, js: true do
+  let(:batch)  { create(:batch, ids: [pdf.id]) }
+  let(:user)   { create(:admin) }
+  let(:pdf)    { create(:pdf) }
+
+  before do
+    login_as user
+    batch
+  end
+
+  scenario 'list batches' do
+    visit '/batches'
+
+    expect(page).to have_content batch.creator
+  end
+
+  scenario 'show batch' do
+    visit "/batches/#{batch.id}"
+
+    expect(page).to have_content batch.creator
+  end
+end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Batch, type: :model do
+  subject(:batch) { FactoryGirl.build(:batch) }
+
+  it { is_expected.to have_attributes(creator: an_instance_of(User)) }
+
+  describe '#ids' do
+    context 'with no ids' do
+      subject(:batch) { FactoryGirl.build(:batch, ids: nil) }
+      it { is_expected.to have_attributes(ids: be_empty) }
+    end
+
+    it 'contains item ids' do
+      expect(batch.ids).to contain_exactly('abc', '123')
+    end
+  end
+
+  describe '#items' do
+    let(:items) do
+      batch.ids.each_with_object({}) { |id, h| h[id] = :"Item #{id}" }
+    end
+
+    before do
+      items.each do |id, item|
+        allow(described_class::Item)
+          .to receive(:new)
+          .with(id)
+          .and_return(item)
+      end
+    end
+
+    it 'contains the items' do
+      expect(batch.items).to contain_exactly(*items.values)
+    end
+
+    context 'with no ids' do
+      subject(:batch) { FactoryGirl.build(:batch, ids: nil) }
+
+      it 'is empty' do
+        expect(batch.items.first).to be_nil
+      end
+    end
+  end
+end

--- a/spec/presenters/batch_presenter_spec.rb
+++ b/spec/presenters/batch_presenter_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe BatchPresenter do
+  subject(:presenter) { described_class.new(batch) }
+  let(:batch)         { FactoryGirl.build(:batch) }
+
+  it { is_expected.to delegate_method(:created_at).to(:object) }
+  it { is_expected.to delegate_method(:id).to(:object) }
+  it { is_expected.to delegate_method(:items).to(:object) }
+
+  describe '#creator' do
+    it 'is the creator #email' do
+      expect(presenter.creator).to eq batch.creator.email
+    end
+  end
+
+  describe '#count' do
+    let(:ids) { ['abc', '123'] }
+
+    before { batch.ids = ids }
+
+    it 'is the number of ids/jobs' do
+      expect(presenter.count).to eq ids.count.to_s
+    end
+  end
+end

--- a/spec/support/shared_contexts/as_admin.rb
+++ b/spec/support/shared_contexts/as_admin.rb
@@ -1,0 +1,4 @@
+RSpec.shared_context 'as admin' do
+  let(:user) { FactoryGirl.create(:admin) }
+  before     { sign_in user }
+end


### PR DESCRIPTION
410aac1 creates a basic `Batch` class and show view, partially closing #158.

be97313 wires `Batch` into the existing `TemplateUpdate` tasks with a polymorphic `belongs_to`. The logic is still somewhat fragmented between the existing `TemplateUpdate` and the `Batch`, we plan to resolve this in continued work on #158, #159, and #160, as well as during implementation of other `batchable` tasks. This closes #157.