### PR TITLE
Remove text limits from contribution forms

### DIFF
--- a/app/models/forms/contribution.rb
+++ b/app/models/forms/contribution.rb
@@ -3,8 +3,8 @@ class Contribution
   include ActiveModel::Conversion
   extend ActiveModel::Naming
 
-  validates :title, presence: true, length: { maximum: 250 }
-  validates :description, presence: true, length: { maximum: 2000 }
+  validates :title, presence: true
+  validates :description, presence: true
   validates :creator, presence: true
   validates :attachment, presence: true
   validate  :attachment_has_valid_content_type

--- a/spec/features/undergrad_scholarship_contribute_spec.rb
+++ b/spec/features/undergrad_scholarship_contribute_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       attach_file('contribution_attachment', File.absolute_path(file_fixture('pdf-sample.pdf')))
       fill_in "Title", with: title
       fill_in "Contributor", with: depositing_user.display_name
-      fill_in "Short Description", with: FFaker::Lorem.paragraph
+      fill_in "Short Description", with: FFaker::Lorem.paragraphs + FFaker::Lorem.paragraphs
       click_button "Agree & Deposit"
       created_pdf = Pdf.last
       expect(created_pdf.title.first).to eq title


### PR DESCRIPTION
This removes the maximum character length on the contribute forms and changes the feature test to use around 4000 words of text. 

Closes #356 