### PR TITLE
Basic XML Import with Batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dump.rdb
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+/public/uploads/*
 
 # Ignore Byebug command history file.
 .byebug_history

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,8 +31,8 @@ RSpec/AnyInstance:
 RSpec/MultipleExpectations:
   Exclude:
   - 'spec/controllers/contribute_controller_spec.rb'
-  - 'spec/features/publication_workflow_spec.rb'
   - 'spec/lib/tufts/workflow_setup_spec.rb'
+  - 'spec/features/**/*'
 Style/FileName:
   Exclude:
     - '**/Capfile'

--- a/app/controllers/hyrax/xml_imports_controller.rb
+++ b/app/controllers/hyrax/xml_imports_controller.rb
@@ -1,0 +1,55 @@
+module Hyrax
+  class XmlImportsController < ApplicationController
+    def new
+      @import = XmlImport.new
+    end
+
+    def create
+      @import       = XmlImport.new(import_params)
+      @import.batch = Batch.new(batchable: @import,
+                                creator:   current_user,
+                                ids:       [])
+      if @import.save
+        redirect_to main_app.xml_import_path(@import)
+      else
+        messages    = @import.errors.messages[:base].join("\n")
+        flash.alert = " Errors were found in #{@import.metadata_file.filename}:" \
+                      "\n#{messages}"
+        redirect_to main_app.new_xml_import_path
+      end
+    end
+
+    def edit
+      @import = XmlImportPresenter.new(XmlImport.find(params[:id]))
+    end
+
+    def show
+      @import = XmlImportPresenter.new(XmlImport.find(params[:id]))
+    end
+
+    def update
+      @import = XmlImport.find(params[:id])
+
+      new_files = params.fetch(:uploaded_files, [])
+
+      if new_files.empty?
+        flash.alert = 'No files added. Please upload files before submitting.'
+        redirect_to main_app.edit_xml_import_path(@import)
+      else
+        @import.uploaded_file_ids.concat(new_files)
+        @import.save
+
+        redirect_to main_app.xml_import_path(@import),
+                    notice: "Added files: #{new_files}"
+      end
+    end
+
+    private
+
+      def import_params
+        params
+          .require(:xml_import)
+          .permit(:metadata_file)
+      end
+  end
+end

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -1,0 +1,5 @@
+##
+# A job to process imported records and files
+class ImportJob < BatchableJob
+  def perform(import_record, file); end # no-op
+end

--- a/app/models/xml_import.rb
+++ b/app/models/xml_import.rb
@@ -1,0 +1,68 @@
+class XmlImport < ApplicationRecord
+  ##
+  # @!attribute metadata_file [rw]
+  #   @return [Tufts::MetadataFileUploader]
+  #   @see CarrierWave::Uploader::Base
+  #   @note Set with `import.metadata_file = File.open('path/to/file'`)
+  mount_uploader :metadata_file, Tufts::MetadataFileUploader
+
+  validates :metadata_file, presence: true
+  validate :file_is_correctly_formatted
+
+  ##
+  # @!attribute batch [rw]
+  #   @return [Batch]
+  has_one :batch, as: :batchable
+
+  ##
+  # @!method records
+  #   @see Tufts::Importer#records
+  delegate :records, to: :parser
+
+  ##
+  # @!attribute uploaded_file_ids [rw]
+  #   @return [Array<String>]
+  serialize :uploaded_file_ids, Array
+
+  TYPE_STRING = 'XML Import'.freeze
+
+  ##
+  # @return [String]
+  def batch_type
+    TYPE_STRING
+  end
+
+  ##
+  # @note Unlike other `Batchable`s, `XmlImport` feeds the batch a
+  #   `Hyrax::UploadedFile#id`, rather than an object id to identify jobs in the
+  #   batch. The object id is not yet minted at the time of enqueuing.
+  #
+  # @return [Hash<String, String> a hash associating file ids with job ids
+  def enqueue!
+    uploaded_files.each_with_object({}) do |file, hsh|
+      hsh[file.id.to_s] = ImportJob.perform_later(self, file).job_id
+    end
+  end
+
+  ##
+  # @return [Tufts::Importer]
+  def parser
+    Tufts::MiraXmlImporter.new(file: metadata_file.file)
+  end
+
+  ##
+  # @return [Array<Hyrax::UploadedFile>]
+  def uploaded_files
+    return [] if uploaded_file_ids.empty?
+
+    Array.wrap(Hyrax::UploadedFile.find(*uploaded_file_ids))
+  end
+
+  private
+
+    def file_is_correctly_formatted
+      return unless metadata_file_changed?
+
+      parser.validate!.each { |err| errors.add(:base, err.message) }
+    end
+end

