### PR TITLE
Add shared examples for Batchable

### DIFF
--- a/spec/models/template_update_spec.rb
+++ b/spec/models/template_update_spec.rb
@@ -1,28 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe TemplateUpdate, type: :model do
-  subject(:update) { FactoryGirl.create(:template_update) }
+  subject(:batchable) { FactoryGirl.create(:template_update) }
+
+  it_behaves_like 'a batchable'
 
   describe '#behavior' do
     it 'is a writable attribute' do
-      expect { update.behavior = described_class::PRESERVE }
-        .to change { update.behavior }
+      expect { batchable.behavior = described_class::PRESERVE }
+        .to change { batchable.behavior }
         .to described_class::PRESERVE
     end
   end
 
   describe '#ids' do
     it 'is a writable attribute' do
-      expect { update.ids = ['moomin1', 'moomin2'] }
-        .to change { update.ids }
+      expect { batchable.ids = ['moomin1', 'moomin2'] }
+        .to change { batchable.ids }
         .to contain_exactly('moomin1', 'moomin2')
     end
   end
 
   describe '#template_name' do
     it 'is a writable attribute' do
-      expect { update.template_name = 'moomin' }
-        .to change { update.template_name }
+      expect { batchable.template_name = 'moomin' }
+        .to change { batchable.template_name }
         .to 'moomin'
     end
   end

--- a/spec/support/shared_examples/batchable.rb
+++ b/spec/support/shared_examples/batchable.rb
@@ -1,0 +1,36 @@
+shared_examples 'a batchable' do
+  let(:batch) { FactoryGirl.create(:batch, ids: ids) }
+  let(:ids)   { [] }
+
+  describe '#batch' do
+    it 'sets a batch' do
+      expect { batchable.batch = batch }
+        .to change { batchable.batch }
+        .to(batch)
+    end
+  end
+
+  describe '#batch_type' do
+    it 'has a type string' do
+      expect(batchable.batch_type).to be_a String
+    end
+  end
+
+  describe '#enqueue!' do
+    before { batchable.batch = batch }
+
+    it 'returns an empty hash' do
+      expect(batchable.enqueue!).to eq({})
+    end
+
+    context 'with ids in batch' do
+      let(:ids) { ['abc', '123'] }
+
+      it 'gives a hash associating ids to jobs' do
+        expect(batchable.enqueue!)
+          .to include('abc' => an_instance_of(String),
+                      '123' => an_instance_of(String))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This improves the test coverage for `TemplateUpdate` and adds shared examples for Batchables in preparation for the introduction of new batch tasks.