### PR TITLE
Wire up MVC for MetadataExport

### DIFF
--- a/app/controllers/hyrax/batches_controller.rb
+++ b/app/controllers/hyrax/batches_controller.rb
@@ -15,9 +15,7 @@ module Hyrax
 
       batch.enqueue!
 
-      redirect_to main_app.batches_path action: 'show',
-                                        id:     batch.id,
-                                        notice: 'Batch Enqueued!'
+      redirect_to main_app.batch_path(batch)
     end
 
     def show

--- a/app/controllers/hyrax/metadata_exports_controller.rb
+++ b/app/controllers/hyrax/metadata_exports_controller.rb
@@ -1,0 +1,27 @@
+module Hyrax
+  class MetadataExportsController < ApplicationController
+    def create
+      ids = params[:ids] || params[:batch_document_ids] || []
+
+      export       = MetadataExport.new
+      export.batch = Batch.create(batchable: export,
+                                  creator:   current_user,
+                                  ids:       ids)
+
+      export.save!
+      export.batch.enqueue!
+
+      redirect_to main_app.batch_path(export.batch)
+    end
+
+    def download
+      export   = MetadataExport.find(params.require(:id))
+      filename = export.filename
+
+      raise(ActionController::RoutingError, 'Not Found') unless filename
+
+      # we trust our own file extensions to give good hints to MIME::TYPES
+      send_file export.path
+    end
+  end
+end

--- a/app/jobs/metadata_export_job.rb
+++ b/app/jobs/metadata_export_job.rb
@@ -1,0 +1,14 @@
+##
+# A job that prepares a metadata export for a batch.
+#
+# This job takes a list of ids for Works and produces a metadata download file.
+class MetadataExportJob < BatchableJob
+  def perform(export)
+    exporter = Tufts::MetadataExporter.new(ids:  export.object_ids,
+                                           name: "xml_export-#{export.id}")
+    exporter.export!
+
+    export.filename = exporter.filename
+    export.save!
+  end
+end

--- a/app/lib/tufts/metadata_exporter.rb
+++ b/app/lib/tufts/metadata_exporter.rb
@@ -1,0 +1,80 @@
+module Tufts
+  ##
+  # Handles export of metedata for groups of files.
+  class MetadataExporter
+    ##
+    # @!attribute [rw] builder
+    #   @return [XmlMetadataBuilder]
+    # @!attribute [rw] ids
+    #   @return [Array<String>]
+    # @!attribute [rw] name
+    #   @return [String]
+    attr_accessor :builder, :ids, :name
+
+    STORAGE_DIR = Pathname.new(Rails.configuration.exports_storage_dir).freeze
+
+    ##
+    # @param filename [String]
+    #
+    # @return [Pathname]
+    def self.path_for(filename:)
+      STORAGE_DIR.join(filename)
+    end
+
+    ##
+    # @param ids [Array<String>]
+    def initialize(ids:, builder: XmlMetadataBuilder.new, name: SecureRandom.uuid)
+      @builder = builder
+      @ids     = ids
+      @name    = name
+    end
+
+    ##
+    # @return [void]
+    def cleanup!
+      File.delete(path) if File.exist?(path)
+    end
+
+    ##
+    # Generates an IO object with the exported data.
+    #
+    # @return [IO]
+    def export
+      StringIO.new(builder.build)
+    end
+
+    ##
+    # Saves the generated export to a file.
+    #
+    # @return [File] a file handle open for read
+    # @see #export
+    def export!
+      File.open(path, 'w') do |file|
+        file.write(builder.build)
+      end
+
+      file
+    end
+
+    ##
+    # @yield Yields a file when a block is given.
+    # @yieldparam file [File] the file via `File#open(&block)`
+    #
+    # @return [File, nil] a file opened for read; nil if none exists
+    def file(&block)
+      File.exist?(path) ? File.open(path, 'r', &block) : nil
+    end
+
+    ##
+    # @return [String]
+    def filename
+      "#{name}#{builder.file_extension}"
+    end
+
+    ##
+    # @return [Pathname]
+    def path
+      self.class.path_for(filename: filename)
+    end
+  end
+end

--- a/app/lib/tufts/xml_metadata_builder.rb
+++ b/app/lib/tufts/xml_metadata_builder.rb
@@ -1,0 +1,17 @@
+module Tufts
+  ##
+  # A builder class for constructing XML metadata exports
+  class XmlMetadataBuilder
+    FILE_EXT = '.xml'.freeze
+
+    ##
+    # @return [String] the built metadata for export
+    def build
+      'temporary fake xml'
+    end
+
+    def file_extension
+      FILE_EXT
+    end
+  end
+end