--- a/app/presenters/xml_import_presenter.rb
+++ b/app/presenters/xml_import_presenter.rb
@@ -1,0 +1,53 @@
+##
+# A presenter for the XmlImport model, behaves maximally like a BatchPresenter
+# for the associated batch.
+class XmlImportPresenter
+  ##
+  # @!attribute xml_import
+  #   @return [XmlImport]
+  attr_accessor :xml_import
+
+  ##
+  # @!method batch
+  #   @return [Batch]
+  delegate :batch, to: :xml_import
+
+  ##
+  # @!method object
+  #   @see #batch
+  alias object batch
+
+  ##
+  # @param xml_import [XmlImport]
+  def initialize(xml_import)
+    @xml_import = xml_import
+  end
+
+  ##
+  # @return [BatchPresenter]
+  def batch_presenter
+    @batch_presenter = BatchPresenter.for(object: batch)
+  end
+
+  delegate :creator, :created_at, :id, :items, :review_status, :status,
+           to: :batch_presenter
+
+  ##
+  # @return [Integer]
+  def count
+    xml_import.records.to_a.size
+  end
+
+  ##
+  # @return [Enumerable<String>]
+  def missing_files
+    xml_import.records.map(&:file).to_a -
+      xml_import.uploaded_files.map { |file| File.basename(file.file.path) }
+  end
+
+  ##
+  # @return [String]
+  def type
+    xml_import.batch_type
+  end
+end

--- a/app/views/hyrax/xml_imports/edit.html.erb
+++ b/app/views/hyrax/xml_imports/edit.html.erb
@@ -1,0 +1,25 @@
+<h1>Upload files</h1>
+
+<% if missing = @import.missing_files %>
+  <div class="well">
+    The following files in this import still need to be uploaded:<br/>
+    <ul class="missing_files">
+      <% missing.sort_by { |a| [a.upcase, a] }.each do |file| %>
+        <li><%= file %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= link_to "Import Summary", [main_app, @import.xml_import], class: 'btn btn-primary', id: 'next_button' %>
+
+<%= form_for [main_app, @import.xml_import], html: { id: 'fileupload' } do |f| %>
+  <%= render 'hyrax/base/form_files' %>
+
+  <div id="file-submit">
+    <%= f.button type: 'submit', id: 'start_upload', class: 'btn btn-primary start' do %>
+      <i class="icon-upload icon-white"></i>
+      Add Files to Batch
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/hyrax/xml_imports/new.html.erb
+++ b/app/views/hyrax/xml_imports/new.html.erb
@@ -1,0 +1,6 @@
+<h1> Archival Content Batch Import </h1>
+
+<%= form_for [main_app, @import] do |f| %>
+  <%= f.file_field :metadata_file, id: 'metadata_file' %>
+  <%= f.submit 'Next' %>
+<% end %>

--- a/app/views/hyrax/xml_imports/show.html.erb
+++ b/app/views/hyrax/xml_imports/show.html.erb
@@ -1,0 +1,22 @@
+<div class="col-sm-12">
+  <h1>Batch Status</h1>
+
+  <%= link_to "All batches", main_app.batches_path %>
+
+  <% missing = @import.missing_files %>
+  <% unless missing.empty? %>
+    <div class="alert alert-warning">
+      <strong>Warning:</strong> Metadata exists for the following files that have not been updated:<br/>
+      <ul>
+        <% missing.each do |file| %>
+          <li class="missing-file"><%= file %></li>
+        <% end %>
+      </ul>
+      <%= link_to "add additional files to this batch", main_app.edit_xml_import_path(@import.xml_import) %>
+    </div>
+  <% end %>
+
+  <%= render "hyrax/batches/batch_info",  batch: @import %>
+  <!-- %= render "batches/batch_actions", batch: @batch % -->
+  <%= render "hyrax/batches/batch_items", batch: @import %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,12 +53,16 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :xml_imports,
+            controller: 'hyrax/xml_imports',
+            only:       [:show, :create, :new, :edit, :update]
+
   resources :templates,
             controller: 'hyrax/templates',
             only:       [:index, :destroy, :edit, :update, :new]
   resources :template_updates,
             controller: 'hyrax/template_updates',
