### PR TITLE
GenericTischDeposit should use the Hyrax workflow.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ Metrics/LineLength:
 Metrics/MethodLength:
    Exclude:
     - 'app/models/forms/contribution.rb'
+    - 'app/models/forms/generic_tisch_deposit.rb'
 RSpec/ExampleLength:
    Exclude:
     - 'spec/features/**/*'

--- a/app/models/forms/generic_tisch_deposit.rb
+++ b/app/models/forms/generic_tisch_deposit.rb
@@ -2,15 +2,29 @@ class GenericTischDeposit < Contribution
   def tufts_pdf
     return @tufts_pdf if @tufts_pdf
     now = Time.zone.now
-
     note = "#{creator} self-deposited on #{now.strftime('%Y-%m-%d at %H:%M:%S %Z')} using the Deposit Form for the Tufts Digital Library"
-    @tufts_pdf = Pdf.new(createdby: SELFDEP, title: [title],
-                         steward: 'tisch', displays_in: ['dl'], format_label: ['application/pdf'],
-                         publisher: ['Tufts University. Tisch Library.'],
-                         license: ['http://dca.tufts.edu/ua/access/rights-creator.html'],
-                         date_available: [now.to_s], date_uploaded: now.to_s, internal_note: note)
-
+    @tufts_pdf = Pdf.new(
+      createdby: SELFDEP,
+      depositor: @depositor,
+      visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+      contributor: [creator],
+      title: [title],
+      steward: 'tisch',
+      displays_in: ['dl'],
+      format_label: ['application/pdf'],
+      publisher: ['Tufts University. Tisch Library.'],
+      license: ['http://dca.tufts.edu/ua/access/rights-creator.html'],
+      date_available: [now.to_s],
+      date_uploaded: now.to_s,
+      internal_note: note
+    )
     copy_attributes
+    user = User.find_by(email: @depositor)
+    current_ability = ::Ability.new(user)
+    uploaded_file = Hyrax::UploadedFile.create(user: user, file: @attachment)
+    attributes = { uploaded_files: [uploaded_file.id] }
+    env = Hyrax::Actors::Environment.new(@tufts_pdf, current_ability, attributes)
+    Hyrax::CurationConcern.actor.create(env)
     @tufts_pdf
   end
 

--- a/spec/features/undergrad_scholarship_contribute_spec.rb
+++ b/spec/features/undergrad_scholarship_contribute_spec.rb
@@ -1,0 +1,43 @@
+# Generated via
+#  `rails generate hyrax:work Pdf`
+require 'rails_helper'
+require 'ffaker'
+require 'import_export/deposit_type_importer.rb'
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.feature 'Create a PDF', :clean, js: true do
+  context do
+    let(:depositing_user) { FactoryGirl.create(:user) }
+    let(:title) { FFaker::Movie.title }
+    before do
+      importer = DepositTypeImporter.new('./config/deposit_type_seed.csv')
+      importer.import_from_csv
+      Pdf.delete_all
+      Hyrax::UploadedFile.delete_all
+      login_as depositing_user
+    end
+
+    scenario "a new user contributes undergraduate research" do
+      visit '/contribute'
+      select 'General Undergraduate Scholarship', from: 'deposit_type'
+      click_button "Begin"
+      attach_file('contribution_attachment', File.absolute_path(file_fixture('pdf-sample.pdf')))
+      fill_in "Title", with: title
+      fill_in "Contributor", with: depositing_user.display_name
+      fill_in "Short Description", with: FFaker::Lorem.paragraph
+      click_button "Agree & Deposit"
+      created_pdf = Pdf.last
+      expect(created_pdf.title.first).to eq title
+      expect(created_pdf.contributor.first).to eq depositing_user.display_name
+      expect(created_pdf.depositor).to eq depositing_user.user_key
+      expect(created_pdf.admin_set.title.first).to eq "Default Admin Set"
+      expect(created_pdf.active_workflow.name).to eq "mira_publication_workflow"
+      expect(created_pdf.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      # Check notifications for depositing user
+      login_as depositing_user
+      visit("/notifications?locale=en")
+      expect(page).to have_content "#{created_pdf.title.first} (#{created_pdf.id}) has been deposited by #{depositing_user.display_name} (#{depositing_user.user_key}) and is awaiting publication."
+    end
+  end
+end


### PR DESCRIPTION
GenericTischDeposit, the contribution type created by Undergrad Scholarship contributions, defines its own `tufts_pdf` method. All other object types use the `tufts_pdf` method from `app/models/forms/contribution.rb`. The method in contribution.rb had already been updated to use the Hyrax workflow, but I missed updating this one previously. Only one contribution type uses this, afaict. 

Fixes #333