### PR TITLE
Add contact language to all self-deposit forms

### DIFF
--- a/app/assets/stylesheets/tufts.scss
+++ b/app/assets/stylesheets/tufts.scss
@@ -180,7 +180,14 @@ body.dashboard > div#content-wrapper {
             display: inline-block;
         }
     }
+
+  #deposit-questions {
+    margin-top: 3em;
+    background-color: #CEDCE7;
+  }
 }
+
+
 
 /* ------------------------
  *  FOOTER

--- a/app/views/contribute/deposit_view/_capstone_project.html.erb
+++ b/app/views/contribute/deposit_view/_capstone_project.html.erb
@@ -15,8 +15,3 @@
 <span class="help-block">An embargo will restrict all access to your work until the selected time has passed.</span>
 
 <%= f.text_area :description, label: 'Short Description', help_block: 'Please limit description to 2000 characters or less.', rows: 5, class: 'col-sm-8'  %>
-
-<div class='well'>Technical questions? <a target="_blank" href="http://dca.tufts.edu/contact/">Contact DCA</a>.
-  Other questions? <a target="_blank"href="http://www.library.tufts.edu/ginn/forms/forms.aspx?form=department&department=Reference">
-  Contact Ginn Library</a>.</div>
-<div class='clearfix'></div>

--- a/app/views/contribute/new.html.erb
+++ b/app/views/contribute/new.html.erb
@@ -11,28 +11,37 @@
     <% end %>
 
     <% if @deposit_type.deposit_view == 'gis_poster' %>
-    <div class="well contribute-file-upload">
-      <%= f.file_field :attachment, label: 'PDF to upload', accept: 'application/pdf', required: 'required'%>
-    </div>
-    <% else %>
-    <div class="well contribute-file-upload">
-      <%= f.file_field :attachment, label: 'PDF to upload', accept: 'application/pdf', html: { class: 'well' } %>
-    </div>
+      <div class="well contribute-file-upload">
+        <%= f.file_field :attachment, label: 'PDF to upload', accept: 'application/pdf', required: 'required'%>
+      </div>
+      <% else %>
+      <div class="well contribute-file-upload">
+        <%= f.file_field :attachment, label: 'PDF to upload', accept: 'application/pdf', html: { class: 'well' } %>
+      </div>
     <% end %>
     <%= render "contribute/deposit_view/#{@deposit_type.deposit_view}", :f => f  %>
     <%= hidden_field_tag 'deposit_type', @deposit_type.id %>
+
     <div class="well">
-    <h4>Deposit Agreement</h4>
-    <p><%= raw @deposit_type.deposit_agreement %></p>
+      <h4>Deposit Agreement</h4>
+      <p><%= raw @deposit_type.deposit_agreement %></p>
     </div>
+
     <ul>
       <li>
         <%= f.submit 'Agree & Deposit', class: 'btn btn-primary' %>
       </li>
       <li>
-        <%= link_to 'Cancel', contributions_path,  class: 'btn btn-warning' %>
+        <%= link_to 'Cancel', contributions_path,  class: 'btn btn btn-default' %>
       </li>
     </ul>
+
+    <div class='well' id='deposit-questions'>
+      Technical questions? <a target="_blank" href="http://dca.tufts.edu/contact/">Contact DCA</a>.
+      Other questions? <a target="_blank"href="http://www.library.tufts.edu/ginn/forms/forms.aspx?form=department&department=Reference">Contact Ginn Library</a>.
+    </div>
+    <div class='clearfix'></div>
+
 
 <% end %>
 </div>


### PR DESCRIPTION
Fixes #471

Moves the contact language from the capstone_project partial to the new contribution form so it shows up on all deposit types.