-            only:       [:new, :create]
+            only:       [:index, :new, :create]
 
   # Routes for managing drafts
   post '/draft/save_draft/:id', to: 'tufts/draft#save_draft'

--- a/db/migrate/20170907215935_create_xml_imports.rb
+++ b/db/migrate/20170907215935_create_xml_imports.rb
@@ -1,0 +1,9 @@
+class CreateXmlImports < ActiveRecord::Migration[5.0]
+  def change
+    create_table :xml_imports do |t|
+      t.string :metadata_file
+      t.text   :uploaded_file_ids
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -558,6 +558,13 @@ ActiveRecord::Schema.define(version: 20170918235305) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id", using: :btree
   end
 
+  create_table "xml_imports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "metadata_file"
+    t.text     "uploaded_file_ids", limit: 65535
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+  end
+
   add_foreign_key "curation_concerns_operations", "users"
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"

--- a/lib/tufts/importer.rb
+++ b/lib/tufts/importer.rb
@@ -1,0 +1,149 @@
+module Tufts
+  ##
+  # A generic (empty) importer.
+  #
+  # @example defining and registering a new importer
+  #   class MyImporter < Importer
+  #     def self.match?(**opts)
+  #
+  #     end
+  #   end
+  #
+  # @example using the factory and accessing methods
+  #   importer = Tufts::Importer.for(file: 'moomin.xml')
+  #   importer.records
+  #
+  class Importer
+    ##
+    # @!attribute file [rw]
+    #   @return [IO]
+    attr_accessor :file
+
+    @subclasses = [] # @private
+
+    class << self
+      ##
+      # @return [Importer]
+      def for(file:)
+        klass = @subclasses.find { |k| k.match?(filename: file) } || self
+
+        klass.new(file: file)
+      end
+
+      ##
+      # @param   opts [Hash]
+      # @options filename [String]
+      #
+      # @return [Boolean]
+      def match?(**_opts)
+        false
+      end
+
+      private
+
+      ##
+      # @private Register new class when inherited
+      def inherited(other)
+        @subclasses << other
+        super
+      end
+    end
+
+    ##
+    # @param [IO] file
+    def initialize(file:)
+      raise(ArgumentError, "file must be an IO, got a #{file.class}") unless
+        file.respond_to? :read
+
+      @file = file
+    end
+
+    ##
+    # @return [Array<Error>]
+    def errors
+      @errors ||= []
+    end
+
+    ##
+    # @yield Gives each record to the block
+    # @yieldparam [ImportRecord]
+    #
+    # @return [Enumerable<ImportRecord>]
+    def records
+      []
+    end
+
+    ##
+    # Validates the file. Returns false and populates errors when invalid.
+    #
+    # At least one error must be added for an invalid file.
+    #
+    # @return [Enumerable<Error>]
+    # @see #errors
+    def validate!
+      validate_filenames
+      errors
+    end
+
+    ##
+    # A generic error class for errors in import files.
+    #
+    # @example
+    #   err = Importer::Error.new(27, type: :serious)
+    #
+    #   err.message
+    #   # => "An error occured parsing the file at line: 27; (type: serious)"
+    #
+    class Error < StandardError
+      ##
+      # @param line    [Integer]
+      # @param details [Hash<#to_s, #to_s>]
+      def initialize(line = nil, details = {})
+        @line    = line
+        @details = details
+
+        super(message)
+      end
+
+      ##
+      # @private
+      # @return [String]
+      def present_details
+        return '' if @details.empty?
+        '(' + @details.map { |k, v| "#{k}: #{v}" }.join(', ') + ')'
+      end
+
+      ##
+      # @private
+      # @return [String]
+      def present_line
+        (@line || 'Unknown Line').to_s
+      end
+
+      ##
+      # @return [String]
+      def message
+        "An error occured parsing the file at line: #{present_line}; #{present_details}"
+      end
+    end
+
+    class MissingFileError < Error
+      ##
+      # @return [String]
+      def message
+        "A file was missing for the record at line: #{present_line}; #{present_details}"
+      end
+    end
+
+    private
+
+      ##
+      # @private
+      def validate_filenames
+        records.each do |record|
+          errors << MissingFileError.new if
+            record.file.nil? || record.file.empty?
+        end
+      end
+  end
+end

