### PR TITLE
Treat :title as a single valued field for changeset application

### DIFF
--- a/app/lib/tufts/changeset_overwrite_strategy.rb
+++ b/app/lib/tufts/changeset_overwrite_strategy.rb
@@ -36,6 +36,8 @@ module Tufts
           if subject == model.rdf_subject
             values = statements.map(&:object)
             values = values.first unless config.multiple?
+            values = [values.first] if config.term == :title
+
             model.send("#{property}=".to_sym, values)
           else
             model.resource.insert(*statements)

--- a/spec/lib/tufts/changeset_overwrite_strategy_spec.rb
+++ b/spec/lib/tufts/changeset_overwrite_strategy_spec.rb
@@ -12,14 +12,20 @@ RSpec.describe Tufts::ChangesetOverwriteStrategy do
 
       it 'applies the changes' do
         expect { strategy.apply }
-          .to change { model.title.to_a }
-          .to contain_exactly('moomin', 'moominmama', 'snork')
+          .to change { model.subject.to_a }
+          .to contain_exactly('too-ticky', 'snufkin')
       end
 
       it 'updates changed attributes' do
         expect { strategy.apply }
           .to change { model.changed_attributes }
           .to include('title', 'subject')
+      end
+
+      it 'uses only one first value for title' do
+        expect { strategy.apply }
+          .to change { model.title.to_a.count }
+          .to eq 1
       end
     end
   end

--- a/spec/lib/tufts/changeset_preserve_strategy_spec.rb
+++ b/spec/lib/tufts/changeset_preserve_strategy_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Tufts::ChangesetPreserveStrategy do
 
       it 'applies the changes to empty field' do
         expect { strategy.apply }
-          .to change { model.title.to_a }
-          .to contain_exactly('moomin', 'moominmama', 'snork')
+          .to change { model.subject.to_a }
+          .to contain_exactly('too-ticky', 'snufkin')
       end
 
       it 'updates changed attributes' do
@@ -23,11 +23,11 @@ RSpec.describe Tufts::ChangesetPreserveStrategy do
       end
 
       it 'merges existing values' do
-        model.title = ['snufkin']
+        model.subject = ['hobgoblin']
 
         expect { strategy.apply }
-          .to change { model.title.to_a }
-          .to contain_exactly('moomin', 'moominmama', 'snork', 'snufkin')
+          .to change { model.subject.to_a }
+          .to contain_exactly('hobgoblin', 'too-ticky', 'snufkin')
       end
 
       it 'leaves existing values unchanged for fields not in the changeset' do
@@ -50,6 +50,20 @@ RSpec.describe Tufts::ChangesetPreserveStrategy do
         expect { strategy.apply }
           .not_to change { model.single_value }
           .from 'snufkin'
+      end
+
+      it 'applies one value to empty title field' do
+        expect { strategy.apply }
+          .to change { model.title.to_a.count }
+          .to eq 1
+      end
+
+      it 'retains the value in an existing title field' do
+        model.title = ['snufkin']
+
+        expect { strategy.apply }
+          .not_to change { model.title.to_a }
+          .from a_collection_containing_exactly('snufkin')
       end
     end
   end

--- a/spec/lib/tufts/draft_spec.rb
+++ b/spec/lib/tufts/draft_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe Tufts::Draft do
 
       it 'applies the changes' do
         expect { draft.apply }
-          .to change { model.title.to_a }
-          .to contain_exactly('moomin', 'moominmama', 'snork')
+          .to change { model.subject.to_a }
+          .to contain_exactly('too-ticky')
       end
 
       it 'updates changed attributes' do

--- a/spec/support/shared_examples/changeset_application_strategy.rb
+++ b/spec/support/shared_examples/changeset_application_strategy.rb
@@ -23,7 +23,7 @@ RSpec.shared_context 'strategy with changes' do
 
   let(:changeset) do
     new_model = FakeWork.new(title:        ['moomin', 'moominmama', 'snork'],
-                             subject:      ['too-ticky'],
+                             subject:      ['too-ticky', 'snufkin'],
                              single_value: 'moomin')
     ActiveFedora::ChangeSet
       .new(new_model, new_model.resource, new_model.changed_attributes.keys)


### PR DESCRIPTION
We have `:title` enforced as single valued via validations, but it is "multivalued" in configuration. This is an artifact of a larger issue with ActiveFedora's handling of "single values". This patch is a little hacky, but
the best we have in scope.