### PR TITLE
Change location of derivatives in production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,3 +89,5 @@ Rails.application.configure do
   config.exports_storage_dir   = Rails.root.join('tmp', 'exports')
   config.templates_storage_dir = Rails.root.join('tmp', 'templates')
 end
+
+Hyrax.config.derivatives_path = '/opt/derivatives'


### PR DESCRIPTION
Usually the derivatives setting is in `config\initializers\hyrax.rb` but making a change to that requires making a local copy on the production server that's treated as a shared file by Capistano.

Making this setting in `config/environments/production.rb` minimizes the footprint of the change and lets us manage it in the code repository instead of having to manually craft a file on the server.