--- a/lib/tufts/metadata_file_uploader.rb
+++ b/lib/tufts/metadata_file_uploader.rb
@@ -1,0 +1,7 @@
+require 'carrierwave'
+
+module Tufts
+  class MetadataFileUploader < CarrierWave::Uploader::Base
+    storage :file
+  end
+end

--- a/lib/tufts/mira_xml_importer.rb
+++ b/lib/tufts/mira_xml_importer.rb
@@ -11,19 +11,17 @@ module Tufts
   #
   # @see http://www.openarchives.org/OAI/openarchivesprotocol.html#ListRecords
   #   for the OAI ListRecords format.
-  class MiraXmlImporter
+  class MiraXmlImporter < Importer
     ##
-    # @!ottribute file [rw]
-    #   @return [IO]
-    attr_accessor :file
-
-    ##
-    # @param [IO] file
-    def initialize(file:)
-      raise(ArgumentError, "file must be an IO, got a #{file.class}") unless
-        file.respond_to? :read
-
-      @file = file
+    # @note This class matches all files. If new import formats are added, the
+    #   logic of this method should change.
+    #
+    # @param   opts [Hash]
+    # @options filename [String]
+    #
+    # @return [Boolean]
+    def self.match?(**_opts)
+      true
     end
 
     ##
@@ -49,8 +47,8 @@ module Tufts
     private
 
       def doc
-        file.rewind
-        Nokogiri::XML(file)
+        file.rewind if file.respond_to? :rewind
+        Nokogiri::XML(file.read)
       end
 
       def metadata_nodes

--- a/spec/controllers/hyrax/xml_imports_controller_spec.rb
+++ b/spec/controllers/hyrax/xml_imports_controller_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/NestedGroups
+RSpec.describe Hyrax::XmlImportsController, type: :controller do
+  let(:import) { FactoryGirl.create(:xml_import) }
+
+  context 'as admin' do
+    include_context 'as admin'
+
+    describe 'GET #new' do
+      it 'renders the form' do
+        get :new
+        expect(response).to render_template :new
+      end
+    end
+
+    describe 'POST #create' do
+      let(:file_upload) { fixture_file_upload('files/mira_xml.xml') }
+
+      it 'uploads the file' do
+        post :create, params: { xml_import: { metadata_file: file_upload } }
+        expect(assigns(:import).metadata_file.filename).to eq 'mira_xml.xml'
+      end
+
+      it 'creates a batch' do
+        post :create, params: { xml_import: { metadata_file: file_upload } }
+        expect(assigns(:import).batch.creator).to eq user
+      end
+
+      context 'when the file has an error' do
+        let(:file_upload) { fixture_file_upload('files/mira_xml_invalid.xml') }
+
+        it 'flashes an alert' do
+          post :create, params: { xml_import: { metadata_file: file_upload } }
+          expect(flash[:alert]).to be_present
+        end
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'assigns the import' do
+      get :edit, params: { id: import.id }
+
+      expect(assigns(:import).xml_import).to eq import
+    end
+  end
+
+  describe 'GET #show' do
+    it 'renders the correct import details' do
+      get :show, params: { id: import.id }
+
+      expect(assigns(:import).xml_import).to eq import
+    end
+
+    it 'renders the batch' do
+      get :show, params: { id: import.id }
+
+      expect(assigns(:import).batch_presenter.object).to eq import.batch
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:file_ids) { ['38', '91', '1234'] }
+    let(:params)   { { id: import.id, uploaded_files: file_ids } }
+
+    it 'adds uploaded files to the import' do
+      import.uploaded_file_ids = ['1']
+
+      expect { patch :update, params: params }
+        .to change { import.reload.uploaded_file_ids }
+    end
+  end
+end

--- a/spec/factories/hyrax_uploaded_files.rb
+++ b/spec/factories/hyrax_uploaded_files.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :hyrax_uploaded_file, class: Hyrax::UploadedFile do
+    user
+    file File.open('spec/fixtures/files/pdf-sample.pdf')
+  end
+end

--- a/spec/factories/xml_imports.rb
+++ b/spec/factories/xml_imports.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :xml_import do
+    metadata_file File.open('spec/fixtures/files/mira_xml.xml')
+    batch
+  end
+end

