### PR TITLE
Fix logo redirection and search bar location for admin users

### DIFF
--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,11 +1,5 @@
 <% if current_user && current_user.admin? %>
-<nav class="navbar navbar-default navbar-static-top" role="navigation">
-  <div class="container-fluid">
-    <div class="row">
-      <div class="searchbar-left navbar-left col-sm-7 col-md-6">
+      <div class="searchbar-center navbar-center col-sm-12 col-md-12">
         <%= render partial: 'catalog/search_form' %>
       </div>
-    </div>
-  </div>
-</nav><!-- /.navbar -->
 <% end %>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -2,6 +2,9 @@
   <% if user_signed_in? %>
   <% if current_user.admin? %>
   <li>
+  <%= render '/controls' %>
+  </li>
+  <li>
       <%= render 'hyrax/users/notify_number' %>
   </li>
   <% end %>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,9 +1,3 @@
-<% content_for(:navbar) do %>
-  <div class="image-masthead">
-    <%= render '/controls' %>
-  </div>
-<% end %>
-
 <% content_for(:precontainer_content) do %>
   <%= render 'hyrax/homepage/announcement' if controller_name == 'homepage' %>
 <% end %>

--- a/app/views/layouts/hyrax/1_column.html.erb
+++ b/app/views/layouts/hyrax/1_column.html.erb
@@ -1,0 +1,1 @@
+<%= render template: 'layouts/hyrax' %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -5,11 +5,6 @@
         <%= link_to application_name, root_path, class: "navbar-brand" %>
       </div>
       <div class="navbar-right">
-        <div class="nav navbar-nav" id="searchbar">
-          <% unless controller_name.in?(['contribute', 'templates', 'records', 'sessions']) %>
-            <%= render_search_bar %>
-          <% end %>
-        </div>
         <div class="nav navbar-nav">
         <%= render '/user_util_links' %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   concern :searchable, Blacklight::Routes::Searchable.new
 
   constraints admin_constraint do
+    root to: 'hyrax/dashboard#show'
     # Only admin users should be able to search
     resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
       concerns :searchable
@@ -20,9 +21,8 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  root to: 'contribute#redirect'
-
   constraints non_admin_constraint do
+    root to: 'contribute#redirect'
     get '/dashboard', to: 'contribute#redirect'
   end
 

--- a/spec/features/redirection_spec.rb
+++ b/spec/features/redirection_spec.rb
@@ -58,10 +58,24 @@ RSpec.feature 'redirection' do
     let(:user) { FactoryGirl.create(:admin) }
     before { login_as user }
 
-    describe 'getting redirected to contribute when logging in' do
+    describe 'being able to access the dashboard' do
       scenario do
         visit '/dashboard'
         expect(page).to have_content 'Manage'
+      end
+    end
+
+    describe 'getting redirected to the dashboard when visiting root' do
+      scenario do
+        visit '/'
+        expect(page).to have_content 'Administration'
+      end
+    end
+
+    describe 'having access to search when on dashboard' do
+      scenario do
+        visit '/dashboard'
+        expect(page).to have_selector '#search-field-header'
       end
     end
 


### PR DESCRIPTION
This commit redirects admin users to `/dashboard` when they visit `/` regular users are still redirected to `/contribute` from `/`.

This also places the catalog search into the header across pages for admin users by the notifications icon.

There are two additonal feature specs that cover this new behavior.

Closes #292 