--- a/app/models/metadata_export.rb
+++ b/app/models/metadata_export.rb
@@ -1,0 +1,45 @@
+##
+# A model for managing and batch metadata exports.
+#
+# @see MetadataExportJob
+class MetadataExport < ApplicationRecord
+  ##
+  # @!attrbute filename [rw]
+  #   @return [String]
+  # @!attribute batch [rw]
+  #   @return [Batch]
+  has_one :batch, as: :batchable
+
+  TYPE_STRING = 'Export'.freeze
+
+  ##
+  # @return [String]
+  def batch_type
+    TYPE_STRING
+  end
+
+  ##
+  # @return [Hash]
+  def enqueue!
+    return {} if object_ids.empty?
+
+    job_id = MetadataExportJob.perform_later(self).job_id
+
+    object_ids.each_with_object({}) do |id, hsh|
+      hsh[id] = job_id
+    end
+  end
+
+  ##
+  # @return [Pathname]
+  # @see MetadataExporter.path_for
+  def path
+    Tufts::MetadataExporter.path_for(filename: filename)
+  end
+
+  ##
+  # @return [Array<String>] the ids from the batch
+  def object_ids
+    batch ? batch.ids : []
+  end
+end

--- a/app/presenters/batch_presenter.rb
+++ b/app/presenters/batch_presenter.rb
@@ -27,7 +27,8 @@ class BatchPresenter
   end
 
   class << self
-    REGISTRY = { XmlImport => XmlImportPresenter }.freeze
+    REGISTRY = { XmlImport      => XmlImportPresenter,
+                 MetadataExport => MetadataExportPresenter }.freeze
 
     ##
     # @param object [Batch]

--- a/app/presenters/metadata_export_presenter.rb
+++ b/app/presenters/metadata_export_presenter.rb
@@ -1,0 +1,71 @@
+##
+# A presenter for the MetadataExport model, behaves maximally like a
+# BatchPresenter for the associated batch.
+#
+# @see BatchPresenter
+class MetadataExportPresenter
+  ##
+  # @!attribute xml_import
+  #   @return [XmlImport]
+  attr_accessor :export
+
+  ##
+  # @!method batch
+  #   @return [Batch]
+  delegate :batch, to: :export
+
+  ##
+  # @!method object
+  #   @see #batch
+  alias object batch
+
+  ##
+  # @param export [MetadataExport]
+  def initialize(export)
+    @export = export
+  end
+
+  ##
+  # @!method count
+  #   @see BatchPresenter#count
+  # @!method creator
+  #   @see BatchPresenter#creator
+  # @!method created_at
+  #   @see BatchPresenter#created_at
+  # @!method id
+  #   @see BatchPresenter#id
+  # @!method items
+  #   @see BatchPresenter#items
+  # @!method path
+  #   @see BatchPresenter#path
+  # @!method review_status
+  #   @see BatchPresenter#review_status
+  # @!method status
+  #   @see BatchPresenter#status
+  delegate :count, :creator, :created_at, :id, :items, :path, :review_status,
+           :status, to: :batch_presenter
+
+  ##
+  # @return [BatchPresenter]
+  def batch_presenter
+    @batch_presenter ||= BatchPresenter.new(batch)
+  end
+
+  ##
+  # @return [String]
+  def download
+    download_ready? ? export.filename : 'n/a'
+  end
+
+  ##
+  # @return [Boolean]
+  def download_ready?
+    !export.filename.nil?
+  end
+
+  ##
+  # @return [String]
+  def type
+    export.batch_type
+  end
+end

--- a/app/views/catalog/_batch_header.html.erb
+++ b/app/views/catalog/_batch_header.html.erb
@@ -8,6 +8,9 @@
   <li>
     <%= button_to "Publish", batches_path, method: :post, params: { batch: { batchable_attributes: { batch_type: "Publish" } } }, class: "btn btn-primary submits-batches" %>
   </li>
+  <li>
+    <%= button_to "Export Metadata", metadata_exports_path, method: :post, class: "btn btn-primary submits-batches" %>
+  </li>
   <li class="selected-documents">
     <div id="selected_documents_count">Number of documents selected: 0</div>
   </li>

--- a/app/views/hyrax/batches/_batch_info.html.erb
+++ b/app/views/hyrax/batches/_batch_info.html.erb
@@ -5,6 +5,10 @@
       <dt>Record Count</dt><dd><%= batch.count %></dd>
       <dt>Creator</dt><dd><%= batch.creator %></dd>
       <dt>Created At</dt><dd><%= batch.created_at %></dd>