--- a/spec/features/xml_import_spec.rb
+++ b/spec/features/xml_import_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Create an XML Import', :clean, js: true do
+  let(:document) { file_fixture('pdf-sample.pdf') }
+  let(:file)     { file_fixture('mira_xml.xml') }
+  let(:user)     { create(:admin) }
+
+  before { login_as user }
+
+  scenario 'import records through a form upload' do
+    visit '/xml_imports/new'
+
+    attach_file 'metadata_file', file
+    click_button 'Next'
+
+    within(:css, 'div.alert-warning') do
+      expect(page).to have_css('li.missing-file', count: 2)
+      expect(page).to have_content 'pdf-sample.pdf'
+      expect(page).to have_content '2.pdf'
+    end
+
+    click_link 'add additional files to this batch'
+
+    click_button 'Add Files to Batch'
+
+    expect(page).to have_content 'pdf-sample.pdf'
+    expect(page).to have_content '2.pdf'
+  end
+
+  scenario 'importing an invalid file' do
+    visit '/xml_imports/new'
+
+    attach_file 'metadata_file', file_fixture('mira_xml_invalid.xml')
+
+    click_button 'Next'
+
+    expect(page).to have_content 'Error'
+  end
+end

--- a/spec/fixtures/files/mira_xml.xml
+++ b/spec/fixtures/files/mira_xml.xml
@@ -24,7 +24,7 @@
                      xmlns:dcterms="http://purl.org/dc/terms/"
                      xmlns:admin="http://nils.lib.tufts.edu/dcaadmin/"
                      xmlns:xlink="http://www.w3.org/TR/xlink">
-          <dcterms:source>1.pdf</dcterms:source>
+          <dcterms:source>pdf-sample.pdf</dcterms:source>
           <dc:title>President Jean Mayer speakin0g at commencement, 1987</dc:title>
           <dc:description>5x7</dc:description>
           <dc:source>UA136</dc:source>

--- a/spec/fixtures/files/mira_xml_invalid.xml
+++ b/spec/fixtures/files/mira_xml_invalid.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2017-09-01T19:20:30Z</responseDate>
+  <request verb="ListRecords" from="1998-01-15"
+           set="any:set"
+           metadataPrefix="mira_import">
+  http://example.com/OAI</request>
+  <ListRecords>
+    <record>
+      <header>
+        <identifier>oai:arXiv.org:hep-th/9901001</identifier>
+        <datestamp>1999-12-25</datestamp>
+        <setSpec>any:set</setSpec>
+        <setSpec>another_set</setSpec>
+      </header>
+      <metadata>
+        <mira_import xmlns:dc="http://purl.org/dc/elements/1.1/"
+                     xmlns:dca_dc="http://nils.lib.tufts.edu/dca_dc/"
+                     xmlns:dcadesc="http://nils.lib.tufts.edu/dcadesc/"
+                     xmlns:dcatech="http://nils.lib.tufts.edu/dcatech/"
+                     xmlns:dcterms="http://purl.org/dc/terms/"
+                     xmlns:admin="http://nils.lib.tufts.edu/dcaadmin/"
+                     xmlns:xlink="http://www.w3.org/TR/xlink">
+          <dc:title>No File</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/jobs/import_job_spec.rb
+++ b/spec/jobs/import_job_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ImportJob, type: :job do
+  subject(:job) { described_class }
+
+  describe '#perform_later' do
+    xit 'enqueues the job' do
+      ActiveJob::Base.queue_adapter = :test
+    end
+  end
+end

--- a/spec/lib/tufts/importer_spec.rb
+++ b/spec/lib/tufts/importer_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::Importer do
+  let(:file) { StringIO.new('blah') }
+
+  it_behaves_like 'an importer'
+
+  describe '.for' do
+    it 'gives an importer instance' do
+      expect(described_class.for(file: file)).to be_a described_class
+    end
+  end
+
+  describe described_class::Error do
+    subject(:error) { described_class.new(lineno, details) }
+    let(:details)   { { type: 'serious' } }
+    let(:lineno)    { 27 }
+
+    describe '#message' do
+      it 'has the line number' do
+        expect(error.message).to include lineno.to_s
+      end
+
+      it 'has the details' do
+        expect(error.message).to include 'type: serious'
+      end
+    end
+  end
+end

--- a/spec/lib/tufts/metadata_file_uploader_spec.rb
+++ b/spec/lib/tufts/metadata_file_uploader_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::MetadataFileUploader do
+  subject(:uploader) { described_class.new(model, :metadata_file) }
+  let(:file)         { StringIO.new('moomin') }
+  let(:model)        { FactoryGirl.create(:xml_import) }
+
+  it 'is a carrierwave uploader' do
+    expect(uploader).to be_a CarrierWave::Uploader::Base
+  end
+end

