### PR TITLE
Support Publish in batch using generic `BatchTasks`

### DIFF
--- a/app/controllers/hyrax/batches_controller.rb
+++ b/app/controllers/hyrax/batches_controller.rb
@@ -1,10 +1,14 @@
 module Hyrax
   class BatchesController < ApplicationController
+    before_action :check_permissions
+
     def index
       @batches = Batch.all.map { |batch| BatchPresenter.for(object: batch) }
     end
 
     def create
+      params['batch']['ids'] ||= params[:batch_document_ids]
+
       batch           = Batch.new(params.require(:batch).permit(ids: []))
       batch.batchable = BatchTask.new(batchable_params)
       batch.save
@@ -31,6 +35,10 @@ module Hyrax
           .require(:batch)
           .require(:batchable_attributes)
           .permit(:batch_type)
+      end
+
+      def check_permissions
+        authorize! :create, Batch
       end
   end
 end

--- a/app/controllers/hyrax/batches_controller.rb
+++ b/app/controllers/hyrax/batches_controller.rb
@@ -4,8 +4,33 @@ module Hyrax
       @batches = Batch.all.map { |batch| BatchPresenter.for(object: batch) }
     end
 
+    def create
+      batch           = Batch.new(params.require(:batch).permit(ids: []))
+      batch.batchable = BatchTask.new(batchable_params)
+      batch.save
+
+      batch.enqueue!
+
+      redirect_to main_app.batches_path action: 'show',
+                                        id:     batch.id,
+                                        notice: 'Batch Enqueued!'
+    end
+
     def show
       @batch = BatchPresenter.for(object: Batch.find(params[:id]))
     end
+
+    private
+
+      def batch_params
+        params.require(:batch).permit(ids: [])
+      end
+
+      def batchable_params
+        params
+          .require(:batch)
+          .require(:batchable_attributes)
+          .permit(:batch_type)
+      end
   end
 end

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -1,0 +1,9 @@
+##
+# A job to mark an existing object published.
+class PublishJob < BatchableJob
+  def perform(id)
+    model = ActiveFedora::Base.find(id)
+    model.mark_published
+    model.save
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,7 +13,8 @@ class Ability
     # end
 
     can [:create], Contribution if current_user
-    can [:manage], DepositType if current_user
+    can [:create], Batch        if current_user
+    can [:manage], DepositType  if current_user
     # Limits creating new objects to a specific group
     #
     # if user_groups.include? 'special_group'

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -9,6 +9,7 @@ class Batch < ApplicationRecord
   # @!attribute batchable [r]
   #   @return [#enqueue!]
   belongs_to :batchable, polymorphic: true
+  accepts_nested_attributes_for :batchable
 
   ##
   # @!attribute ids [rw]

--- a/app/models/batch_task.rb
+++ b/app/models/batch_task.rb
@@ -1,0 +1,44 @@
+##
+# A generic batchable to support simple batch cases.
+#
+# This class supports a simple mapping between a batch type name and a job
+# class. `#enqueue!` creates jobs of the correct type, passing in the ids
+# from the associated batch.
+#
+# @see Batch
+class BatchTask < ApplicationRecord
+  # @!attribute batch [rw]
+  #   @return [Batch]
+  # @!attribute batch_type [rw]
+  #   @return [String]
+  has_one :batch, as: :batchable
+
+  BATCH_TYPES = { publish: PublishJob }.freeze
+
+  validates :batch_type,
+            inclusion: { in: BATCH_TYPES.keys.map { |t| t.capitalize.to_s } }
+
+  ##
+  # @param [#to_sym] type_key
+  #
+  # @return [Class] a subclass of `BatchableJob`
+  def self.job_for(type_key)
+    BATCH_TYPES[type_key.to_sym.downcase]
+  end
+
+  ##
+  # @return [Hash<String, String>] a hash associating object ids to job ids
+  def enqueue!
+    job = self.class.job_for(batch_type)
+
+    ids.each_with_object({}) do |id, hsh|
+      hsh[id] = job.perform_later(id).job_id
+    end
+  end
+
+  ##
+  # @return [Array<String>]
+  def ids
+    batch ? batch.ids : []
+  end
+end

--- a/app/presenters/batch_presenter.rb
+++ b/app/presenters/batch_presenter.rb
@@ -45,7 +45,7 @@ class BatchPresenter
   ##
   # @return [String]
   def creator
-    object.creator.email
+    object.creator.try(:email) || 'No Creator'
   end
 
   ##

