### PR TITLE
Remove broken image tag from contribute page

### DIFF
--- a/app/views/contribute/index.html.erb
+++ b/app/views/contribute/index.html.erb
@@ -21,9 +21,7 @@
 
       <p><%= link_to "Login", new_user_session_path, class: 'btn-primary btn' %></p>
 
-      <p><a href="http://uit.tufts.edu/?pid=744">
-        <img src="https://library.tufts.edu/screens/Logo2-35pxNoText.png" alt="Tufts Simplified Sign-On" height="35" width="35" />
-        Tufts Simplified Sign-On Enabled</a></p>
+      <p><a href="http://uit.tufts.edu/?pid=744">Tufts Simplified Sign-On Enabled</a></p>
 
 
   <%# Display the following options for logged in users %>


### PR DESCRIPTION
When we last looked at this issue, I looked at the Tufts SSO guidelines and they are no longer using that image to indicate that an app has SSO. I just removed the image tag from the page. 

Closes #278 