### PR TITLE
Search the catalog from dashboard

### DIFF
--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -2,4 +2,5 @@ module HyraxHelper
   include ::BlacklightHelper
   include Hyrax::BlacklightOverride
   include Hyrax::HyraxHelperBehavior
+  include Tufts::TuftsHelperBehavior
 end

--- a/app/helpers/tufts/tufts_helper_behavior.rb
+++ b/app/helpers/tufts/tufts_helper_behavior.rb
@@ -1,0 +1,8 @@
+module Tufts
+  module TuftsHelperBehavior
+    # @return [String] only search the catalog, not dashboard
+    def search_form_action
+      main_app.search_catalog_path
+    end
+  end
+end

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+def new_state
+  Blacklight::SearchState.new({}, CatalogController.blacklight_config)
+end
+
+RSpec.describe HyraxHelper, type: :helper do
+  describe "#search_form_action" do
+    context "when the user is not in the dashboard" do
+      it "returns the catalog index path" do
+        allow(helper).to receive(:params).and_return(controller: "foo")
+        expect(helper.search_form_action).to eq(search_catalog_path)
+      end
+    end
+
+    context "when the user is on the dashboard page" do
+      it "returns the catalog index path not the works path" do
+        allow(helper).to receive(:params).and_return(controller: "hyrax/dashboard")
+        expect(helper.search_form_action).to eq(search_catalog_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #432 

Add our own helper method for specifying the action of the search form. The default helper method searches the dashboard when on the dashboard, but we want to be able to search the catalog from the dashboard.