### PR TITLE
This commits restores autocomplete for the Undergrad Thesis contribut…

### DIFF
--- a/app/assets/javascripts/tufts.js
+++ b/app/assets/javascripts/tufts.js
@@ -2,5 +2,11 @@ var Tufts = {
   qrStatus: function () {
     var QrStatus = require('tufts/qr_status')
     return new QrStatus()
+  },
+  autocomplete: function () {
+    var Autocomplete = require('hyrax/autocomplete')
+    var autocomplete = new Autocomplete()
+    
+    autocomplete.setup($('#contribution_department'),'default','/authorities/search/local/departments')
   }
 }

--- a/app/views/contribute/deposit_view/_honors_thesis.html.erb
+++ b/app/views/contribute/deposit_view/_honors_thesis.html.erb
@@ -8,7 +8,11 @@
 <% end %>
 <%= f.text_field :creator, label: 'Contributor', value: contributor, required: true  %>
 
-<%= f.text_field :department, label: 'Department', class: 'typeahead', autocomplete: false, data: {provide:"typeahead", source: tufts_department_labels } %>
+<%= f.text_field :department, label: 'Department', 'data-autocomplete': '/authorities/search/local/departments'  %>
+
+<script>
+  Tufts.autocomplete()
+</script>
 
 <%= f.select :embargo_note, standard_embargos,  label: 'Embargo'  %>
 

--- a/spec/features/contribute/undergrad_honors_thesis_spec.rb
+++ b/spec/features/contribute/undergrad_honors_thesis_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 require 'ffaker'
 include Warden::Test::Helpers
+require 'import_export/deposit_type_importer'
 
-RSpec.feature 'submit an Undergraduate Honors Thesis contribution' do
+RSpec.feature 'submit an Undergraduate Honors Thesis contribution', js: true do
   let(:user) { FactoryGirl.create(:user) }
   let(:csv_path) { Rails.root.join('config', 'deposit_type_seed.csv').to_s }
   let(:importer) { DepositTypeImporter.new(csv_path) }
@@ -21,8 +22,15 @@ RSpec.feature 'submit an Undergraduate Honors Thesis contribution' do
     fill_in 'Thesis title', with: FFaker::Book.title
     fill_in 'Contributor', with: FFaker::Book.author
 
+    # Test department autocomplete
+    fill_in 'Department', with: 'geol'
+    page.execute_script %{ $('#contribution_department').trigger('focus') }
+    page.execute_script %{ $('#contribution_department').trigger('keydown') }
+    expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item')
+    page.execute_script %{ $('ul.ui-autocomplete li.ui-menu-item:contains("Dept. of Geology")').trigger('mouseenter').click() }
+    expect(find_field('Department').value).to eq 'Dept. of Geology'
+
     fill_in 'Short Description', with: FFaker::Book.description
-    fill_in 'Department', with: 'Dept. of Geology'
     click_button 'Agree & Deposit'
     expect(page).to have_content 'Your deposit has been submitted for approval.'
   end


### PR DESCRIPTION
…ion form.

This form was using Typeahead, but Hyrax has built in autocomplete functionality that
works with local QA vocabs so that was used instead.

There is a feature test searches for 'geol' and checks to see if the autocomplete returns 'Dept. of Geology'

Hyrax doesn't include the autocomplete functionality in a global scope so I modified our global `Tufts` object
to import it and make it available as `Tufts.autocomplete`. Additional fields will need to be added to that function
if they need autocomplete.

Closes #309 