### PR TITLE
Readonly contributor on contribute forms

### DIFF
--- a/app/views/contribute/deposit_view/_capstone_project.html.erb
+++ b/app/views/contribute/deposit_view/_capstone_project.html.erb
@@ -6,7 +6,7 @@
 <% if @contribution.creator.nil? %>
    <% contributor = current_user.display_name  %>
 <% end %>
-<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true  %>
+<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true, readonly: 'readonly'  %>
 
 <%= f.select :degree, options_for_select(fletcher_degrees), {prompt: 'Please select a degree', label: 'Degree'}, {required: true} %>
 

--- a/app/views/contribute/deposit_view/_cummings_thesis.html.erb
+++ b/app/views/contribute/deposit_view/_cummings_thesis.html.erb
@@ -6,7 +6,7 @@
 <% if @contribution.creator.nil? %>
    <% contributor = current_user.display_name  %>
 <% end %>
-<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true  %>
+<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true, readonly: 'readonly'  %>
 
 
 <%= f.select :embargo_note, standard_embargos,  label: 'Embargo'  %>

--- a/app/views/contribute/deposit_view/_faculty_scholarship.html.erb
+++ b/app/views/contribute/deposit_view/_faculty_scholarship.html.erb
@@ -6,7 +6,7 @@
 <% if @contribution.creator.nil? %>
    <% contributor = current_user.display_name  %>
 <% end %>
-<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true  %>
+<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true, readonly: 'readonly' %>
 
 <%= f.text_field :bibliographic_citation, label: 'Bibliographic Citation', help_block: '<b>Optional</b> - the bibliographic citation field may be left blank'.html_safe %>
 

--- a/app/views/contribute/deposit_view/_generic_deposit.html.erb
+++ b/app/views/contribute/deposit_view/_generic_deposit.html.erb
@@ -6,7 +6,7 @@
 <% if @contribution.creator.nil? %>
    <% contributor = current_user.display_name  %>
 <% end %>
-<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true  %>
+<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true, readonly: 'readonly'  %>
 
 <%= f.select :embargo_note, standard_embargos,  label: 'Embargo'  %>
 

--- a/app/views/contribute/deposit_view/_generic_tisch_deposit.html.erb
+++ b/app/views/contribute/deposit_view/_generic_tisch_deposit.html.erb
@@ -6,6 +6,6 @@
 <% if @contribution.creator.nil? %>
    <% contributor = current_user.display_name  %>
 <% end %>
-<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true  %>
+<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true, readonly: 'readonly'   %>
 
 <%= f.text_area :description, label: 'Short Description', help_block: 'Please limit description to 2000 characters or less.', rows: 5, class: 'col-sm-8'  %>

--- a/app/views/contribute/deposit_view/_honors_thesis.html.erb
+++ b/app/views/contribute/deposit_view/_honors_thesis.html.erb
@@ -6,7 +6,7 @@
 <% if @contribution.creator.nil? %>
    <% contributor = current_user.display_name  %>
 <% end %>
-<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true  %>
+<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true, readonly: 'readonly'  %>
 
 <%= f.text_field :department, label: 'Department', 'data-autocomplete': '/authorities/search/local/departments'  %>
 

--- a/app/views/contribute/deposit_view/_qualifying_paper.html.erb
+++ b/app/views/contribute/deposit_view/_qualifying_paper.html.erb
@@ -6,7 +6,7 @@
 <% if @contribution.creator.nil? %>
    <% contributor = current_user.display_name  %>
 <% end %>
-<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true  %>
+<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true, readonly: 'readonly'  %>
 
 <%= f.select :embargo_note, standard_embargos,  label: 'Embargo'  %>
 

--- a/app/views/contribute/deposit_view/_undergrad_summer_scholar.html.erb
+++ b/app/views/contribute/deposit_view/_undergrad_summer_scholar.html.erb
@@ -6,6 +6,6 @@
 <% if @contribution.creator.nil? %>
    <% contributor = current_user.display_name  %>
 <% end %>
-<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true  %>
+<%= f.text_field :creator, label: 'Contributor', value: contributor, required: true, readonly: 'readonly' %>
 
 <%= f.text_area :description, label: 'Short Description', help_block: 'Please limit description to 2000 characters or less.', rows: 5, class: 'col-sm-8'  %>

