### PR TITLE
Use Datatables for the Deposit Type index page

### DIFF
--- a/app/views/deposit_types/index.html.erb
+++ b/app/views/deposit_types/index.html.erb
@@ -1,14 +1,16 @@
 <h1>Manage Deposit Types</h1>
 <div class='clear'></div>
 
-<table>
+<table id="deposit-types">
+  <thead>
   <tr>
     <th> Type </th>
     <th> View </th>
     <th> License </th>
     <th> Agreement </th>
   </tr>
-
+  </thead>
+  <tbody>
   <% @deposit_types.each do |deposit_type| %>
     <tr>
       <td class='display_name'> <%= link_to deposit_type.display_name, deposit_type_path(deposit_type) %> </td>
@@ -16,8 +18,11 @@
       <td class='license_name'> <%= deposit_type.license_name %> </td>
       <td class='deposit_agreement'> <%= truncate(deposit_type.deposit_agreement, length: 60) %> </td>
     </tr>
-  <% end %>
+    <% end %>
+  </tbody>
 </table>
-
+<script>
+  $('#deposit-types').DataTable()
+</script>
 <p><%= link_to 'Add a New Deposit Type', new_deposit_type_path, class: 'btn btn-primary' %></p>
 <p><%= link_to 'Export Deposit Type Data', export_deposit_types_path, class: 'btn float-right' %></p>


### PR DESCRIPTION
 This commit adds DataTables to the Deposit Types index page. It comes with Hyrax so we just need to turn it on for this table. It enables searching and sorting for the list of types.

<img width="1129" alt="screen shot 2017-10-11 at 4 21 04 pm" src="https://user-images.githubusercontent.com/4324761/31464953-8df2cd9c-aea0-11e7-885e-7f9a71a8bf01.png">