+      <% if batch.respond_to?(:download) %>
+      <dt>Download</dt>
+        <dd><%= batch.download_ready? ? link_to(batch.download, "/metadata_exports/#{batch.export.id}/download", id: "download", data: { turbolinks: false }) : batch.download %></dd>
+      <% end %>
       <dt>Status</dt><dd><%= batch.status %></dd>
     </dl>
   </div>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,6 +41,9 @@ append :linked_dirs, "log"
 # link the draft dir specified in config/environments/produciton.rb config.drafts_storage_dir
 append :linked_dirs, "tmp/drafts"
 
+# link the draft dir specified in config/environments/production.rb config.exports_storage_dir
+append :linked_dirs, "tmp/exports"
+
 # link the template dir specified in config/environments/produciton.rb config.templates_storage_dir
 append :linked_dirs, "tmp/templates"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,5 +56,6 @@ Rails.application.configure do
 
   # Configure the drafts strorage directory
   config.drafts_storage_dir    = Rails.root.join('tmp', 'drafts')
+  config.exports_storage_dir   = Rails.root.join('tmp', 'exports')
   config.templates_storage_dir = Rails.root.join('tmp', 'templates')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,5 +86,6 @@ Rails.application.configure do
 
   # Configure the drafts strorage directory
   config.drafts_storage_dir    = Rails.root.join('tmp', 'drafts')
+  config.exports_storage_dir   = Rails.root.join('tmp', 'exports')
   config.templates_storage_dir = Rails.root.join('tmp', 'templates')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,5 +46,6 @@ Rails.application.configure do
 
   # Configure the drafts strorage directory
   config.drafts_storage_dir    = Rails.root.join('tmp', 'drafts')
+  config.exports_storage_dir   = Rails.root.join('tmp', 'exports')
   config.templates_storage_dir = Rails.root.join('tmp', 'templates')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,16 +51,20 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :metadata_exports,
+            controller: 'hyrax/metadata_exports',
+            only:       [:create]
   resources :xml_imports,
             controller: 'hyrax/xml_imports',
             only:       [:show, :create, :new, :edit, :update]
-
   resources :templates,
             controller: 'hyrax/templates',
             only:       [:index, :destroy, :edit, :update, :new]
   resources :template_updates,
             controller: 'hyrax/template_updates',
             only:       [:index, :new, :create]
+
+  get '/metadata_exports/:id/download', to: 'hyrax/metadata_exports#download'
 
   # Routes for managing drafts
   post '/draft/save_draft/:id', to: 'tufts/draft#save_draft'

--- a/db/migrate/20171003153633_create_metadata_exports.rb
+++ b/db/migrate/20171003153633_create_metadata_exports.rb
@@ -1,0 +1,8 @@
+class CreateMetadataExports < ActiveRecord::Migration[5.0]
+  def change
+    create_table :metadata_exports do |t|
+      t.string :filename
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170922200243) do
+ActiveRecord::Schema.define(version: 20171003153633) do
 
   create_table "batch_tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "batch_type"
@@ -196,6 +196,12 @@ ActiveRecord::Schema.define(version: 20170922200243) do
     t.string   "message_id"
     t.index ["notification_id"], name: "index_mailboxer_receipts_on_notification_id", using: :btree
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type", using: :btree
+  end
+
+  create_table "metadata_exports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "filename"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "minter_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/controllers/hyrax/metadata_exports_controller_spec.rb
+++ b/spec/controllers/hyrax/metadata_exports_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::MetadataExportsController, type: :controller do
+  let(:ids)    { models.map(&:id) }
+  let(:models) { FactoryGirl.create_list(:generic_object, 2) }
+
+  context 'as admin' do
+    let(:user) { FactoryGirl.create(:admin) }
+
+    before { sign_in user }
+
+    describe 'POST #create' do
+      let(:params) { { batch_document_ids: ids } }
+
+      it 'creates a batch' do
+        expect { post :create, params: params }.to change { Batch.count }.by(1)
+      end
+
+      it 'enqueues an export job' do
+        ActiveJob::Base.queue_adapter = :test
+
+        expect { post :create, params: params }
+          .to enqueue_job(MetadataExportJob)
+          .once
+      end
+    end
+
+    describe 'GET #download' do
+      subject(:export) { FactoryGirl.create(:metadata_export) }
+      let(:params)     { { id: export.id } }
+
+      it 'returns 404' do
+        expect { get :download, params: params }.to raise_error('Not Found')
+      end
+
+      context 'with a filename' do
+        subject(:export) do
+          FactoryGirl.create(:metadata_export, filename: filename)
+        end
+
+        let(:contents) { 'moomin moomin' }
+        let(:filename) { 'moomin.xml' }
+
+        before { File.open(export.path, 'w') { |f| f.write(contents) } }
+        after  { File.delete(export.path) }
+
+        it 'downloads the file' do
+          get :download, params: params
+
+          expect(response.body).to eq contents
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/metadata_exports.rb
+++ b/spec/factories/metadata_exports.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :metadata_export do
+    batch
+  end
+end

