### PR TITLE
Implement basic XML import parser

### DIFF
--- a/lib/tufts/import_record.rb
+++ b/lib/tufts/import_record.rb
@@ -1,0 +1,26 @@
+module Tufts
+  ##
+  # A record for import.
+  #
+  # Instances are in-memory representations of records from import
+  # documents, prepared for import into Fedora. In addition to the metadata
+  # present in the final record, several other pieces of data are provided
+  # to the import record to aid in importing the correct files and types.
+  #
+  # @example
+  #   record      = ImportRecord.new
+  #   record.file = 'filename.png'
+  #
+  class ImportRecord
+    ##
+    # @!attribute file [rw]
+    #   @return [String]
+    attr_accessor :file
+
+    ##
+    # @param file [String]
+    def initialize(file: '')
+      @file = file
+    end
+  end
+end

--- a/lib/tufts/mira_xml_importer.rb
+++ b/lib/tufts/mira_xml_importer.rb
@@ -1,0 +1,65 @@
+module Tufts
+  ##
+  # An importer for MIRA XML.
+  #
+  # The import format is a stripped down OAI-PMH ListRecords response format.
+  # Each `<record>` tag represents a single object.
+  #
+  # @example
+  #   importer = MiraXmlImporter.new(file: File.open('my_import.xml'))
+  #
+  #
+  # @see http://www.openarchives.org/OAI/openarchivesprotocol.html#ListRecords
+  #   for the OAI ListRecords format.
+  class MiraXmlImporter
+    ##
+    # @!ottribute file [rw]
+    #   @return [IO]
+    attr_accessor :file
+
+    ##
+    # @param [IO] file
+    def initialize(file:)
+      raise(ArgumentError, "file must be an IO, got a #{file.class}") unless
+        file.respond_to? :read
+
+      @file = file
+    end
+
+    ##
+    # @yield Gives each record to the block
+    # @yieldparam [ImportRecord]
+    #
+    # @return [Enumerable<ImportRecord>]
+    def records
+      if block_given?
+        metadata_nodes.each do |node|
+          record      = ImportRecord.new
+          record.file = node.xpath('./dcterms:source', node.namespaces)
+                            .children
+                            .map(&:content)
+                            .first || ''
+          yield record
+        end
+      end
+
+      enum_for(:records)
+    end
+
+    private
+
+      def doc
+        file.rewind
+        Nokogiri::XML(file)
+      end
+
+      def metadata_nodes
+        root = doc.root
+
+        return [] if root.nil?
+
+        root.xpath('//xmlns:record/xmlns:metadata/xmlns:mira_import',
+                   root.namespaces)
+      end
+  end
+end

