### PR TITLE
mira_publication_workflow updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ RSpec/ExampleLength:
     - 'spec/lib/import_export/deposit_type_importer_spec.rb'
     - 'spec/lib/import_export/deposit_type_exporter_spec.rb'
     - 'spec/lib/deposit_types_controller_spec.rb'
+    - 'spec/lib/tufts/workflow_setup_spec.rb'
     - 'spec/controllers/contribute_controller_spec.rb'
     - 'spec/controllers/deposit_types_controller_spec.rb'
 RSpec/NestedGroups:
@@ -31,6 +32,7 @@ RSpec/MultipleExpectations:
   Exclude:
   - 'spec/controllers/contribute_controller_spec.rb'
   - 'spec/features/publication_workflow_spec.rb'
+  - 'spec/lib/tufts/workflow_setup_spec.rb'
 Style/FileName:
   Exclude:
     - '**/Capfile'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ rvm:
   - 2.3.4
 before_script:
   - bundle exec sidekiq -d -l /tmp/sidekiq.log
-  - bundle exec rails db:setup
+  - bundle exec rake db:create
 script:
-  - bundle exec rake
+  - bundle exec rubocop
+  - xvfb-run -a bundle exec rake travis
 addons:
-  apt:  
+  apt:
     packages:
      - imagemagick
 services:
   - redis-server
-

--- a/config/workflows/mira_publication_workflow.json
+++ b/config/workflows/mira_publication_workflow.json
@@ -9,41 +9,40 @@
                 {
                     "name": "deposit",
                     "from_states": [],
-                    "transition_to": "pending_review",
+                    "transition_to": "unpublished",
                     "notifications": [
                         {
                             "notification_type": "email",
                             "name": "Hyrax::Workflow::PendingReviewNotification",
-                            "to": ["approving"]
+                            "to": ["publishing"]
                         }
                     ],
                     "methods": [
                         "Hyrax::Workflow::DeactivateObject"
                     ]
                 }, {
-                    "name": "request_changes",
-                    "from_states": [{"names": ["published", "pending_review"], "roles": ["approving"]}],
-                    "transition_to": "changes_required",
+                    "name": "unpublish",
+                    "from_states": [{"names": ["published"], "roles": ["publishing"]}],
+                    "transition_to": "unpublished",
                     "notifications": [
                         {
                             "notification_type": "email",
                             "name": "Hyrax::Workflow::ChangesRequiredNotification",
-                            "to": ["approving"]
+                            "to": ["publishing"]
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::DeactivateObject",
-                        "Hyrax::Workflow::GrantEditToDepositor"
+                        "Hyrax::Workflow::DeactivateObject"
                     ]
                 }, {
-                    "name": "approve",
-                    "from_states": [{"names": ["pending_review"], "roles": ["approving"]}],
+                    "name": "publish",
+                    "from_states": [{"names": ["unpublished"], "roles": ["publishing"]}],
                     "transition_to": "published",
                     "notifications": [
                         {
                             "notification_type": "email",
                             "name": "Hyrax::Workflow::DepositedNotification",
-                            "to": ["approving"]
+                            "to": ["publishing"]
                         }
                     ],
                     "methods": [
@@ -52,21 +51,9 @@
                         "Hyrax::Workflow::ActivateObject"
                     ]
                 }, {
-                    "name": "request_review",
-                    "from_states": [{"names": ["changes_required"], "roles": ["depositing"]}],
-                    "transition_to": "pending_review",
-                    "notifications": [
-                        {
-                            "notification_type": "email",
-                            "name": "Hyrax::Workflow::PendingReviewNotification",
-                            "to": ["approving"]
-                        }
-                    ]
-                }, {
                     "name": "comment_only",
                     "from_states": [
-                        { "names": ["pending_review", "published"], "roles": ["approving"] },
-                        { "names": ["changes_required"], "roles": ["depositing"] }
+                        { "names": ["unpublished", "published"], "roles": ["publishing"] }
                     ]
                 }
             ]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,15 @@ require 'import_export/deposit_type_importer'
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+puts
+puts "== Setting mira publication workflow =="
+puts
+require 'tufts/workflow_setup'
+# Our database has just been reset, so you MUST destroy and
+# re-create all AdminSets too
+w = Tufts::WorkflowSetup.new
+w.setup
+
 # DepositType.create!(display_name: 'Initial Seed', deposit_view: 'generic_deposit', license_name: 'N/A')
 importer = DepositTypeImporter.new('./config/deposit_type_seed.csv')
 importer.import_from_csv