--- a/spec/features/metadata_export_spec.rb
+++ b/spec/features/metadata_export_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Export Metadata', :clean, js: true, batch: true do
+  let!(:objects) { [object, other] }
+  let(:object)   { create(:pdf) }
+  let(:other)    { create(:pdf) }
+
+  context 'with logged in user' do
+    let(:user) { FactoryGirl.create(:admin) }
+
+    before do
+      ActiveJob::Base.queue_adapter = :test
+
+      login_as user
+    end
+
+    scenario 'export metadata for selected items' do
+      visit '/catalog'
+
+      objects.each do |obj|
+        find("#document_#{obj.id}").check "batch_document_#{obj.id}"
+      end
+
+      expect { click_on 'Export Metadata' }
+        .to enqueue_job(MetadataExportJob)
+        .once
+
+      expect(page).to have_content 'Download'
+    end
+
+    context 'with a generated file' do
+      let(:contents) { '<?xml version="1.0" encoding="UTF-8"?><blah></blah>' }
+      let(:filename) { 'moomin.xml' }
+
+      let!(:export) { FactoryGirl.create(:metadata_export, filename: filename) }
+
+      before { File.open(export.path, 'w') { |f| f.write(contents) } }
+      after  { File.delete(export.path) }
+
+      scenario 'downloading an export' do
+        visit "batches/#{export.batch.id}"
+        click_on(filename)
+
+        expect(page.response_headers['Content-Disposition'])
+          .to include 'attachment'
+      end
+    end
+  end
+end

--- a/spec/jobs/metadata_export_job_spec.rb
+++ b/spec/jobs/metadata_export_job_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe MetadataExportJob, type: :job do
+  subject(:job) { described_class }
+  let(:pdf)     { create(:pdf) }
+
+  it_behaves_like 'an ActiveJob job'
+end

--- a/spec/lib/tufts/metadata_exporter_spec.rb
+++ b/spec/lib/tufts/metadata_exporter_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::MetadataExporter do
+  subject(:exporter) { described_class.new(ids: ids, builder: builder) }
+  let(:builder)      { fake_builder.new }
+  let(:ids)          { models.map(&:id) }
+  let(:models)       { FactoryGirl.create_list(:generic_object, 3) }
+
+  let(:fake_builder) do
+    Class.new do
+      def fake_metadata
+        'some super fake metadata'
+      end
+
+      def build
+        fake_metadata
+      end
+
+      def file_extension
+        '.fake'
+      end
+    end
+  end
+
+  define :read_as do |expected|
+    match { |actual| actual.read == expected }
+  end
+
+  it { is_expected.to have_attributes(ids: ids, builder: builder) }
+
+  after { exporter.cleanup! }
+
+  describe '#builder' do
+    it 'defaults to an xml metadata builder' do
+      expect(described_class.new(ids: ids))
+        .to have_attributes(builder: an_instance_of(Tufts::XmlMetadataBuilder))
+    end
+  end
+
+  describe '#export' do
+    it 'contains built metadata' do
+      expect(exporter.export).to read_as(builder.fake_metadata)
+    end
+  end
+
+  describe '#export!' do
+    it 'writes built metadata to a file' do
+      expect { exporter.export! }
+        .to change { exporter.file }
+        .from(nil).to(read_as(builder.fake_metadata))
+    end
+  end
+
+  describe '#file' do
+    it 'is nil export' do
+      expect(exporter.file).to be_nil
+    end
+
+    context 'after export' do
+      before { exporter.export! }
+
+      it 'contains built metadata' do
+        expect(exporter.file).to read_as(builder.fake_metadata)
+      end
+
+      it 'yields a file containing built metadata' do
+        expect { |b| exporter.file(&b) }
+          .to yield_with_args(read_as(builder.fake_metadata))
+      end
+
+      it 'gives the same file from a new instance' do
+        new_exporter =
+          described_class.new(ids: ids, builder: builder, name: exporter.name)
+
+        expect(new_exporter.file).to read_as(builder.fake_metadata)
+      end
+    end
+  end
+end