--- a/spec/features/contribute/faculty_scholarship_contribute_spec.rb
+++ b/spec/features/contribute/faculty_scholarship_contribute_spec.rb
@@ -20,6 +20,8 @@ RSpec.feature 'Create a Faculty Scholarship self contribution', :clean, js: true
       Pdf.delete_all
       Hyrax::UploadedFile.delete_all
       login_as user
+      user.display_name = "     Name   with   Spaces    "
+      user.save
     end
 
     scenario "a new user contributes faculty scholarship" do
@@ -28,14 +30,13 @@ RSpec.feature 'Create a Faculty Scholarship self contribution', :clean, js: true
       click_button "Begin"
       attach_file('contribution_attachment', File.absolute_path(file_fixture('pdf-sample.pdf')))
       fill_in "Title", with: title
-      fill_in "Contributor", with: user.display_name
       fill_in "Bibliographic Citation", with: bibliographic_citation
       # fill_in "Other authors", with: other_author
       fill_in "Short Description", with: abstract
       click_button "Agree & Deposit"
       created_pdf = Pdf.last
       expect(created_pdf.title.first).to eq title
-      expect(created_pdf.contributor.first).to eq user.display_name
+      expect(created_pdf.contributor.first).to eq "Name with Spaces"
       expect(created_pdf.depositor).to eq user.user_key
       expect(created_pdf.admin_set.title.first).to eq "Default Admin Set"
       expect(created_pdf.active_workflow.name).to eq "mira_publication_workflow"
@@ -59,7 +60,6 @@ RSpec.feature 'Create a Faculty Scholarship self contribution', :clean, js: true
       click_button "Begin"
       attach_file('contribution_attachment', File.absolute_path(file_fixture('pdf-sample.pdf')))
       fill_in "Title", with: " Space   non normalized \n  title    "
-      fill_in "Contributor", with: " Name   with  Spaces "
       fill_in "Short Description", with: " A short   description    with  wonky spaces   "
       fill_in "Bibliographic Citation", with: " bibliographic   citation  \n with     spaces    "
       click_button "Agree & Deposit"

--- a/spec/features/contribute/faculty_scholarship_spec.rb
+++ b/spec/features/contribute/faculty_scholarship_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature 'submit a Faculty Scholarship contribution', js: true do
     click_button 'Begin'
     attach_file('PDF to upload', pdf_path)
     fill_in 'Title', with: FFaker::Book.title
-    fill_in 'Contributor', with: FFaker::Book.author
     fill_in 'Bibliographic Citation', with: FFaker::Book.title
     fill_in 'Short Description', with: FFaker::Book.description
     click_button 'Add Another Author'

--- a/spec/features/contribute/fletcher_school_capstone_contribute_spec.rb
+++ b/spec/features/contribute/fletcher_school_capstone_contribute_spec.rb
@@ -24,7 +24,6 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       click_button "Begin"
       attach_file('contribution_attachment', File.absolute_path(file_fixture('pdf-sample.pdf')))
       fill_in "Capstone Project Title", with: title
-      fill_in "Contributor", with: user.display_name
       select 'Master of Arts', from: 'contribution_degree'
       fill_in "Short Description", with: FFaker::Lorem.paragraph
       click_button "Agree & Deposit"

--- a/spec/features/contribute/fletcher_school_capstone_spec.rb
+++ b/spec/features/contribute/fletcher_school_capstone_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature 'submit a Fletcher School Capstone Project contribution' do
     click_button 'Begin'
     attach_file('PDF to upload', pdf_path)
     fill_in 'Capstone Project Title', with: FFaker::Book.title
-    fill_in 'Contributor', with: FFaker::Book.author
     select 'Master of Arts', from: 'Degree'
     fill_in 'Short Description', with: FFaker::Book.description
     click_button 'Agree & Deposit'

--- a/spec/features/contribute/general_undergrad_scholarship_spec.rb
+++ b/spec/features/contribute/general_undergrad_scholarship_spec.rb
@@ -17,8 +17,6 @@ RSpec.feature 'submit a General Undergraduate Scholarship contribution', js: tru
     click_button 'Begin'
     attach_file('PDF to upload', pdf_path)
     fill_in 'Title', with: FFaker::Book.title
-    fill_in 'Contributor', with: FFaker::Book.author
-
     fill_in 'Short Description', with: FFaker::Book.description
     click_button 'Agree & Deposit'
     expect(page).to have_content 'Your deposit has been submitted for approval.'

