### PR TITLE
Delete blacklight saved searches nightly so they don't fill up our da…

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -39,3 +39,7 @@ require "capistrano/sidekiq"
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
 
 require 'capistrano/honeybadger'
+
+# use whenever to manage cron jobs
+set :whenever_command, "bundle exec whenever"
+require "whenever/capistrano"

--- a/Gemfile
+++ b/Gemfile
@@ -34,9 +34,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
+gem 'whenever', require: false
 
 group :production, :development do
   gem 'honeybadger', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -599,6 +599,7 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
+    chronic (0.10.2)
     clipboard-rails (1.7.1)
     cliver (0.3.2)
     coffee-rails (4.2.2)
@@ -1249,6 +1250,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.9.7)
+      chronic (>= 0.6.3)
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
@@ -1303,6 +1306,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  whenever
 
 BUNDLED WITH
    1.15.4

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,25 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+# Delete blacklight saved searches
+every :day, at: '11:55pm' do
+  rake "blacklight:delete_old_searches[1]"
+end


### PR DESCRIPTION
…tabase

I test deployed this, and it worked as expected. The crontab now includes:

```
# Begin Whenever generated tasks for: epigaea
55 23 * * * /bin/bash -l -c 'cd /opt/epigaea/releases/20171012194211 && RAILS_ENV=production bundle exec rake blacklight:delete_old_searches[1] --silent'

# End Whenever generated tasks for: epigaea
```