### PR TITLE
Add preliminary user specs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,18 +22,20 @@ class User < ApplicationRecord
   # user class to get a user-displayable login/identifier for
   # the account.
   def to_s
-    email
+    display_name
   end
 
-  def add_role(role)
-    role = Role.find_by(name: role)
-    role = Role.create(name: role) if role.nil?
+  def add_role(name)
+    role = Role.find_by(name: name)
+    role = Role.create(name: name) if role.nil?
     role.users << self
     role.save
+    reload
   end
 
-  def remove_role(role)
-    roles = Role.find_by(name: role)
-    roles.users.delete(self) if roles && roles.users && roles.users.include?(self)
+  def remove_role(name)
+    role = Role.find_by(name: name)
+    role.users.delete(self) if role && role.users && role.users.include?(self)
+    reload
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe User do
+  subject(:user) { build(:user) }
+  let(:plain_user) { create(:user) }
+
+  it_behaves_like 'a Hyrax User'
+
+  it "has a display name" do
+    expect(user.display_name).not_to be_empty
+  end
+
+  it '#to_s yeilds the #display_name' do
+    expect(user.to_s).to eq user.display_name
+  end
+
+  describe 'roles' do
+    it 'is emplty for a new user' do
+      new_user = create(:user)
+      expect(new_user.roles).to be_empty
+    end
+
+    it "#add_role adds a named role" do
+      plain_user.add_role('some_role')
+      expect(plain_user.roles.inspect).to match(/some_role/)
+    end
+
+    it "#add_role creates a new role if needed" do
+      expect { plain_user.add_role('named_role') }.to change { Role.count }.by(1)
+    end
+
+    it "#add_role uses an existing role if it exists" do
+      role = Role.create(name: 'existing_role')
+      plain_user.add_role('existing_role')
+      expect(plain_user.roles.to_a).to include role
+    end
+
+    it "#remove_role removes a named role" do
+      new_user = create(:user)
+      new_user.add_role('new_role')
+      expect { new_user.remove_role('new_role') }.to change { new_user.roles.count }.from(1).to(0)
+    end
+
+    it "#remove_role does nothing on non-existant names" do
+      existing_roles = plain_user.roles
+      plain_user.remove_role('nonexistent_role_name')
+      expect(plain_user.roles).to match existing_roles
+    end
+  end
+
+  describe '#admin?' do
+    it 'is false for regular user' do
+      expect(user).not_to be_admin
+    end
+
+    it 'is true when a user has the "admin" role' do
+      admin_user = create(:user)
+      admin_user.add_role(:admin)
+      expect(admin_user).to be_admin
+    end
+  end
+end

--- a/spec/support/shared_examples/hyrax_user.rb
+++ b/spec/support/shared_examples/hyrax_user.rb
@@ -1,0 +1,23 @@
+RSpec.shared_examples 'a Hyrax User' do
+  describe '#ability' do
+    it 'has abilities managed by Ability' do
+      expect(user.ability).to be_a Ability
+    end
+  end
+
+  describe '#email' do
+    it 'is the set email' do
+      expect { user.email = 'example.user@test.com' }
+        .to change { user.email }
+        .to 'example.user@test.com'
+    end
+  end
+
+  describe '#password' do
+    it 'is the set password' do
+      expect { user.password = 'secret' }
+        .to change { user.password }
+        .to 'secret'
+    end
+  end
+end


### PR DESCRIPTION
```
User
  has a display name
  #to_s yeilds the #display_name
  behaves like a Hyrax User
    #ability
      has abilities managed by Ability
    #email
      is the set email
    #password
      is the set password
  roles
    is emplty for a new user
    #add_role creates a new role for the user
    #add_role uses an existing role if it exists
    #add_role creates a new role for the user
    #remove_role removes a named role
    #remove_role does nothing on non-existant names
  #admin?
    is false for regular user
    is true when a user has the "admin" role
```