### PR TITLE
Run Hyrax 2.0 Migrations

### DIFF
--- a/db/migrate/20170918235305_create_job_io_wrappers.hyrax.rb
+++ b/db/migrate/20170918235305_create_job_io_wrappers.hyrax.rb
@@ -1,0 +1,16 @@
+# This migration comes from hyrax (originally 20170621201939)
+class CreateJobIoWrappers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :job_io_wrappers do |t|
+      t.references :user
+      t.references :uploaded_file
+      t.string :file_set_id
+      t.string :mime_type
+      t.string :original_name
+      t.string :path
+      t.string :relation
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170831005450) do
+ActiveRecord::Schema.define(version: 20170918235305) do
 
   create_table "batch_tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "batch_type"
@@ -128,6 +128,20 @@ ActiveRecord::Schema.define(version: 20170831005450) do
     t.boolean  "enabled",    default: false, null: false
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+  end
+
+  create_table "job_io_wrappers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "user_id"
+    t.integer  "uploaded_file_id"
+    t.string   "file_set_id"
+    t.string   "mime_type"
+    t.string   "original_name"
+    t.string   "path"
+    t.string   "relation"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.index ["uploaded_file_id"], name: "index_job_io_wrappers_on_uploaded_file_id", using: :btree
+    t.index ["user_id"], name: "index_job_io_wrappers_on_user_id", using: :btree
   end
 
   create_table "mailboxer_conversation_opt_outs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
Hyrax 2.0-beta1 had an unrun migration. Ran with:

`bundle exec rake hyrax:install:migrations; bundle exec rake db:migrate`