--- a/spec/lib/tufts/mira_xml_importer_spec.rb
+++ b/spec/lib/tufts/mira_xml_importer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Tufts::MiraXmlImporter do
   subject(:importer) { described_class.new(file: file) }
   let(:file)         { File.open(file_fixture('mira_xml.xml')) }
 
-  it { is_expected.to have_attributes file: file }
+  it_behaves_like 'an importer'
 
   describe '#records' do
     it 'yields correct number of records' do
@@ -21,18 +21,18 @@ RSpec.describe Tufts::MiraXmlImporter do
     end
 
     it 'populates records with files' do
-      expect(importer.records.map(&:file)).to contain_exactly('1.pdf', '2.pdf')
+      expect(importer.records.map(&:file)).to contain_exactly('pdf-sample.pdf', '2.pdf')
     end
+  end
 
-    context 'with empty file' do
-      let(:file) { StringIO.new('') }
+  describe 'validations' do
+    context 'with missing filenames' do
+      let(:file) { File.open(file_fixture('mira_xml_invalid.xml')) }
 
-      it 'yields nothing' do
-        expect { |b| importer.records(&b) }.not_to yield_control
-      end
-
-      it 'returns an empty enumerable' do
-        expect(importer.records.to_a).to be_empty
+      it 'validates presence of filenames' do
+        expect { importer.validate! }
+          .to change { importer.errors }
+          .to include(an_instance_of(Tufts::Importer::MissingFileError))
       end
     end
   end

--- a/spec/models/xml_import_spec.rb
+++ b/spec/models/xml_import_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe XmlImport, type: :model do
+  subject(:import) { FactoryGirl.build(:xml_import) }
+
+  # `it_behaves_like 'a batchable'` tests are pending due to oddities in
+  # #enqueue!'s behavior. We need to loosen `batchable` expectations by
+  # reworking the tests.
+
+  describe '#records' do
+    it 'returns ImportRecords' do
+      expect(import.records)
+        .to contain_exactly(an_instance_of(Tufts::ImportRecord),
+                            an_instance_of(Tufts::ImportRecord))
+    end
+    it 'has the correct records' do
+      expect(import.records.map(&:file)).to contain_exactly('pdf-sample.pdf', '2.pdf')
+    end
+  end
+
+  describe '#metadata_file' do
+    subject(:import)  { FactoryGirl.build(:xml_import, metadata_file: nil) }
+    let(:file)        { file_fixture('mira_xml.xml') }
+
+    it 'is an uploader' do
+      expect { import.metadata_file = File.open(file) }
+        .to change { import.metadata_file }
+        .to(an_instance_of(Tufts::MetadataFileUploader))
+    end
+  end
+
+  describe '#uploaded_file_ids' do
+    let(:ids) { ['1', '2'] }
+
+    it 'sets uploaded file ids' do
+      expect { import.uploaded_file_ids = ids }
+        .to change { import.uploaded_file_ids }
+        .to contain_exactly(*ids)
+    end
+  end
+
+  describe '#uploaded_files' do
+    subject(:import) do
+      FactoryGirl.create(:xml_import, uploaded_file_ids: files.map(&:id))
+    end
+
+    let(:files) { FactoryGirl.create_list(:hyrax_uploaded_file, 3) }
+
+    it 'has the correct files' do
+      expect(import.uploaded_files).to contain_exactly(*files)
+    end
+
+    context 'when empty' do
+      subject(:import) do
+        FactoryGirl.create(:xml_import, uploaded_file_ids: [])
+      end
+
+      it 'is empty' do
+        expect(import.uploaded_files).to be_empty
+      end
+    end
+
+    context 'with false file ids' do
+      before { import.uploaded_file_ids.concat(['false_id']) }
+
+      it 'raises an error' do
+        expect { import.uploaded_files }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
+  describe '#enqueue!' do
+    subject(:import) do
+      FactoryGirl.create(:xml_import, uploaded_file_ids: [file.id])
+    end
+
+    let(:file) { FactoryGirl.create(:hyrax_uploaded_file) }
+
+    it 'enqueues the correct job type' do
+      ActiveJob::Base.queue_adapter = :test
+
+      expect { import.enqueue! }
+        .to enqueue_job(ImportJob)
+        .with(import, file)
+        .on_queue('batch')
+    end
+
+    context 'when empty' do
+      subject(:import) do
+        FactoryGirl.create(:xml_import, uploaded_file_ids: [])
+      end
+
+      it 'gives an empty result' do
+        expect(import.enqueue!).to be_empty
+      end
+
+      it 'does not enqueue jobs' do
+        expect { import.enqueue! }.not_to enqueue_job(ImportJob)
+      end
+    end
+  end
+end

