### PR TITLE
Don't use a hardcoded title in redirection spec

### DIFF
--- a/spec/features/redirection_spec.rb
+++ b/spec/features/redirection_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature 'redirection' do
     describe 'viewing an item page' do
       scenario do
         visit "/concern/pdfs/#{pdf.id}"
-        expect(page).to have_content 'Test'
+        expect(page).to have_content pdf.title[0]
       end
     end
   end


### PR DESCRIPTION
@tom this fill fix the failure in #248 

