### PR TITLE
Use mira_publication_workflow and hyrax actor stack for self-deposit contributions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ Metrics/BlockLength:
 Metrics/LineLength:
    Exclude:
     - 'spec/controllers/tufts/draft_controller_spec.rb'
+Metrics/MethodLength:
+   Exclude:
+    - 'app/models/forms/contribution.rb'
 RSpec/ExampleLength:
    Exclude:
     - 'spec/features/**/*'
@@ -31,7 +34,8 @@ RSpec/AnyInstance:
 RSpec/MultipleExpectations:
   Exclude:
   - 'spec/controllers/contribute_controller_spec.rb'
-  - 'spec/features/publication_workflow_spec.rb'
+  - 'spec/features/**/*'
+  - 'spec/services/**/*'
   - 'spec/lib/tufts/workflow_setup_spec.rb'
 Style/FileName:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ bundle install
 bundle exec rails db:setup
 bundle exec sidekiq -d -l tmp/sidekiq.log
 # open a separate session and run bundle exec rails hydra:server
-bundle exec rails hyrax:default_admin_set:create 
 ```
 Other services and settings required:
-* MySQL 
-* Redis 
+* MySQL
+* Redis
 * Path to [FITS](https://projects.iq.harvard.edu/fits/downloads) in the [Hyrax initializer](https://github.com/curationexperts/epigaea/blob/master/config/initializers/hyrax.rb)
 * sidekiq as queue adapter in [application.rb](https://github.com/curationexperts/epigaea/blob/master/config/):        `config.active_job.queue_adapter = :sidekiq`
 

--- a/app/controllers/contribute_controller.rb
+++ b/app/controllers/contribute_controller.rb
@@ -16,7 +16,9 @@ class ContributeController < ApplicationController
   end
 
   def create
-    @contribution = @deposit_type.contribution_class.new(params[:contribution].merge(deposit_type: @deposit_type))
+    @contribution = @deposit_type.contribution_class.new(
+      params[:contribution].merge(deposit_type: @deposit_type).merge(depositor: current_user.user_key)
+    )
 
     if @contribution.save
       flash[:notice] = "Your deposit has been submitted for approval."

--- a/app/services/hyrax/workflow/mira_notification.rb
+++ b/app/services/hyrax/workflow/mira_notification.rb
@@ -1,0 +1,27 @@
+module Hyrax
+  module Workflow
+    class MiraNotification < AbstractNotification
+      # regardless of what is passed in, set the recipients according to this notification's requirements
+      def initialize(entity, comment, user, recipients)
+        super
+        @recipients = workflow_recipients
+      end
+
+      def workflow_recipients
+        raise NotImplementedError, "Implement workflow_recipients in a child class"
+      end
+
+      # The Users who have an admin role
+      # @return [<Array>::User] an Array of Hyrax::User objects
+      def admins
+        Role.where(name: 'admin').first_or_create.users.to_a
+      end
+
+      # The Hyrax::User who desposited the work
+      # @return [Hyrax::User]
+      def depositor
+        ::User.find_by(email: document.depositor)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/published_notification.rb
+++ b/app/services/hyrax/workflow/published_notification.rb
@@ -1,0 +1,21 @@
+module Hyrax
+  module Workflow
+    # Notification of state change to "approved".
+    # Should notify users with the approving role for the work's AdminSet, plus super users.
+    class PublishedNotification < MiraNotification
+      def workflow_recipients
+        { "to" => (admins << depositor) }
+      end
+
+      private
+
+        def subject
+          "Deposit #{title} has been published"
+        end
+
+        def message
+          "#{title} (#{link_to work_id, document_path}) has been published by #{user.display_name}.  #{comment}"
+        end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/self_deposit_notification.rb
+++ b/app/services/hyrax/workflow/self_deposit_notification.rb
@@ -1,0 +1,19 @@
+module Hyrax
+  module Workflow
+    class SelfDepositNotification < MiraNotification
+      def workflow_recipients
+        { "to" => (admins << depositor) }
+      end
+
+      private
+
+        def subject
+          "Deposit #{title} awaiting publication"
+        end
+
+        def message
+          "#{title} (#{link_to work_id, document_path}) has been deposited by #{depositor.display_name} (#{depositor.user_key}) and is awaiting publication."
+        end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/unpublished_notification.rb
+++ b/app/services/hyrax/workflow/unpublished_notification.rb
@@ -1,0 +1,21 @@
+module Hyrax
+  module Workflow
+    # Notification of state change to "approved".
+    # Should notify users with the approving role for the work's AdminSet, plus super users.
+    class UnpublishedNotification < MiraNotification
+      def workflow_recipients
+        { "to" => admins }
+      end
+
+      private
+
+        def subject
+          "Deposit #{title} has been unpublished"
+        end
+
+        def message
+          "#{title} (#{link_to work_id, document_path}) has been unpublished by #{user.display_name}.  #{comment}"
+        end
+    end
+  end
+end

--- a/config/workflows/mira_publication_workflow.json
+++ b/config/workflows/mira_publication_workflow.json
@@ -13,7 +13,7 @@
                     "notifications": [
                         {
                             "notification_type": "email",
-                            "name": "Hyrax::Workflow::PendingReviewNotification",
+                            "name": "Hyrax::Workflow::SelfDepositNotification",
                             "to": ["publishing"]
                         }
                     ],
@@ -27,7 +27,7 @@
                     "notifications": [
                         {
                             "notification_type": "email",
-                            "name": "Hyrax::Workflow::ChangesRequiredNotification",
+                            "name": "Hyrax::Workflow::UnpublishedNotification",
                             "to": ["publishing"]
                         }
                     ],
@@ -41,7 +41,7 @@
                     "notifications": [
                         {
                             "notification_type": "email",
-                            "name": "Hyrax::Workflow::DepositedNotification",
+                            "name": "Hyrax::Workflow::PublishedNotification",
                             "to": ["publishing"]
                         }
                     ],

--- a/spec/factories/pdf.rb
+++ b/spec/factories/pdf.rb
@@ -1,7 +1,9 @@
+require 'ffaker'
+
 FactoryGirl.define do
   factory :pdf do
     id { ActiveFedora::Noid::Service.new.mint }
-    title ['Test']
+    title [FFaker::Book.title]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
   end
 end

--- a/spec/features/batch_spec.rb
+++ b/spec/features/batch_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 RSpec.feature 'Create a Batch', :clean, js: true do
@@ -8,7 +9,7 @@ RSpec.feature 'Create a Batch', :clean, js: true do
   let(:user)    { create(:admin) }
 
   before do
-    AdminSet.find_or_create_default_admin_set_id
+    Tufts::WorkflowSetup.setup
 
     objects.each do |obj|
       obj.visibility = 'open'

--- a/spec/features/fletcher_school_capstone_contribute_spec.rb
+++ b/spec/features/fletcher_school_capstone_contribute_spec.rb
@@ -1,0 +1,42 @@
+# Generated via
+#  `rails generate hyrax:work Pdf`
+require 'rails_helper'
+require 'ffaker'
+require 'tufts/workflow_setup'
+require 'import_export/deposit_type_importer.rb'
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.feature 'Create a PDF', :clean, js: true do
+  context 'a logged in admin user' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:title) { FFaker::Movie.title }
+    before do
+      Tufts::WorkflowSetup.setup
+      importer = DepositTypeImporter.new('./config/deposit_type_seed.csv')
+      importer.import_from_csv
+      Pdf.delete_all
+      Hyrax::UploadedFile.delete_all
+      login_as user
+    end
+
+    scenario "a new user contributes a capstone project" do
+      visit '/contribute'
+      select 'Fletcher School Capstone Project', from: 'deposit_type'
+      click_button "Begin"
+      attach_file('contribution_attachment', File.absolute_path(file_fixture('pdf-sample.pdf')))
+      fill_in "Capstone project title", with: title
+      fill_in "Contributor", with: user.display_name
+      select 'Master of Arts', from: 'contribution_degree'
+      fill_in "Short description", with: FFaker::Lorem.paragraph
+      click_button "Agree & Deposit"
+      created_pdf = Pdf.last
+      expect(created_pdf.title.first).to eq title
+      expect(created_pdf.contributor.first).to eq user.display_name
+      expect(created_pdf.depositor).to eq user.user_key
+      expect(created_pdf.admin_set.title.first).to eq "Default Admin Set"
+      expect(created_pdf.active_workflow.name).to eq "mira_publication_workflow"
+      expect(created_pdf.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+  end
+end

--- a/spec/services/hyrax/workflow/published_notification_spec.rb
+++ b/spec/services/hyrax/workflow/published_notification_spec.rb
@@ -1,0 +1,43 @@
+libdir = File.expand_path('../../../../', __FILE__)
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+require 'rails_helper'
+require 'active_fedora/cleaner'
+require 'tufts/workflow_setup'
+require 'database_cleaner'
+
+RSpec.describe Hyrax::Workflow::PublishedNotification do
+  before :all do
+    Tufts::WorkflowSetup.setup
+  end
+  let(:depositor) { FactoryGirl.create(:user) }
+  let(:admin) { FactoryGirl.create(:admin) }
+  let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }
+  let(:ability) { ::Ability.new(depositor) }
+  let(:recipients) do
+    { 'to' => [depositor] }
+  end
+  let(:notification) do
+    current_ability = ::Ability.new(depositor)
+    admin # ensure admin user exists
+    attributes = {}
+    env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
+    Hyrax::CurationConcern.actor.create(env)
+    work_global_id = work.to_global_id.to_s
+    entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
+    described_class.new(entity, '', depositor, recipients)
+  end
+  it "can instantiate" do
+    expect(notification).to be_instance_of(described_class)
+  end
+  it "can find depositor" do
+    expect(notification.depositor).to be_instance_of(::User)
+    expect(notification.depositor.email).to eq depositor.user_key
+  end
+  it "can find admins" do
+    expect(notification.admins).to be_instance_of(Array)
+    expect(notification.admins.pluck(:id)).to contain_exactly(admin.id)
+  end
+  it "sends notifications to the depositor, application admins and no one else" do
+    expect(notification.recipients["to"].pluck(:email)).to contain_exactly(depositor.user_key, admin.user_key)
+  end
+end

--- a/spec/services/hyrax/workflow/self_deposit_notification_spec.rb
+++ b/spec/services/hyrax/workflow/self_deposit_notification_spec.rb
@@ -1,0 +1,43 @@
+libdir = File.expand_path('../../../../', __FILE__)
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+require 'rails_helper'
+require 'active_fedora/cleaner'
+require 'tufts/workflow_setup'
+require 'database_cleaner'
+
+RSpec.describe Hyrax::Workflow::SelfDepositNotification do
+  before :all do
+    Tufts::WorkflowSetup.setup
+  end
+  let(:depositor) { FactoryGirl.create(:user) }
+  let(:admin) { FactoryGirl.create(:admin) }
+  let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }
+  let(:ability) { ::Ability.new(depositor) }
+  let(:recipients) do
+    { 'to' => [depositor] }
+  end
+  let(:notification) do
+    current_ability = ::Ability.new(depositor)
+    admin # ensure admin user exists
+    attributes = {}
+    env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
+    Hyrax::CurationConcern.actor.create(env)
+    work_global_id = work.to_global_id.to_s
+    entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
+    described_class.new(entity, '', depositor, recipients)
+  end
+  it "can instantiate" do
+    expect(notification).to be_instance_of(described_class)
+  end
+  it "can find depositor" do
+    expect(notification.depositor).to be_instance_of(::User)
+    expect(notification.depositor.email).to eq depositor.user_key
+  end
+  it "can find admins" do
+    expect(notification.admins).to be_instance_of(Array)
+    expect(notification.admins.pluck(:id)).to contain_exactly(admin.id)
+  end
+  it "sends notifications to the depositor, application admins and no one else" do
+    expect(notification.recipients["to"].pluck(:email)).to contain_exactly(depositor.user_key, admin.user_key)
+  end
+end

--- a/spec/services/hyrax/workflow/unpublished_notification_spec.rb
+++ b/spec/services/hyrax/workflow/unpublished_notification_spec.rb
@@ -1,0 +1,43 @@
+libdir = File.expand_path('../../../../', __FILE__)
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+require 'rails_helper'
+require 'active_fedora/cleaner'
+require 'tufts/workflow_setup'
+require 'database_cleaner'
+
+RSpec.describe Hyrax::Workflow::UnpublishedNotification do
+  before :all do
+    Tufts::WorkflowSetup.setup
+  end
+  let(:depositor) { FactoryGirl.create(:user) }
+  let(:admin) { FactoryGirl.create(:admin) }
+  let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }
+  let(:ability) { ::Ability.new(depositor) }
+  let(:recipients) do
+    { 'to' => [depositor] }
+  end
+  let(:notification) do
+    current_ability = ::Ability.new(depositor)
+    admin # ensure admin user exists
+    attributes = {}
+    env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
+    Hyrax::CurationConcern.actor.create(env)
+    work_global_id = work.to_global_id.to_s
+    entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
+    described_class.new(entity, '', depositor, recipients)
+  end
+  it "can instantiate" do
+    expect(notification).to be_instance_of(described_class)
+  end
+  it "can find depositor" do
+    expect(notification.depositor).to be_instance_of(::User)
+    expect(notification.depositor.email).to eq depositor.user_key
+  end
+  it "can find admins" do
+    expect(notification.admins).to be_instance_of(Array)
+    expect(notification.admins.pluck(:id)).to contain_exactly(admin.id)
+  end
+  it "sends notifications to application admins and no one else" do
+    expect(notification.recipients["to"].pluck(:email)).to contain_exactly(admin.user_key)
+  end
+end


### PR DESCRIPTION
Add feature test for capstone contribute
Persist depositor to fedora object (enables "my works" behavior)
Pdfs created via contribute should use default admin set and mira_publication_workflow
Use AttachFilesToWorkJob to attach uploaded file
Creation of default admin set now happens in db:seed, which is run in db:setup
Using Tufts::WorkflowSetup.setup instead of creating default admin set directly will avoid intermittent test failures
Enable customized notifications

This is a rebased and slightly modified version of number #248.

Fixes #245
Fixes #3
Fixes #5
Fixes #235