--- a/lib/tasks/travis.rake
+++ b/lib/tasks/travis.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+unless Rails.env.production?
+  APP_ROOT = File.dirname(__FILE__)
+  require "solr_wrapper"
+  require "fcrepo_wrapper"
+  require 'solr_wrapper/rake_task'
+
+  desc "Run Continuous Integration"
+  task :travis do
+    ENV["environment"] = "test"
+    solr_params = {
+      port: 8985,
+      verbose: true,
+      managed: true
+    }
+    fcrepo_params = {
+      port: 8986,
+      verbose: true,
+      managed: true,
+      enable_jms: false,
+      fcrepo_home_dir: 'tmp/fcrepo4-test-data'
+    }
+    SolrWrapper.wrap(solr_params) do |solr|
+      solr.with_collection(
+        name: "hydra-test",
+        persist: false,
+        dir: Rails.root.join("solr", "config")
+      ) do
+        FcrepoWrapper.wrap(fcrepo_params) do
+          Rake::Task["spec"].invoke
+        end
+      end
+    end
+  end
+end

--- a/lib/tufts/workflow_setup.rb
+++ b/lib/tufts/workflow_setup.rb
@@ -1,16 +1,23 @@
 module Tufts
   class WorkflowSetup
+    MIRA_WORKFLOW_NAME = 'mira_publication_workflow'.freeze
+    def setup
+      set_default_workflow
+      grant_publish_role_to_admins
+    end
+
     def set_default_workflow
       # This is the non-destructive way to ensure the default admin set and its
       # associated PermissionTemplate exist, even if the database has been reset
       # Cribbed from hyrax/lib/tasks/default_admin_set.rake
-      id = AdminSet.find_or_create_default_admin_set_id
-      Hyrax::PermissionTemplate.create(admin_set_id: AdminSet::DEFAULT_ID)
-      load_workflows
-      permission_template = Hyrax::PermissionTemplate.find_by(admin_set_id: id)
-      mira_publication_workflow = permission_template.available_workflows.where(name: "mira_publication_workflow").first
+      AdminSet.find_or_create_default_admin_set_id
+      Hyrax::PermissionTemplate.create!(admin_set_id: AdminSet::DEFAULT_ID) unless Hyrax::PermissionTemplate.find_by(admin_set_id: AdminSet::DEFAULT_ID)
+      permission_template = Hyrax::PermissionTemplate.find_by(admin_set_id: AdminSet::DEFAULT_ID)
+      load_workflows unless permission_template.available_workflows.where(name: Tufts::WorkflowSetup::MIRA_WORKFLOW_NAME).first
+      mira_publication_workflow = permission_template.available_workflows.where(name: Tufts::WorkflowSetup::MIRA_WORKFLOW_NAME).first
+      # If the workflow is already active, calling activate! will *deactive* it
+      return if permission_template.active_workflow == mira_publication_workflow
       Sipity::Workflow.activate!(permission_template: permission_template, workflow_id: mira_publication_workflow.id)
-      grant_approval_to_admins(mira_publication_workflow)
     end
 
     # Load the workflows from config/workflows
@@ -22,14 +29,15 @@ module Tufts
       abort("Failed to process all workflows:\n  #{errors.join('\n  ')}") unless errors.empty?
     end
 
-    def grant_approval_to_admins(workflow)
+    def grant_publish_role_to_admins
+      workflow = AdminSet.find(AdminSet::DEFAULT_ID).active_workflow
       workflow.permission_template.access_grants.create(
         agent_type: 'group',
         agent_id: 'admin',
         access: Hyrax::PermissionTemplateAccess::MANAGE
       )
-      approving_role = Sipity::Role['Approving']
-      workflow.update_responsibilities(role: approving_role, agents: Hyrax::Group.new('admin'))
+      publishing_role = Sipity::Role['publishing']
+      workflow.update_responsibilities(role: publishing_role, agents: Hyrax::Group.new('admin'))
     end
   end
 end

--- a/spec/features/publication_workflow_spec.rb
+++ b/spec/features/publication_workflow_spec.rb
@@ -7,12 +7,12 @@ include Warden::Test::Helpers
 
 RSpec.feature 'deposit and publication' do
   let(:depositing_user) { FactoryGirl.create(:user) }
-  let(:approving_user) { FactoryGirl.create(:admin) }
+  let(:publishing_user) { FactoryGirl.create(:admin) }
   let(:work) { FactoryGirl.create(:image) }
   context 'a logged in user' do
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-      Tufts::WorkflowSetup.new.set_default_workflow
+      Tufts::WorkflowSetup.new.setup
       current_ability = ::Ability.new(depositing_user)
       attributes = {}
       env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
@@ -23,7 +23,7 @@ RSpec.feature 'deposit and publication' do
       expect(work.active_workflow.name).to eq "mira_publication_workflow"
 
       # Upon submission, works are in the "pending review" workflow state
-      expect(work.to_sipity_entity.reload.workflow_state_name).to eq "pending_review"
+      expect(work.to_sipity_entity.reload.workflow_state_name).to eq "unpublished"
 
       # Upon submission, works are not visible to the public
       visit("/concern/images/#{work.id}")
@@ -42,32 +42,30 @@ RSpec.feature 'deposit and publication' do
       visit("/notifications?locale=en")
       expect(page).to have_content "Deposit needs review #{work.title.first} (#{work.id}) was deposited by #{depositing_user.email} and is awaiting approval"
 
-      # Check notifications for approving user
+      # Check notifications for publishing user
       logout
