### PR TITLE
Remove locale from url

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,6 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options
-    {}
+    super.except(:locale)
   end
 end


### PR DESCRIPTION
This removes the `locale?en` from all the URLs by changing the `default_url_options` method
to exclude that param.

Closes #213 