--- a/spec/presenters/xml_import_presenter_spec.rb
+++ b/spec/presenters/xml_import_presenter_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe XmlImportPresenter do
+  subject(:presenter) { described_class.new(import) }
+  let(:import)        { FactoryGirl.build(:xml_import) }
+
+  it { is_expected.to delegate_method(:batch).to(:xml_import) }
+
+  it { is_expected.to delegate_method(:creator).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:created_at).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:id).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:items).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:review_status).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:status).to(:batch_presenter) }
+
+  describe '#count' do
+    it 'reflects the count of records in the import file' do
+      expect(presenter.count).to eq 2
+    end
+  end
+
+  describe '#missing_files' do
+    it 'contains the record files' do
+      expect(presenter.missing_files)
+        .to contain_exactly(*import.parser.records.map(&:file))
+    end
+
+    context 'with files' do
+      subject(:import) { FactoryGirl.create(:xml_import) }
+
+      let(:file) do
+        FactoryGirl
+          .create(:hyrax_uploaded_file,
+                  file: File.open(file_fixture(filename)))
+      end
+
+      let(:filename) { 'pdf-sample.pdf' }
+
+      before { import.uploaded_file_ids << file.id }
+
+      it 'contains only the missing files' do
+        remaining_files = import.parser.records.map(&:file).to_a - [filename]
+
+        expect(presenter.missing_files).to contain_exactly(*remaining_files)
+      end
+    end
+  end
+
+  describe '#type' do
+    it 'has the correct type' do
+      expect(presenter.type).to eq import.batch_type
+    end
+  end
+end

--- a/spec/support/shared_examples/batchable.rb
+++ b/spec/support/shared_examples/batchable.rb
@@ -24,12 +24,12 @@ shared_examples 'a batchable' do
     end
 
     context 'with ids in batch' do
-      let(:ids) { ['abc', '123'] }
+      let(:ids) { ['123', '124'] }
 
       it 'gives a hash associating ids to jobs' do
         expect(batchable.enqueue!)
-          .to include('abc' => an_instance_of(String),
-                      '123' => an_instance_of(String))
+          .to include('123' => an_instance_of(String),
+                      '124' => an_instance_of(String))
       end
     end
   end

--- a/spec/support/shared_examples/importer.rb
+++ b/spec/support/shared_examples/importer.rb
@@ -1,0 +1,50 @@
+shared_examples 'an importer' do
+  subject(:importer) { described_class.new(file: file) }
+
+  before do
+    raise "Define `file` with `let(:file) to use the shared examples" unless
+      defined?(file)
+  end
+
+  it { is_expected.to have_attributes file: file }
+
+  describe '.match?' do
+    it 'responds to match' do
+      expect(described_class).to be_respond_to :match?
+    end
+  end
+
+  describe '#records' do
+    context 'with empty file' do
+      let(:file) { StringIO.new('') }
+
+      it 'yields nothing' do
+        expect { |b| importer.records(&b) }.not_to yield_control
+      end
+
+      it 'returns an empty enumerable' do
+        expect(importer.records.to_a).to be_empty
+      end
+    end
+  end
+
+  describe '#validate!' do
+    it 'does not add errors when valid' do
+      expect { importer.validate! }
+        .not_to change { importer.errors }
+        .from(be_empty)
+    end
+
+    context 'with an invalid file' do
+      subject(:importer) { described_class.new(file: invalid_file) }
+
+      it 'adds an error' do
+        if defined?(invalid_file)
+          expect { importer.validate! }
+            .to change { importer.errors }
+            .from(be_empty)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements a specialized `XmlImport` batch task as a `Batchable`.

User interactions allow for:

  - Uploading and validating XML metadata file;
    - The only current validation is the presence of a filename for each record.
  - Attaching files to the import.
    - The list of expected files and currently "missing" files are displayed in
    - the show and edit views for the `XmlImport`.

We reuse the Hyrax uploader form.

This closes most of #184. We don't yet create persistent representations of anything in this process. This will come in follow-up work.