--- a/spec/lib/tufts/xml_metadata_builder_spec.rb
+++ b/spec/lib/tufts/xml_metadata_builder_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::XmlMetadataBuilder do
+  subject(:builder) { described_class.new }
+
+  it_behaves_like 'a MetadataBuilder'
+
+  describe '#file_extension' do
+    it 'is .xml' do
+      expect(builder.file_extension).to eq '.xml'
+    end
+  end
+end

--- a/spec/models/metadata_export_spec.rb
+++ b/spec/models/metadata_export_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe MetadataExport, type: :model do
+  subject(:batchable) { FactoryGirl.create(:metadata_export) }
+
+  it_behaves_like 'a batchable'
+
+  it { is_expected.to have_attributes(batch_type: 'Export') }
+
+  describe '#enqueue!' do
+    subject(:batchable) { FactoryGirl.create(:metadata_export, batch: batch) }
+
+    let(:batch)   { FactoryGirl.create(:batch, ids: ids) }
+    let(:ids)     { objects.map(&:id) }
+    let(:objects) { FactoryGirl.create_list(:pdf, 2) }
+
+    it 'returns the same job id for all objects' do
+      expect(batchable.enqueue!.values.uniq)
+        .to contain_exactly(an_instance_of(String))
+    end
+
+    it 'enqeues one job for the full batch' do
+      ActiveJob::Base.queue_adapter = :test
+
+      expect { batchable.enqueue! }
+        .to enqueue_job(MetadataExportJob)
+        .once
+    end
+  end
+
+  describe '#filename' do
+    let(:filename) { 'moomin.xml' }
+
+    it 'is an attribute' do
+      expect { batchable.filename = filename }
+        .to change { batchable.filename }
+        .to filename
+    end
+  end
+end

--- a/spec/presenters/metadata_export_presenter_spec.rb
+++ b/spec/presenters/metadata_export_presenter_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe MetadataExportPresenter do
+  subject(:presenter) { described_class.new(export) }
+  let(:batch)         { FactoryGirl.build(:batch, ids: []) }
+  let(:export)        { FactoryGirl.build(:metadata_export, batch: batch) }
+
+  it { is_expected.to have_attributes(export: export, batch: batch) }
+
+  it { is_expected.to delegate_method(:batch).to(:export) }
+
+  it { is_expected.to delegate_method(:count).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:creator).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:created_at).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:id).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:path).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:review_status).to(:batch_presenter) }
+  it { is_expected.to delegate_method(:status).to(:batch_presenter) }
+
+  describe '#download' do
+    context 'without a file' do
+      it 'is n/a' do
+        expect(presenter.download).to eq 'n/a'
+      end
+    end
+
+    context 'with a file' do
+      let(:filename) { 'moomin.xml' }
+
+      before { export.filename = filename }
+
+      it 'is the filename' do
+        expect(presenter.download).to eq filename
+      end
+    end
+  end
+
+  describe '#type' do
+    it 'has the correct type' do
+      expect(presenter.type).to eq export.batch_type
+    end
+  end
+end

--- a/spec/support/shared_examples/active_job_job.rb
+++ b/spec/support/shared_examples/active_job_job.rb
@@ -1,0 +1,5 @@
+shared_examples 'an ActiveJob job' do
+  subject(:job) { described_class.new }
+
+  it { is_expected.to respond_to :perform }
+end

--- a/spec/support/shared_examples/metadata_builder.rb
+++ b/spec/support/shared_examples/metadata_builder.rb
@@ -1,0 +1,15 @@
+shared_examples 'a MetadataBuilder' do
+  subject(:builder) { described_class.new }
+
+  describe '#build' do
+    it 'builds a string' do
+      expect(builder.build.to_str).to be_a String
+    end
+  end
+
+  describe '#file_extension' do
+    it 'is an extension' do
+      expect(builder.file_extension).to match(/^\.[a-z]+$/)
+    end
+  end
+end


### PR DESCRIPTION
Adds models, views, controllers, presenters, and jobs for metadata export. This
includes:

   - A `MetadataExport` and associated controller, filling the role of a
     `Batchable`.
   - A `MetadataExportPresenter`, along with minor changes to `BatchPresenter`
     and the `_batch_info` view partial to add a download link when
     appropriate.
   - A generic `Tufts::MetadataExporter`, handling file generation, and a job to
     marshall its work.
   - Configuration for file export file paths.
   - A download action to handle the actual download (turbolinks *must* be
     disabled on this link).
   - Unit and feature tests.

Exports are generated by a `Tufts::MetadataExporter` which uses an metadata
builder (`Tufts::XmlMetadataBuilder` by default) to generate the actual
file. The metadata handling is a follow-up PR.