### PR TITLE
Fix changeset application to avoid changing the model in place

### DIFF
--- a/app/lib/tufts/changeset_preserve_strategy.rb
+++ b/app/lib/tufts/changeset_preserve_strategy.rb
@@ -37,11 +37,11 @@ module Tufts
             values = statements.map(&:object).to_a
 
             if config.multiple?
-              values += model.public_send(property).to_a
               if config.term == :title
                 model.public_send("#{property}=".to_sym, [values.first]) if
                   model.public_send(property).empty?
               else
+                values += model.public_send(property).to_a
                 model.public_send("#{property}=".to_sym, values)
               end
             else

--- a/app/lib/tufts/changeset_serializer.rb
+++ b/app/lib/tufts/changeset_serializer.rb
@@ -53,12 +53,14 @@ module Tufts
       # @return [RDF::Graph]
       def changed_graph(statements, model)
         graph = model.resource.dup
+        graph.set_persistence_strategy(ActiveTriples::RepositoryStrategy)
+        graph.persistence_strategy.graph = model.resource.graph.dup
 
         grouped = statements.group_by do |statement|
           statement.subject.to_base + statement.predicate.to_base
         end
 
-        grouped.each do |_, sts|
+        grouped.each_value do |sts|
           graph.update(sts.pop)
           graph.insert(*sts)
         end

--- a/app/lib/tufts/template.rb
+++ b/app/lib/tufts/template.rb
@@ -73,6 +73,11 @@ module Tufts
     def apply_to(model:)
       changeset_for_model = load_with_model(model)
 
+      # ActiveTriples::RDFSource#dup isn't good enough to keep us to prevent
+      # changes from being applied, so we reload.
+      # @see https://github.com/ActiveTriples/ActiveTriples/issues/265
+      model.reload if model.persisted?
+
       Tufts::ChangesetApplicationStrategy
         .for(behavior, model: model, changeset: changeset_for_model)
         .apply


### PR DESCRIPTION
`ActiveFedora::Changeset` requires an entire `GenerateResourceSchema` object to
generate a `Changeset`. Our strategy in deserializing a SPARQL changeset to an
object is to dup the `GeneratedResourceSchema`, apply the changes, then generate
the changeset from that. However, `ActiveTriples::RDFSource#dup` isn't smart
enough to give us an independent working copy.

Pending a fix for https://github.com/ActiveTriples/ActiveTriples/issues/265, we
simply reload the original model after deserializing the changeset, but before
applying it. This gives us back our original data and avoids destroying data
unintentionally.