--- a/spec/fixtures/files/mira_xml.xml
+++ b/spec/fixtures/files/mira_xml.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2017-09-01T19:20:30Z</responseDate>
+  <request verb="ListRecords" from="1998-01-15"
+           set="any:set"
+           metadataPrefix="mira_import">
+  http://example.com/OAI</request>
+  <ListRecords>
+    <record>
+      <header>
+        <identifier>oai:arXiv.org:hep-th/9901001</identifier>
+        <datestamp>1999-12-25</datestamp>
+        <setSpec>any:set</setSpec>
+        <setSpec>another_set</setSpec>
+      </header>
+      <metadata>
+        <mira_import xmlns:dc="http://purl.org/dc/elements/1.1/"
+                     xmlns:dca_dc="http://nils.lib.tufts.edu/dca_dc/"
+                     xmlns:dcadesc="http://nils.lib.tufts.edu/dcadesc/"
+                     xmlns:dcatech="http://nils.lib.tufts.edu/dcatech/"
+                     xmlns:dcterms="http://purl.org/dc/terms/"
+                     xmlns:admin="http://nils.lib.tufts.edu/dcaadmin/"
+                     xmlns:xlink="http://www.w3.org/TR/xlink">
+          <dcterms:source>1.pdf</dcterms:source>
+          <dc:title>President Jean Mayer speakin0g at commencement, 1987</dc:title>
+          <dc:description>5x7</dc:description>
+          <dc:source>UA136</dc:source>
+          <dc:coverage>Medford;7014023;42.417;-71.100</dc:coverage>
+          <dc:temporal>1987</dc:temporal>
+          <dc:creator>Unknown</dc:creator>
+          <dc:publisher>Digital Collections and Archives, Tufts University</dc:publisher
+          <dc:rights>http://dca.tufts.edu/ua/access/rights.html</dc:rights>
+          <dc:identifier>http://hdl.handle.net/10427/448</dc:identifier>
+          <dcterms:isPartOf>UA136</dcterms:isPartOf>
+          <dcterms:created>07/02/2002</dcterms:created>
+          <dcterms:available>02/26/2004</dcterms:available>
+          <dc:type>image</dc:type>
+          <dc:format>image/tiff</dc:format>
+          <dcatech:resolution>600</dcatech:resolution>
+          <dcatech:bitDepartment>8</dcatech:bitDepartment>
+          <dcatech:colorSpace>grayscale</dcatech:colorSpace>
+          <dcadesc:persname>Mayer, Jean</dcadesc:persname>
+          <dcadesc:corpname>Office of the President</dcadesc:corpname>
+          <dcadesc:subject>People</dcadesc:subject>
+          <dcadesc:subject>Commencement</dcadesc:subject>
+          <dcadesc:subject>Events</dcadesc:subject>
+          <dcadesc:subject>College presidents</dcadesc:subject>
+        </mira_import>
+      </metadata>
+      <about>
+        <oai_dc:dc
+            xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                                http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+          <dc:publisher>Los Alamos arXiv</dc:publisher>
+          <dc:rights>Metadata may be used without restrictions as long as
+          the oai identifier remains attached to it.</dc:rights>
+        </oai_dc:dc>
+      </about>
+    </record>
+    <record>
+      <metadata>
+        <mira_import xmlns:dc="http://purl.org/dc/elements/1.1/"
+                     xmlns:dca_dc="http://nils.lib.tufts.edu/dca_dc/"
+                     xmlns:dcadesc="http://nils.lib.tufts.edu/dcadesc/"
+                     xmlns:dcatech="http://nils.lib.tufts.edu/dcatech/"
+                     xmlns:dcterms="http://purl.org/dc/terms/"
+                     xmlns:admin="http://nils.lib.tufts.edu/dcaadmin/"
+                     xmlns:xlink="http://www.w3.org/TR/xlink">
+          <dcterms:source>2.pdf</dcterms:source>
+          <dc:title>President Jean Mayer speaking at commencement, 1988</dc:title>
+          <dc:description>5x7</dc:description>
+          <dc:source>UA136</dc:source>
+          <dc:coverage>Medford;7014023;42.417;-71.100</dc:coverage>
+          <dc:temporal>1987</dc:temporal>
+          <dc:creator>Unknown</dc:creator>
+          <dc:publisher>Digital Collections and Archives, Tufts University</dc:publisher
+          <dc:rights>http://dca.tufts.edu/ua/access/rights.html</dc:rights>
+          <dc:identifier>http://hdl.handle.net/10427/448</dc:identifier>
+          <dcterms:isPartOf>UA136</dcterms:isPartOf>
+          <dcterms:created>07/02/2002</dcterms:created>
+          <dcterms:available>02/26/2004</dcterms:available>
+          <dc:type>image</dc:type>
+          <dc:format>image/tiff</dc:format>
+          <dcatech:resolution>600</dcatech:resolution>
+          <dcatech:bitDepartment>8</dcatech:bitDepartment>
+          <dcatech:colorSpace>grayscale</dcatech:colorSpace>
+          <dcadesc:persname>Mayer, Jean</dcadesc:persname>
+          <dcadesc:corpname>Office of the President</dcadesc:corpname>
+          <dcadesc:subject>People</dcadesc:subject>
+          <dcadesc:subject>Commencement</dcadesc:subject>
+          <dcadesc:subject>Events</dcadesc:subject>
+          <dcadesc:subject>College presidents</dcadesc:subject>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <header status="deleted">
+        <identifier>oai:arXiv.org:hep-th/9901007</identifier>
+        <datestamp>1999-12-21</datestamp>
+      </header>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/lib/tufts/import_record_spec.rb
+++ b/spec/lib/tufts/import_record_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::ImportRecord do
+  subject(:record) { described_class.new(file: filename) }
+  let(:filename)   { '1.pdf' }
+
+  describe '#file' do
+    it 'has a filename' do
+      expect(record.file).to eq filename
+    end
+
+    it 'sets the filename' do
+      new_filename = 'NEW_FILENAME.pdf'
+
+      expect { record.file = new_filename }
+        .to change { record.file }
+        .to new_filename
+    end
+  end
+end

--- a/spec/lib/tufts/mira_xml_importer_spec.rb
+++ b/spec/lib/tufts/mira_xml_importer_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::MiraXmlImporter do
+  subject(:importer) { described_class.new(file: file) }
+  let(:file)         { File.open(file_fixture('mira_xml.xml')) }
+
+  it { is_expected.to have_attributes file: file }
+
+  describe '#records' do
+    it 'yields correct number of records' do
+      # yield once for each record in the sample file, excluding deleted records
+      expect { |b| importer.records(&b) }
+        .to yield_successive_args(an_instance_of(Tufts::ImportRecord),
+                                  an_instance_of(Tufts::ImportRecord))
+    end
+
+    it 'returns the records' do
+      expect(importer.records)
+        .to contain_exactly(an_instance_of(Tufts::ImportRecord),
+                            an_instance_of(Tufts::ImportRecord))
+    end
+
+    it 'populates records with files' do
+      expect(importer.records.map(&:file)).to contain_exactly('1.pdf', '2.pdf')
+    end
+
+    context 'with empty file' do
+      let(:file) { StringIO.new('') }
+
+      it 'yields nothing' do
+        expect { |b| importer.records(&b) }.not_to yield_control
+      end
+
+      it 'returns an empty enumerable' do
+        expect(importer.records.to_a).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow parsing XML to an intermediary `ImportRecord` format.