### PR TITLE
Export mapping

### DIFF
--- a/app/lib/tufts/metadata_exporter.rb
+++ b/app/lib/tufts/metadata_exporter.rb
@@ -40,6 +40,7 @@ module Tufts
     #
     # @return [IO]
     def export
+      populate_builder
       StringIO.new(builder.build)
     end
 
@@ -49,6 +50,7 @@ module Tufts
     # @return [File] a file handle open for read
     # @see #export
     def export!
+      populate_builder
       File.open(path, 'w') do |file|
         file.write(builder.build)
       end
@@ -76,5 +78,18 @@ module Tufts
     def path
       self.class.path_for(filename: filename)
     end
+
+    private
+
+      ##
+      # @private
+      # @return [void]
+      def populate_builder
+        active_ids = ids.select { |r| ActiveFedora::Base.exists?(r) }
+
+        ActiveFedora::Base.find(active_ids).each do |object|
+          builder.add(object)
+        end
+      end
   end
 end

--- a/app/lib/tufts/mira_xml_mapping.rb
+++ b/app/lib/tufts/mira_xml_mapping.rb
@@ -1,0 +1,59 @@
+module Tufts
+  ##
+  # Defines a mapping between GenericObject metadata and custom mira XML.
+  class MiraXmlMapping
+    ##
+    # A sturct representing a metadata field
+    #
+    # @example
+    #   field = Field.new('dc', 'title', :title)
+    #
+    #   field.namespace # => 'dc'
+    #   field.name      # => 'title'
+    #   field.property  # => :title
+    #
+    Field = Struct.new(:namespace, :name, :property, :filter)
+
+    PROPERTIES    = GenericObject.properties.values.freeze
+    FILTERS       = { title: Proc.new(&:first) }.freeze
+
+    ##
+    # @yield Yields each field in the mapped object
+    # @yieldparam
+    #
+    # @return [Enumerator<Field>]
+    def map
+      if block_given?
+        yield Field.new('terms', 'id', :id, FILTERS['id'])
+
+        PROPERTIES.each do |node_config|
+          term     = node_config.term
+          ns, name = node_config.predicate.qname
+          next if ns.nil?
+          yield Field.new(ns, name, term, FILTERS[term])
+        end
+      end
+
+      enum_for(:map)
+    end
+
+    ##
+    # @return [Hash<String, String>]
+    def namespaces
+      PROPERTIES.each_with_object({}) do |node_config, hsh|
+        predicate = node_config.predicate
+        ns, name  = predicate.qname
+        next if ns.nil?
+        ns_uri = predicate.to_s[0...-name.length]
+
+        hsh["xmlns:#{ns}"] = ns_uri
+      end
+    end
+
+    ##
+    # Define namespaces for qnames. RDF::URI uses Vocabulary to handle qnames
+    # selection, so this maps to `xmlns:scholarsphere` and `xmlns:opaquehydra`
+    class Scholarsphere < RDF::Vocabulary('http://scholarsphere.psu.edu/ns#'); end
+    class OpaqueHydra < RDF::Vocabulary('http://opaquenamespace.org/ns/hydra/'); end
+  end
+end

--- a/app/lib/tufts/xml_metadata_builder.rb
+++ b/app/lib/tufts/xml_metadata_builder.rb
@@ -4,12 +4,48 @@ module Tufts
   class XmlMetadataBuilder
     FILE_EXT = '.xml'.freeze
 
-    ##
-    # @return [String] the built metadata for export
-    def build
-      'temporary fake xml'
+    def initialize
+      @mapping = MiraXmlMapping.new
+      @objects = []
     end
 
+    ##
+    # @param object [ActiveFedora::Base]
+    def add(*objects)
+      @objects.concat(objects) && @xml = nil
+      @objects
+    end
+
+    ##
+    # @return [String] the built metadata for export
+    def build # rubocop:disable Metrics/MethodLength
+      @xml ||= Nokogiri::XML::Builder.new do |xml|
+        xml.send(:'OAI-PMH',
+                 'xmlns' => 'http://www.openarchives.org/OAI/2.0/') do
+          xml.ListRecords do
+            @objects.each do |object|
+              xml.record do
+                xml.metadata do
+                  xml.mira_import(@mapping.namespaces) do
+                    @mapping.map do |field|
+                      values = object.send(field.property)
+                      values = field.filter.call(values) if field.filter
+
+                      Array(values).each do |value|
+                        xml[field.namespace.to_s].send(field.name, value)
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end.to_xml
+    end
+
+    ##
+    # @return [String]
     def file_extension
       FILE_EXT
     end

--- a/spec/fixtures/files/mira_xml.xml
+++ b/spec/fixtures/files/mira_xml.xml
@@ -2,7 +2,7 @@
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
-                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>2017-09-01T19:20:30Z</responseDate>
   <request verb="ListRecords" from="1998-01-15"
            set="any:set"

--- a/spec/lib/tufts/metadata_exporter_spec.rb
+++ b/spec/lib/tufts/metadata_exporter_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Tufts::MetadataExporter do
         'some super fake metadata'
       end
 
+      def add(*); end
+
       def build
         fake_metadata
       end

--- a/spec/lib/tufts/mira_xml_mapping_spec.rb
+++ b/spec/lib/tufts/mira_xml_mapping_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::MiraXmlMapping do
+  subject(:mapping) { described_class.new }
+
+  describe '#namespaces' do
+    it 'has dc' do
+      expect(mapping.namespaces).to have_key 'xmlns:dc'
+    end
+
+    it 'has valid uris for values' do
+      mapping.namespaces.each_value do |value|
+        expect(RDF::URI(value)).to be_valid
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/metadata_builder.rb
+++ b/spec/support/shared_examples/metadata_builder.rb
@@ -1,6 +1,37 @@
 shared_examples 'a MetadataBuilder' do
   subject(:builder) { described_class.new }
 
+  describe '#add' do
+    let(:object)        { objects.first }
+    let(:objects)       { FactoryGirl.create_list(:pdf, 2) }
+    let(:property_keys) { objects.first.class.properties.keys }
+
+    let(:values) do
+      objects.each_with_object([]) do |object, arry|
+        attributes = object.attributes.slice(*property_keys)
+        arry.concat(attributes.values.map { |vals| Array(vals) }.flatten)
+      end
+    end
+
+    it 'adds the object ids' do
+      expect { builder.add(*objects) }
+        .to change { builder.build }
+        .to include(*objects.map(&:id))
+    end
+
+    it 'adds the object models' do
+      expect { builder.add(*objects) }
+        .to change { builder.build }
+        .to include(":hasModel>#{object.class}</")
+    end
+
+    it 'adds the object attributes' do
+      expect { builder.add(*objects) }
+        .to change { builder.build }
+        .to include(*values)
+    end
+  end
+
   describe '#build' do
     it 'builds a string' do
       expect(builder.build.to_str).to be_a String


### PR DESCRIPTION
This is a follow-up to #367 ~, and needs to be rebased after it is merged~.

Implements a metadata mapping from the declared properties to namespaced
XML. Object id is specially added in the Tufts `terms` namespace.