### PR TITLE
Remove depsosit agreement UI

### DIFF
--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -1,0 +1,51 @@
+<aside id="form-progress" class="form-progress panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title"><%= t("hyrax.works.progress.header") %></h3>
+  </div>
+  <div class="list-group">
+    <div class="list-group-item">
+      <fieldset>
+        <legend class="legend-save-work"><%= t('.requirements') %></legend>
+        <ul class="requirements">
+          <li class="incomplete" id="required-metadata"><%= t('.required_descriptions') %></li>
+          <% if Hyrax.config.work_requires_files? %>
+            <li class="incomplete" id="required-files"><%= t('.required_files') %></li>
+          <% end %>
+          <% if Flipflop.active_deposit_agreement_acceptance? %>
+            <li class="incomplete" id="required-agreement"><%= t('.required_agreement') %></li>
+          <% end %>
+        </ul>
+      </fieldset>
+    </div>
+
+    <div class="set-access-controls list-group-item">
+      <%= render 'form_visibility_component', f: f %>
+    </div>
+    <% unless current_user.can_make_deposits_for.empty? %>
+        <div class="list-group-item">
+          <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
+        </div>
+    <% end %>
+  </div>
+  <div class="panel-footer text-center">
+    <% if ::Flipflop.show_deposit_agreement? %>
+      <% if ::Flipflop.active_deposit_agreement_acceptance? %>
+        <label>
+          <%= check_box_tag 'agreement', 1, f.object.agreement_accepted, required: true %>
+          <%= t('hyrax.active_consent_to_agreement') %><br>
+          <%= link_to t('hyrax.pages.tabs.agreement_page'),
+                      hyrax.agreement_path,
+                      target: '_blank' %>
+        </label>
+      <% end %>
+    <% end %>
+    <br>
+    <%= link_to t(:'helpers.action.cancel'),
+                hyrax.dashboard_path,
+                class: 'btn btn-default' %>
+    <%# TODO: If we start using ActionCable, we could listen for object updates and
+              alert the user that the object has changed by someone else %>
+    <%= f.input Hyrax::Actors::OptimisticLockValidator.version_field, as: :hidden if f.object.persisted? %>
+    <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+  </div>
+</aside>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -125,7 +125,7 @@ Hyrax.config do |config|
   # Should the acceptance of the licence agreement be active (checkbox), or
   # implied when the save button is pressed? Set to true for active
   # The default is true.
-  # config.active_deposit_agreement_acceptance = true
+  config.active_deposit_agreement_acceptance = false
 
   # Should work creation require file upload, or can a work be created first
   # and a file added at a later time?

--- a/spec/features/create_draft_spec.rb
+++ b/spec/features/create_draft_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature 'Create and revert a draft', :clean, js: true do
       click_link "Files"
       execute_script("$('.fileinput-button input:first').css({'opacity':'1', 'display':'block', 'position':'relative'})")
       attach_file('files[]', File.absolute_path(file_fixture('pdf-sample.pdf')))
-      find('#agreement').click
       sleep(1)
       find('#with_files_submit').click
       expect(page).to have_content('Example Title')

--- a/spec/features/create_pdf_spec.rb
+++ b/spec/features/create_pdf_spec.rb
@@ -25,7 +25,6 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       click_link "Files"
       execute_script("$('.fileinput-button input:first').css({'opacity':'1', 'display':'block', 'position':'relative'})")
       attach_file('files[]', File.absolute_path(file_fixture('pdf-sample.pdf')))
-      find('#agreement').click
       sleep(1)
       find('#with_files_submit').click
       expect(page).to have_content('Example Title')


### PR DESCRIPTION
There is a flipflop feature that controls whether this is required or not and this sets it to false.

This also removes the passive agreement message that displays when you set the feature to false.

Closes #350 