### PR TITLE
Remove unused TemplateUpdatesController#show action and routes

### DIFF
--- a/app/controllers/hyrax/template_updates_controller.rb
+++ b/app/controllers/hyrax/template_updates_controller.rb
@@ -16,10 +16,6 @@ module Hyrax
       @update = TemplateUpdate.new(ids: ids)
     end
 
-    def show
-      @update = TemplateUpdate.find(param[:id])
-    end
-
     private
 
       def template_update_params

--- a/app/views/hyrax/template_updates/show.html.erb
+++ b/app/views/hyrax/template_updates/show.html.erb
@@ -1,1 +1,0 @@
-update created!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,8 @@ Rails.application.routes.draw do
             controller: 'hyrax/templates',
             only:       [:index, :destroy, :edit, :update, :new]
   resources :template_updates,
-            controller: 'hyrax/template_updates'
+            controller: 'hyrax/template_updates',
+            only:       [:new, :create]
 
   # Routes for managing drafts
   post '/draft/save_draft/:id', to: 'tufts/draft#save_draft'


### PR DESCRIPTION
TemplateUpdates are shown as `Batchable` through their corresponding batches. The placeholder route is unused and is simply removed.