### PR TITLE
Setup workflow for all feature specs

### DIFF
--- a/spec/features/batch_spec.rb
+++ b/spec/features/batch_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 RSpec.feature 'Create a Batch', :clean, js: true do
@@ -9,8 +8,6 @@ RSpec.feature 'Create a Batch', :clean, js: true do
   let(:user)    { create(:admin) }
 
   before do
-    Tufts::WorkflowSetup.setup
-
     objects.each do |obj|
       obj.visibility = 'open'
       obj.save!

--- a/spec/features/contribute/undergrad_honors_thesis_spec.rb
+++ b/spec/features/contribute/undergrad_honors_thesis_spec.rb
@@ -7,10 +7,12 @@ RSpec.feature 'submit an Undergraduate Honors Thesis contribution' do
   let(:csv_path) { Rails.root.join('config', 'deposit_type_seed.csv').to_s }
   let(:importer) { DepositTypeImporter.new(csv_path) }
   let(:pdf_path) { Rails.root.join('spec', 'fixtures', 'hello.pdf') }
+
   before do
     login_as user
     importer.import_from_csv
   end
+
   scenario do
     visit '/contribute'
     find('#deposit_type').find(:xpath, 'option[10]').select_option

--- a/spec/features/create_audio_spec.rb
+++ b/spec/features/create_audio_spec.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate hyrax:work Audio`
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
@@ -9,10 +8,7 @@ RSpec.feature 'Create a Audio', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
 
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/create_ead_spec.rb
+++ b/spec/features/create_ead_spec.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate hyrax:work Ead`
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
@@ -9,10 +8,7 @@ RSpec.feature 'Create a EAD', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
 
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/create_generic_object_spec.rb
+++ b/spec/features/create_generic_object_spec.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate hyrax:work GenericObject`
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
@@ -9,10 +8,7 @@ RSpec.feature 'Create a GenericObject', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
 
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate hyrax:work Image`
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
@@ -9,10 +8,7 @@ RSpec.feature 'Create a Image', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
 
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/create_pdf_spec.rb
+++ b/spec/features/create_pdf_spec.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate hyrax:work Pdf`
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
@@ -9,10 +8,7 @@ RSpec.feature 'Create a PDF', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
 
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/create_rcr_spec.rb
+++ b/spec/features/create_rcr_spec.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate hyrax:work Rcr`
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
@@ -9,10 +8,7 @@ RSpec.feature 'Create an RCR', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
 
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/create_tei_spec.rb
+++ b/spec/features/create_tei_spec.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate hyrax:work Tei`
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
@@ -9,10 +8,7 @@ RSpec.feature 'Create a TEI', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
 
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/create_video_spec.rb
+++ b/spec/features/create_video_spec.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate hyrax:work Video`
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
@@ -9,10 +8,7 @@ RSpec.feature 'Create a Video', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
 
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/create_voting_record_spec.rb
+++ b/spec/features/create_voting_record_spec.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate hyrax:work VotingRecord`
 require 'rails_helper'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
@@ -9,10 +8,7 @@ RSpec.feature 'Create a VotingRecord', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
 
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/fletcher_school_capstone_contribute_spec.rb
+++ b/spec/features/fletcher_school_capstone_contribute_spec.rb
@@ -2,7 +2,6 @@
 #  `rails generate hyrax:work Pdf`
 require 'rails_helper'
 require 'ffaker'
-require 'tufts/workflow_setup'
 require 'import_export/deposit_type_importer.rb'
 include Warden::Test::Helpers
 
@@ -12,7 +11,6 @@ RSpec.feature 'Create a PDF', :clean, js: true do
     let(:user) { FactoryGirl.create(:user) }
     let(:title) { FFaker::Movie.title }
     before do
-      Tufts::WorkflowSetup.setup
       importer = DepositTypeImporter.new('./config/deposit_type_seed.csv')
       importer.import_from_csv
       Pdf.delete_all

--- a/spec/features/publication_workflow_spec.rb
+++ b/spec/features/publication_workflow_spec.rb
@@ -2,7 +2,6 @@
 #  `rails generate hyrax:work Etd`
 require 'rails_helper'
 require 'active_fedora/cleaner'
-require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
 RSpec.feature 'deposit and publication' do
@@ -12,7 +11,6 @@ RSpec.feature 'deposit and publication' do
   context 'a logged in user' do
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-      Tufts::WorkflowSetup.setup
       publishing_user # Make sure publishing user exists before the work is submitted
       current_ability = ::Ability.new(depositing_user)
       attributes = {}

--- a/spec/features/sidebar_links_spec.rb
+++ b/spec/features/sidebar_links_spec.rb
@@ -5,10 +5,8 @@ include Warden::Test::Helpers
 RSpec.feature 'Manage Deposit Types link in dashboard sidebar', :clean do
   context 'a logged in user' do
     let(:admin) { FactoryGirl.create(:admin) }
-    before do
-      Tufts::WorkflowSetup.setup
-      login_as admin
-    end
+
+    before { login_as admin }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/template_spec.rb
+++ b/spec/features/template_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'Apply a Template', :clean, js: true do
     let(:user) { FactoryGirl.create(:admin) }
 
     before do
-      Tufts::WorkflowSetup.setup
       template # create the template
       object.visibility = 'open'
       object.save!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -103,6 +103,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
+    Tufts::WorkflowSetup.setup
   end
 
   config.before(:each) do |example|
@@ -115,6 +116,9 @@ RSpec.configure do |config|
       DatabaseCleaner.strategy = :transaction
       DatabaseCleaner.start
     end
+
+    Tufts::WorkflowSetup.setup if
+      example.metadata[:type] == :feature || example.metadata[:workflow]
   end
 
   config.after(:each, type: :feature) do

--- a/spec/services/hyrax/workflow/published_notification_spec.rb
+++ b/spec/services/hyrax/workflow/published_notification_spec.rb
@@ -2,13 +2,9 @@ libdir = File.expand_path('../../../../', __FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
 require 'active_fedora/cleaner'
-require 'tufts/workflow_setup'
 require 'database_cleaner'
 
-RSpec.describe Hyrax::Workflow::PublishedNotification do
-  before :all do
-    Tufts::WorkflowSetup.setup
-  end
+RSpec.describe Hyrax::Workflow::PublishedNotification, :workflow do
   let(:depositor) { FactoryGirl.create(:user) }
   let(:admin) { FactoryGirl.create(:admin) }
   let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }

--- a/spec/services/hyrax/workflow/self_deposit_notification_spec.rb
+++ b/spec/services/hyrax/workflow/self_deposit_notification_spec.rb
@@ -2,13 +2,9 @@ libdir = File.expand_path('../../../../', __FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
 require 'active_fedora/cleaner'
-require 'tufts/workflow_setup'
 require 'database_cleaner'
 
-RSpec.describe Hyrax::Workflow::SelfDepositNotification do
-  before :all do
-    Tufts::WorkflowSetup.setup
-  end
+RSpec.describe Hyrax::Workflow::SelfDepositNotification, :workflow do
   let(:depositor) { FactoryGirl.create(:user) }
   let(:admin) { FactoryGirl.create(:admin) }
   let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }

--- a/spec/services/hyrax/workflow/unpublished_notification_spec.rb
+++ b/spec/services/hyrax/workflow/unpublished_notification_spec.rb
@@ -2,13 +2,9 @@ libdir = File.expand_path('../../../../', __FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
 require 'active_fedora/cleaner'
-require 'tufts/workflow_setup'
 require 'database_cleaner'
 
-RSpec.describe Hyrax::Workflow::UnpublishedNotification do
-  before :all do
-    Tufts::WorkflowSetup.setup
-  end
+RSpec.describe Hyrax::Workflow::UnpublishedNotification, :workflow do
   let(:depositor) { FactoryGirl.create(:user) }
   let(:admin) { FactoryGirl.create(:admin) }
   let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }


### PR DESCRIPTION
Workflow is now setup during database cleaning before all feature specs. The
`:workflow` tag is introduced to example metadata to handle setup for
non-feature specs that need workflow.

This reduces the amount of duplication and specialized knowledge needed to setup
workflow for a test. It also fixes several order-dependent spec failures due to
unsatisfactory workflow setup in some existing feature specs.

Closes #264.