-      login_as approving_user
+      login_as publishing_user
       visit("/notifications?locale=en")
       # expect(page).to have_content "#{work.title.first} (#{work.id}) was deposited by #{depositing_user.display_name} and is awaiting approval."
       # expect(page).to have_content "Deposit needs review #{work.title.first} (#{work.id}) was deposited by #{depositing_user.email} and is awaiting approval"
 
-      # Check workflow permissions for approving user
+      # Check workflow permissions for publishing user
       available_workflow_actions = Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(
-        user: approving_user,
+        user: publishing_user,
         entity: work.to_sipity_entity
       ).pluck(:name)
       expect(available_workflow_actions).to contain_exactly(
-        # "mark_reviewed",
-        "approve",
-        "request_changes",
+        "publish",
         "comment_only"
       )
 
       # The admin user approves the work, changing its status to "published"
-      subject = Hyrax::WorkflowActionInfo.new(work, approving_user)
-      sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
+      subject = Hyrax::WorkflowActionInfo.new(work, publishing_user)
+      sipity_workflow_action = PowerConverter.convert_to_sipity_action("publish", scope: subject.entity.workflow) { nil }
       Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Approved in publication_workflow_spec.rb")
       expect(work.to_sipity_entity.reload.workflow_state_name).to eq "published"
 
-      #     # Check notifications for approving user
+      #     # Check notifications for publishing user
       #     visit("/notifications?locale=en")
       #     expect(page).to have_content "#{etd.title.first} (#{etd.id}) has been approved by"
 
@@ -75,13 +73,23 @@ RSpec.feature 'deposit and publication' do
       logout
       login_as depositing_user
       visit("/notifications?locale=en")
-      expect(page).to have_content "#{work.title.first} (#{work.id}) was approved by #{approving_user.email}. Approved in publication_workflow_spec.rb"
+      expect(page).to have_content "#{work.title.first} (#{work.id}) was approved by #{publishing_user.email}. Approved in publication_workflow_spec.rb"
 
       # After publication, works are visible to the public
       # Visit the ETD as a public user. It should be visible.
       logout
       visit("/concern/images/#{work.id}")
       expect(page).not_to have_content "The work is not currently available"
+
+      # After publication, an admin can unpublish a work.
+      subject = Hyrax::WorkflowActionInfo.new(work, publishing_user)
+      sipity_workflow_action = PowerConverter.convert_to_sipity_action("unpublish", scope: subject.entity.workflow) { nil }
+      Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Unpublished in publication_workflow_spec.rb")
+      expect(work.to_sipity_entity.reload.workflow_state_name).to eq "unpublished"
+
+      # After being unpublished, the work will no longer be visible to the public.
+      visit("/concern/images/#{work.id}")
+      expect(page).to have_content "The work is not currently available"
     end
   end
 end

--- a/spec/lib/tufts/workflow_setup_spec.rb
+++ b/spec/lib/tufts/workflow_setup_spec.rb
@@ -3,9 +3,33 @@ require 'tufts/workflow_setup'
 
 RSpec.describe Tufts::WorkflowSetup do
   let(:w) { described_class.new }
-  it "sets the default admin set to use the mira workflow" do
+  let(:admin_user) { FactoryGirl.create(:admin) }
+
+  it "sets the default admin set to use the mira workflow and runs idempotently" do
     w.set_default_workflow
-    a = ::AdminSet.find("admin_set/default")
-    expect(a.active_workflow.name).to eq "mira_publication_workflow"
+    a = AdminSet.find(AdminSet::DEFAULT_ID)
+    expect(a.active_workflow.name).to eq Tufts::WorkflowSetup::MIRA_WORKFLOW_NAME
+    w.set_default_workflow
+    b = AdminSet.find(AdminSet::DEFAULT_ID)
+    b.reload
+    # it has not created a new workflow with the same name
+    expect(b.active_workflow).to eq a.active_workflow
+  end
+  it "grants the workflow approval role to all members of the hyrax admin group" do
+    w.setup
+    a = AdminSet.find(AdminSet::DEFAULT_ID)
+    workflow = a.active_workflow
+    expect(a.active_workflow.name).to eq Tufts::WorkflowSetup::MIRA_WORKFLOW_NAME
+
+    # Check workflow permissions for admin user
+    roles = Hyrax::Workflow::PermissionQuery.scope_processing_workflow_roles_for_user_and_workflow(
+      user: admin_user,
+      workflow: workflow
+    )
+    role_names = roles.map { |r| Sipity::Role.find(r.role_id).name }
+
+    expect(role_names).to contain_exactly(
+      "publishing"
+    )
   end
 end


### PR DESCRIPTION
Loading mira workflow should be idempotent
Change workflow role to publishing, and workflow action to publish
Change workflow state of pending_review to unpublished
Change workflow state of pending_review to unpublished
Add unpublish workflow step
Set mira publication workflow for default admin set in seeds.rb

Fixes #226 
Fixes #223 
Fixes #225 
Fixes #217 