### PR TITLE
Redirect all users visiting / to /contribute

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,7 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  unauthenticated do
-    root to: 'contribute#redirect'
-  end
+  root to: 'contribute#redirect'
 
   constraints non_admin_constraint do
     get '/dashboard', to: 'contribute#redirect'


### PR DESCRIPTION
The page at `/` doesn't really have a purpose. I think we should just redirect `/` to `/contribute` to avoid confusion. 

Closes #280 