### PR TITLE
Temporarily turn off eager_load in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
-  config.eager_load = true
+  config.eager_load = false
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false


### PR DESCRIPTION
Eager loading is causing issues for us in production. We will want to turn it back on, but plan to cut the test environment.