--- a/spec/features/contribute/graduate_school_arts_spec.rb
+++ b/spec/features/contribute/graduate_school_arts_spec.rb
@@ -17,8 +17,6 @@ RSpec.feature 'submit a Graduate School of Arts and Sciences Education Qualifyin
     click_button 'Begin'
     attach_file('PDF to upload', pdf_path)
     fill_in 'Title', with: FFaker::Book.title
-    fill_in 'Contributor', with: FFaker::Book.author
-
     fill_in 'Short Description', with: FFaker::Book.description
     click_button 'Agree & Deposit'
     expect(page).to have_content 'Your deposit has been submitted for approval.'

--- a/spec/features/contribute/masters_in_animal_and_public_spec.rb
+++ b/spec/features/contribute/masters_in_animal_and_public_spec.rb
@@ -17,8 +17,6 @@ RSpec.feature 'submit a Masters in Animal and Pubic Policy contribution' do
     click_button 'Begin'
     attach_file('PDF to upload', pdf_path)
     fill_in 'Title', with: FFaker::Book.title
-    fill_in 'Contributor', with: FFaker::Book.author
-
     fill_in 'Short Description', with: FFaker::Book.description
     click_button 'Agree & Deposit'
     expect(page).to have_content 'Your deposit has been submitted for approval.'

--- a/spec/features/contribute/phpd_capstone_spec.rb
+++ b/spec/features/contribute/phpd_capstone_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature 'submit a PHPD Field Experience/Capstone contribution' do
     click_button 'Begin'
     attach_file('PDF to upload', pdf_path)
     fill_in 'Capstone Project Title', with: FFaker::Book.title
-    fill_in 'Contributor', with: FFaker::Book.author
     select 'MPH', from: 'Degree'
     fill_in 'Short Description', with: FFaker::Book.description
     click_button 'Agree & Deposit'

--- a/spec/features/contribute/tish_library_reward_spec.rb
+++ b/spec/features/contribute/tish_library_reward_spec.rb
@@ -18,8 +18,6 @@ RSpec.feature 'submit a Tish Library Reward contribution' do
     click_button 'Begin'
     attach_file('PDF to upload', pdf_path)
     fill_in 'Title', with: FFaker::Book.title
-    fill_in 'Contributor', with: FFaker::Book.author
-
     fill_in 'Short Description', with: FFaker::Book.description
     click_button 'Agree & Deposit'
     expect(page).to have_content 'Your deposit has been submitted for approval.'

--- a/spec/features/contribute/undergrad_honors_thesis_spec.rb
+++ b/spec/features/contribute/undergrad_honors_thesis_spec.rb
@@ -21,7 +21,6 @@ RSpec.feature 'submit an Undergraduate Honors Thesis contribution', js: true do
     click_button 'Begin'
     attach_file('PDF to upload', pdf_path)
     fill_in 'Thesis title', with: FFaker::Book.title
-    fill_in 'Contributor', with: FFaker::Book.author
     fill_in "Short Description", with: short_description
 
     # Test department autocomplete

--- a/spec/features/contribute/undergrad_scholarship_contribute_spec.rb
+++ b/spec/features/contribute/undergrad_scholarship_contribute_spec.rb
@@ -26,7 +26,6 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       click_button "Begin"
       attach_file('contribution_attachment', File.absolute_path(file_fixture('pdf-sample.pdf')))
       fill_in "Title", with: title
-      fill_in "Contributor", with: depositing_user.display_name
       fill_in "Short Description", with: short_description
       click_button "Agree & Deposit"
       created_pdf = Pdf.last

--- a/spec/features/contribute/undergrad_summer_scholars_spec.rb
+++ b/spec/features/contribute/undergrad_summer_scholars_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature 'submit an Undergraduate Summer Scholars contribution' do
     click_button 'Begin'
     attach_file('PDF to upload', pdf_path)
     fill_in 'Title', with: FFaker::Book.title
-    fill_in 'Contributor', with: FFaker::Book.author
     fill_in 'Short Description', with: FFaker::Book.description
     click_button 'Agree & Deposit'
     expect(page).to have_content 'Your deposit has been submitted for approval.'


### PR DESCRIPTION
This makes the fields for contributor readonly on contribution forms the forms will use the `display_name` attribute of the current user. The feature specs have been updated so that they don't try to fill in the field, but use the `display_name` as well.

Closes #361 