### PR TITLE
Don't show empty attributes on show page

### DIFF
--- a/app/lib/tufts/terms.rb
+++ b/app/lib/tufts/terms.rb
@@ -2,7 +2,7 @@ module Tufts
   class Terms
     SHARED_TERMS = [:displays_in, :geographic_name, :held_by, :alternative_title,
                     :abstract, :table_of_contents, :primary_date, :date_accepted,
-                    :date_available, :date_copyrighted, :date_issued, :steward, :created_by,
+                    :date_available, :date_copyrighted, :date_issued, :steward,
                     :internal_note, :audience, :embargo_note, :end_date, :accrual_policy,
                     :rights_note, :resource_type,
                     :bibliographic_citation, :rights_holder, :format_label, :replaces, :is_replaced_by,

--- a/app/models/concerns/tufts/metadata/adminstrative.rb
+++ b/app/models/concerns/tufts/metadata/adminstrative.rb
@@ -12,9 +12,6 @@ module Tufts
         property :steward, predicate: ::Tufts::Vocab::Terms.steward, multiple: false do |index|
           index.as :stored_searchable
         end
-        property :created_by, predicate: ::Tufts::Vocab::Terms.created_by, multiple: false do |index|
-          index.as :stored_searchable
-        end
         property :internal_note, predicate: ::Tufts::Vocab::Terms.internal_note, multiple: false do |index|
           index.as :stored_searchable
         end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,5 +1,8 @@
 <% Tufts::Terms.shared_terms.each do |term| %>
-<%= presenter.attribute_to_html(term) %>
+  <% presenter_value = presenter.send(term) %>
+  <% unless presenter_value.nil? || presenter_value.empty? || presenter_value == [''] %>
+  <%= presenter.attribute_to_html(term) %>
+  <% end %>
 <% end %>
 
 <%= presenter.attribute_to_html(:creator, render_as: :faceted) %>

--- a/spec/controllers/tufts/draft_controller_spec.rb
+++ b/spec/controllers/tufts/draft_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Tufts::DraftController, type: :controller do
                                                                "related_url" => [""], "source" => [""], "geographic_name" => [""], "held_by" => [""],
                                                                "alternative_title" => [""], "abstract" => [""], "table_of_contents" => [""],
                                                                "primary_date" => [""], "date_accepted" => [""], "date_available" => [""],
-                                                               "date_copyrighted" => [""], "date_issued" => [""], "steward" => "", "created_by" => "",
+                                                               "date_copyrighted" => [""], "date_issued" => [""], "steward" => "",
                                                                "internal_note" => "", "audience" => "", "embargo_note" => "", "end_date" => "",
                                                                "accrual_policy" => "", "rights_note" => "", "resource_type" => [""],
                                                                "admin_set_id" => "admin_set/default", "member_of_collection_ids" => [""],

--- a/spec/support/shared_examples/admin_metadata.rb
+++ b/spec/support/shared_examples/admin_metadata.rb
@@ -24,11 +24,6 @@ shared_examples 'and has admin metadata attributes' do
     expect(work.resource.dump(:ttl)).to match(/dl.tufts.edu\/terms#steward/)
   end
 
-  it 'has created_by' do
-    work.created_by = 'an individual'
-    expect(work.resource.dump(:ttl)).to match(/dl.tufts.edu\/terms#createdBy/)
-  end
-
   it 'has internal_note' do
     work.internal_note = 'An internal note'
     expect(work.resource.dump(:ttl))

--- a/spec/support/shared_examples/metadata_form.rb
+++ b/spec/support/shared_examples/metadata_form.rb
@@ -10,7 +10,7 @@ shared_examples 'a form with Tufts metadata attributes' do
         .to include(:displays_in, :geographic_name, :held_by,
                     :alternative_title, :abstract, :table_of_contents,
                     :primary_date, :date_accepted, :date_available,
-                    :date_copyrighted, :date_issued, :steward, :created_by,
+                    :date_copyrighted, :date_issued, :steward,
                     :internal_note, :audience, :embargo_note, :end_date,
                     :accrual_policy, :tufts_license, :rights_note, :resource_type,
                     :bibliographic_citation, :rights_holder, :format_label,
@@ -20,7 +20,7 @@ shared_examples 'a form with Tufts metadata attributes' do
 
     it 'has Tufts admin terms' do
       expect(form.terms)
-        .to include(:steward, :created_by, :internal_note, :audience, :end_date,
+        .to include(:steward, :internal_note, :audience, :end_date,
                     :accrual_policy, :tufts_license, :retention_period,
                     :admin_start_date, :qr_status, :rejection_reason, :qr_note,
                     :creator_department, :legacy_pid, :personal_name,

--- a/spec/support/shared_examples/tufts_presenter.rb
+++ b/spec/support/shared_examples/tufts_presenter.rb
@@ -33,7 +33,6 @@ shared_examples 'a Tufts presenter' do
 
   describe "with admin attributes that are delegated to Solr" do
     it { is_expected.to delegate_method(:steward).to(:solr_document) }
-    it { is_expected.to delegate_method(:created_by).to(:solr_document) }
     it { is_expected.to delegate_method(:internal_note).to(:solr_document) }
     it { is_expected.to delegate_method(:audience).to(:solr_document) }
     it { is_expected.to delegate_method(:end_date).to(:solr_document) }


### PR DESCRIPTION
@tom these empty-ish values that I talked about earlier today aren't being persisted in Fedora, but are generated by the presenter depending on the type. 
 
Closes #331 
