### PR TITLE
Add UnpublishJob and button

### DIFF
--- a/app/jobs/unpublish_job.rb
+++ b/app/jobs/unpublish_job.rb
@@ -1,0 +1,21 @@
+##
+# A job to unpublish an object
+class UnpublishJob < BatchableJob
+  def perform(id)
+    work = ActiveFedora::Base.find(id)
+    subject = Hyrax::WorkflowActionInfo.new(work, workflow_user)
+    sipity_workflow_action = PowerConverter.convert_to_sipity_action("unpublish", scope: subject.entity.workflow) { nil }
+    Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Unpublished by #{workflow_user.display_name} #{Time.zone.now}")
+  end
+
+  # The workflow needs the action to be performed by a user with admin rights
+  # @return [::User] an admin user to perform the batch publish operation
+  def workflow_user
+    ::User.find_or_create_by(email: 'batch_workflow_user@example.com') do |user|
+      user.display_name = "Batch Publish Job"
+      user.password = SecureRandom.uuid
+      admin_role = Role.where(name: 'admin').first_or_create
+      user.roles << admin_role
+    end
+  end
+end

--- a/app/models/batch_task.rb
+++ b/app/models/batch_task.rb
@@ -13,7 +13,10 @@ class BatchTask < ApplicationRecord
   #   @return [String]
   has_one :batch, as: :batchable
 
-  BATCH_TYPES = { publish: PublishJob }.freeze
+  BATCH_TYPES = {
+    publish: PublishJob,
+    unpublish: UnpublishJob
+  }.freeze
 
   validates :batch_type,
             inclusion: { in: BATCH_TYPES.keys.map { |t| t.capitalize.to_s } }

--- a/app/views/catalog/_batch_header.html.erb
+++ b/app/views/catalog/_batch_header.html.erb
@@ -9,6 +9,9 @@
     <%= button_to "Publish", batches_path, method: :post, params: { batch: { batchable_attributes: { batch_type: "Publish" } } }, class: "btn btn-primary submits-batches" %>
   </li>
   <li>
+    <%= button_to "Unpublish", batches_path, method: :post, params: { batch: { batchable_attributes: { batch_type: "Unpublish" } } }, class: "btn btn-primary submits-batches" %>
+  </li>
+  <li>
     <%= button_to "Export Metadata", metadata_exports_path, method: :post, class: "btn btn-primary submits-batches" %>
   </li>
   <li class="selected-documents">

--- a/spec/jobs/unpublish_job_spec.rb
+++ b/spec/jobs/unpublish_job_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe UnpublishJob, :workflow, type: :job do
+  subject(:job) { described_class }
+  let(:pdf) { FactoryGirl.create(:pdf) }
+
+  describe '#perform_later' do
+    it 'enqueues the job' do
+      ActiveJob::Base.queue_adapter = :test
+      expect { job.perform_later(pdf.id) }
+        .to enqueue_job(described_class)
+        .with(pdf.id)
+        .on_queue('batch')
+    end
+  end
+
+  describe '#workflow_user' do
+    it "finds or creates an admin user who can perform the workflow action" do
+      user = job.new.workflow_user
+      expect(user.user_key).to eq "batch_workflow_user@example.com"
+      expect(user.admin?).to eq true
+    end
+  end
+
+  context "workflow transition" do
+    let(:work) { FactoryGirl.create(:pdf) }
+    let(:depositing_user) { FactoryGirl.create(:user) }
+    before do
+      allow(CharacterizeJob).to receive(:perform_later) # Don't run fits
+      current_ability = ::Ability.new(depositing_user)
+      attributes = {}
+      env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
+      Hyrax::CurationConcern.actor.create(env)
+    end
+    it 'sets the workflow status to published' do
+      PublishJob.perform_now(work.id)
+      expect(work.to_sipity_entity.reload.workflow_state_name).to eq "published"
+      job.perform_now(work.id)
+      expect(work.to_sipity_entity.reload.workflow_state_name).to eq "unpublished"
+    end
+  end
+end


### PR DESCRIPTION
Closes #341 

@no-reply Take a look, please? I know it's not ideal to repeat so much code between PublishJob and UnpublishJob, but I also know we're under deadline and I'm thinking of Sandi saying just get it working the first time and then refactor when you need to. 

Does this look okay for now? Ideally I'd refactor so they were the same job, or at least drew from a common library, but this does work.