--- a/app/views/catalog/_batch_header.html.erb
+++ b/app/views/catalog/_batch_header.html.erb
@@ -1,4 +1,4 @@
 <%= check_box_tag 'check_all', 'yes', @all_checked %>
 <%= button_to "Apply Template", new_template_update_path, method: :get, class: "btn btn-primary submits-batches" %>
-
+<%= button_to "Publish", batches_path, method: :post, params: { batch: { batchable_attributes: { batch_type: "Publish" } } }, class: "btn btn-primary submits-batches" %>
 <div id="selected_documents_count">Number of documents selected: 0</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
-  resources :batches, controller: 'hyrax/batches', only: [:index, :show]
+  resources :batches, controller: 'hyrax/batches', only: [:index, :show, :create]
 
   resources :bookmarks do
     concerns :exportable

--- a/db/migrate/20170831005450_create_batch_tasks.rb
+++ b/db/migrate/20170831005450_create_batch_tasks.rb
@@ -1,0 +1,8 @@
+class CreateBatchTasks < ActiveRecord::Migration[5.0]
+  def change
+    create_table :batch_tasks do |t|
+      t.string :batch_type
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170823020717) do
+ActiveRecord::Schema.define(version: 20170831005450) do
+
+  create_table "batch_tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "batch_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "batchable_type"

--- a/spec/controllers/hyrax/batches_controller_spec.rb
+++ b/spec/controllers/hyrax/batches_controller_spec.rb
@@ -16,6 +16,33 @@ RSpec.describe Hyrax::BatchesController, type: :controller do
       end
     end
 
+    describe 'POST #create' do
+      let(:ids) { ['abc', '123'] }
+
+      let(:params) do
+        {
+          batch: {
+            ids: ids,
+            batchable_attributes: {
+              batch_type: 'Publish'
+            }
+          }
+        }
+      end
+
+      it 'creates a batch' do
+        expect { post :create, params: params }.to change { Batch.count }.by(1)
+      end
+
+      it 'enqueues jobs' do
+        ActiveJob::Base.queue_adapter = :test
+
+        expect { post :create, params: params }
+          .to enqueue_job(PublishJob)
+          .exactly(:twice)
+      end
+    end
+
     describe 'GET #show' do
       let(:batch) { FactoryGirl.create(:batch) }
 

--- a/spec/factories/batch_tasks.rb
+++ b/spec/factories/batch_tasks.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :batch_task do
+    batch_type 'Publish'
+  end
+end

--- a/spec/models/batch_task_spec.rb
+++ b/spec/models/batch_task_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe BatchTask, type: :model do
+  subject(:batchable) { FactoryGirl.build(:batch_task) }
+
+  it_behaves_like 'a batchable'
+
+  it { is_expected.to have_attributes batch_type: 'Publish' }
+
+  it 'validates batch types' do
+    expect(described_class.new(batch_type: 'NONSENSE')).not_to be_valid
+  end
+
+  describe '#enqueue!' do
+    let(:batch) { FactoryGirl.create(:batch, ids: [id]) }
+    let(:id)    { 'FAKE_ID' }
+
+    before { batchable.batch = batch }
+
+    it 'enqueues the correct job type' do
+      ActiveJob::Base.queue_adapter = :test
+
+      expect { batchable.enqueue! }
+        .to enqueue_job(PublishJob)
+        .with(id)
+        .on_queue('batch')
+    end
+  end
+
+  describe '.job_for' do
+    it 'gives a batchable job' do
+      expect(described_class.job_for(batchable.batch_type)).to be < BatchableJob
+    end
+  end
+
+  describe '#ids' do
+    let(:batch) { FactoryGirl.create(:batch) }
+
+    it 'is empty' do
+      expect(batchable.ids).to be_empty
+    end
+
+    context 'with a batch' do
+      let(:batch) { FactoryGirl.create(:batch) }
+
+      before { batchable.batch = batch }
+
+      it 'has the ids from the batch' do
+        expect(batchable.ids).to contain_exactly(*batch.ids)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a generic `BatchTask` to serve as a batchable linking a batch type to a job class, and supporting enqueueing the appropriate jobs for the batch.

A matching controller is introduced to handle creation of generic batches. `TemplateUpdate` is still handled by `TemplateUpdateController`, due to its special parameters.

The `PublishJob` enqueued by the batch publish button simply calls `#mark_published` on the `ActiveFedora` model; that method does not yet exist, pending #5.