### PR TITLE
Don't create items for unmatched files in XmlImports

### DIFF
--- a/app/lib/tufts/mira_xml_importer.rb
+++ b/app/lib/tufts/mira_xml_importer.rb
@@ -34,6 +34,14 @@ module Tufts
     end
 
     ##
+    # @param file [String]
+    #
+    # @return [Boolean]
+    def record?(file:)
+      records.any? { |record| record.file == file }
+    end
+
+    ##
     # @yield Gives each record to the block
     # @yieldparam [ImportRecord]
     #

--- a/app/models/xml_import.rb
+++ b/app/models/xml_import.rb
@@ -100,14 +100,19 @@ class XmlImport < ApplicationRecord
 
     ##
     # @private Mint ids for items ready to enqueue
-    def mint_ids
+    # @todo refactor for internal complexity. Should there be a service
+    #   responsible for handling ids?
+    def mint_ids # rubocop:disable Metrics/CyclomaticComplexity
       return unless uploaded_file_ids_changed?
 
       uploaded_files.each do |file|
         filename = file.file.file.filename
 
-        next if record_ids.key?(filename) || !record?(file: filename)
-        
+        next if record_ids.key?(filename)
+
+        (uploaded_file_ids.delete(file.id) && file.destroy! && next) unless
+          record?(file: filename)
+
         id = NOID_SERVICE.mint
 
         record_ids[filename] = id

--- a/app/models/xml_import.rb
+++ b/app/models/xml_import.rb
@@ -19,11 +19,13 @@ class XmlImport < ApplicationRecord
   has_one :batch, as: :batchable
 
   ##
+  # @!method record?
+  #   @see Tufts::Importer#has_record?
   # @!method record_for
   #   @see Tufts::Importer#record_for
   # @!method records
   #   @see Tufts::Importer#records
-  delegate :record_for, :records, to: :parser
+  delegate :record?, :record_for, :records, to: :parser
 
   ##
   # @!attribute uploaded_file_ids [rw]
@@ -102,10 +104,13 @@ class XmlImport < ApplicationRecord
       return unless uploaded_file_ids_changed?
 
       uploaded_files.each do |file|
-        next if record_ids.key?(file.file.file.filename)
+        filename = file.file.file.filename
 
+        next if record_ids.key?(filename) || !record?(file: filename)
+        
         id = NOID_SERVICE.mint
-        record_ids[file.file.file.filename] = id
+
+        record_ids[filename] = id
         batch.ids << id
       end
 

--- a/spec/lib/tufts/mira_xml_importer_spec.rb
+++ b/spec/lib/tufts/mira_xml_importer_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe Tufts::MiraXmlImporter do
 
   it_behaves_like 'an importer'
 
+  describe '#record?' do
+    let(:filename) { 'pdf-sample.pdf' }
+
+    it 'is true when a record matches the filename' do
+      expect(importer.record?(file: filename)).to be true
+    end
+
+    it 'is false when no record matches' do
+      expect(importer.record?(file: 'not-a-real-file.fake')).to be false
+    end
+  end
+
   describe '#record_for' do
     let(:filename) { 'pdf-sample.pdf' }
 

--- a/spec/models/xml_import_spec.rb
+++ b/spec/models/xml_import_spec.rb
@@ -148,6 +148,18 @@ RSpec.describe XmlImport, type: :model do
         expect { import.save }.not_to change { import.record_ids }
       end
 
+      it 'skips non-matching filenames' do
+        file = FactoryGirl
+                 .create(:hyrax_uploaded_file,
+                         file: File.open('spec/fixtures/files/mira_xml.xml'))
+
+        import.uploaded_file_ids = [file.id]
+
+        expect { import.save }
+          .not_to change { import.record_ids }
+          .from(be_empty)
+      end
+
       it 'does not assign ids twice' do
         import.save
 

--- a/spec/models/xml_import_spec.rb
+++ b/spec/models/xml_import_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable RSpec/NestedGroups
 RSpec.describe XmlImport, type: :model do
   subject(:import) { FactoryGirl.build(:xml_import) }
 
@@ -148,16 +149,25 @@ RSpec.describe XmlImport, type: :model do
         expect { import.save }.not_to change { import.record_ids }
       end
 
-      it 'skips non-matching filenames' do
-        file = FactoryGirl
-                 .create(:hyrax_uploaded_file,
-                         file: File.open('spec/fixtures/files/mira_xml.xml'))
+      context 'with non-matching filenames' do
+        let(:ids) { [non_matching_file.id] }
+        let(:non_matching_file) do
+          FactoryGirl
+            .create(:hyrax_uploaded_file,
+                    file: File.open('spec/fixtures/files/mira_xml.xml'))
+        end
 
-        import.uploaded_file_ids = [file.id]
+        it 'skips non-matching filenames' do
+          expect { import.save }
+            .not_to change { import.record_ids }
+            .from(be_empty)
+        end
 
-        expect { import.save }
-          .not_to change { import.record_ids }
-          .from(be_empty)
+        it 'cleans up unmatched files' do
+          expect { import.save }
+            .to change { non_matching_file.class.exists?(non_matching_file.id) }
+            .to(false)
+        end
       end
 
       it 'does not assign ids twice' do


### PR DESCRIPTION
When a file doesn't match the records in the import, skip it.

90808a8 also cleans up the files on save.