### PR TITLE
Add support for update via Metadata Import

### DIFF
--- a/app/controllers/hyrax/metadata_imports_controller.rb
+++ b/app/controllers/hyrax/metadata_imports_controller.rb
@@ -1,0 +1,29 @@
+class Hyrax::MetadataImportsController < ApplicationController
+  def new
+    @import = MetadataImport.new
+  end
+
+  def create
+    import = MetadataImport.new(import_params)
+    if import.save # upload the file
+      import.update!(batch: Batch.create(batchable: import,
+                                         creator:   current_user,
+                                         ids:       import.ids.to_a))
+      import.batch.enqueue!
+      redirect_to main_app.batches_path(import.batch)
+    else
+      messages = import.errors.messages[:base].join("\n")
+      flash.alert = " Errors were found in #{@import.metadata_file.filename}:" \
+                    "\n#{messages}"
+      redirect_to main_app.new_metadata_import_path
+    end
+  end
+
+  private
+
+    ##
+    # @private
+    def import_params
+      params.require(:metadata_import).permit(:metadata_file)
+    end
+end

--- a/app/jobs/metadata_import_job.rb
+++ b/app/jobs/metadata_import_job.rb
@@ -1,0 +1,7 @@
+##
+# A job that imports metadata to overwrite existing objects.
+class MetadataImportJob < BatchableJob
+  def perform(import, id)
+    Tufts::MetadataImportService.update_object!(import: import, object_id: id)
+  end
+end

--- a/app/lib/tufts/import_record.rb
+++ b/app/lib/tufts/import_record.rb
@@ -13,27 +13,118 @@ module Tufts
   #
   class ImportRecord
     ##
+    # @!attribute mapping [rw]
+    #   @return [MiraXmlMapping]
+    # @!attribute metadata [rw]
+    #   @return [Nokogiri::XML::Node, nil]
     # @!attribute file [rw]
     #   @return [String]
-    # @!attribute title [rw]
-    #   @return [String]
-    attr_accessor :file, :title
+    attr_accessor :mapping, :metadata
+    attr_writer   :file
 
     ##
-    # @param file [String]
-    def initialize(file: '')
-      @file = file
+    # @param metadata [Nokogiri::XML::Node, nil]
+    def initialize(metadata: nil, mapping: MiraXmlMapping.new)
+      @mapping  = mapping
+      @metadata = metadata
+    end
+
+    ##
+    # @return [String, nil]
+    def id
+      return nil if metadata.nil?
+
+      metadata.xpath('./tufts:id', mapping.namespaces)
+              .children.map(&:content).first
+    end
+
+    ##
+    # @return [Class] The model given by model:hasModel; GenericObject if none.
+    def object_class
+      return GenericObject if metadata.nil?
+
+      name = metadata.xpath('./model:hasModel', mapping.namespaces).children.first
+
+      name ? name.content.constantize : GenericObject
+    end
+
+    ##
+    # @return [String]
+    def file
+      return '' if metadata.nil?
+
+      metadata.xpath('./tufts:filename', mapping.namespaces)
+              .children.map(&:content).first || ''
+    end
+
+    ##
+    # @return [String]
+    def title
+      return file if metadata.nil?
+
+      @title ||=
+        metadata.xpath('./dc:title', mapping.namespaces)
+                .children.map(&:content).first || file
     end
 
     ##
     # @return [ActiveFedora::Core] a tufts model
-    def build_object(id: nil)
+    def build_object(id: self.id)
       visibility =
         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
-      GenericObject.new(id:         id,
-                        title:      Array.wrap(title),
-                        visibility: visibility)
+      attributes = fields.each_with_object({}) do |field, attrs|
+        attrs[field.first] = field.last
+      end
+
+      return object_class.new(visibility: visibility, **attributes) unless id
+
+      begin
+        object = object_class.find(id)
+        object.assign_attributes(attributes)
+        object
+      rescue ActiveFedora::ObjectNotFoundError
+        object_class.new(id: id, visibility: visibility, **attributes)
+      end
     end
+
+    def fields
+      return [].to_enum        unless metadata
+      return enum_for(:fields) unless block_given?
+
+      mapping.map do |field|
+        case field.property
+        when :title
+          yield [:title, Array.wrap(title)]
+        when :id, :has_model, :create_date, :modified_date, :head, :tail
+          next
+        else
+          values = values_for(field: field)
+          next unless values
+          yield [field.property, values]
+        end
+      end
+    end
+
+    private
+
+      def singular_properties
+        @singular_properties =
+          GenericObject
+          .properties.select { |_, cf| cf.try(:multiple?) == false }
+          .keys.map(&:to_sym)
+      end
+
+      def values_for(field:)
+        values =
+          metadata
+          .xpath("./#{field.namespace}:#{field.name}", @mapping.namespaces)
+          .children
+        return nil if values.empty?
+
+        values = values.map(&:content)
+        values = values.first if singular_properties.include?(field.property)
+        values
+      end
   end
 end

--- a/app/lib/tufts/mira_xml_mapping.rb
+++ b/app/lib/tufts/mira_xml_mapping.rb
@@ -14,8 +14,8 @@ module Tufts
     #
     Field = Struct.new(:namespace, :name, :property, :filter)
 
-    PROPERTIES    = GenericObject.properties.values.freeze
-    FILTERS       = { title: Proc.new(&:first) }.freeze
+    PROPERTIES = GenericObject.properties.values.freeze
+    FILTERS    = { title: Proc.new(&:first) }.freeze
 
     ##
     # @yield Yields each field in the mapped object

--- a/app/models/metadata_import.rb
+++ b/app/models/metadata_import.rb
@@ -1,0 +1,61 @@
+class MetadataImport < ApplicationRecord
+  ##
+  # @!attribute metadata_file [rw]
+  #   The uploaded metadata file.
+  #
+  #   Set with `import.metadata_file = File.open('path/to/file')`
+  #
+  #   @return [Tufts::MetadataFileUploader]
+  #   @see CarrierWave::Uploader::Base
+  mount_uploader :metadata_file, Tufts::MetadataFileUploader
+
+  ##
+  # @!attribute batch [rw]
+  #   @return [Batch]
+  has_one :batch, as: :batchable
+
+  TYPE_STRING = 'Metadata Import'.freeze
+
+  ##
+  # @!method record?
+  #   @see Tufts::Importer#has_record?
+  # @!method record_for
+  #   @see Tufts::Importer#record_for
+  # @!method records
+  #   @see Tufts::Importer#records
+  delegate :record?, :record_for, :records, to: :parser
+
+  ##
+  # @!attribute [w] parser
+  #   @return [Tufts::MiraXmlImporter]
+  attr_writer :parser
+
+  ##
+  # @return [String]
+  def batch_type
+    TYPE_STRING
+  end
+
+  ##
+  # @return [Hash<String, String>]
+  def enqueue!
+    records.each_with_object({}) do |record, hsh|
+      id      = record.id
+      hsh[id] = MetadataImportJob.perform_later(self, id).job_id
+    end
+  end
+
+  ##
+  # @return [Enumerable<String>]
+  def ids
+    records.map(&:id)
+  end
+
+  ##
+  # @private
+  #
+  # @return [Tufts::Importer]
+  def parser
+    @parser ||= Tufts::MiraXmlImporter.new(file: metadata_file.file)
+  end
+end

--- a/app/models/xml_import.rb
+++ b/app/models/xml_import.rb
@@ -1,9 +1,12 @@
 class XmlImport < ApplicationRecord
   ##
   # @!attribute metadata_file [rw]
+  #   The uploaded metadata file.
+  #
+  #   Set with `import.metadata_file = File.open('path/to/file')`
+  #
   #   @return [Tufts::MetadataFileUploader]
   #   @see CarrierWave::Uploader::Base
-  #   @note Set with `import.metadata_file = File.open('path/to/file')`
   mount_uploader :metadata_file, Tufts::MetadataFileUploader
 
   validates :metadata_file, presence: true

--- a/app/services/tufts/import_service.rb
+++ b/app/services/tufts/import_service.rb
@@ -4,7 +4,9 @@ module Tufts
   # `Hyrax::UploadedFile` and an associated `XmlImport`.
   #
   # @example
-  #   ImportService.new
+  #   ImportService.import_object!(import:    my_import,
+  #                                file:      import_file,
+  #                                object_id: 'a_fedora_id')
   class ImportService
     ##
     # @!attribute file [rw]

--- a/app/services/tufts/metadata_import_service.rb
+++ b/app/services/tufts/metadata_import_service.rb
@@ -1,0 +1,43 @@
+module Tufts
+  ##
+  # A service for updating a persistent resource based on a `MetadataImport`.
+  #
+  # @example
+  #   Tufts::MetadataImportService.import_object!(import:    import,
+  #                                               object_id: object)
+  class MetadataImportService
+    ##
+    # @!attribute import [rw]
+    #   @return [XmlImport]
+    # @!attribute object_id [rw]
+    #   @return [String]
+    attr_accessor :import, :object_id
+
+    ##
+    # @param import    [MetadataImport]
+    # @param object_id [String]
+    #
+    # @return [ActiveFedora::Core]
+    # @see #update_object!
+    def self.update_object!(import:, object_id:)
+      new(import: import, object_id: object_id).update_object!
+    end
+
+    ##
+    # @param import    [MetadataImport]
+    # @param object_id [String]
+    def initialize(import:, object_id:)
+      @import    = import
+      @object_id = object_id
+    end
+
+    ##
+    # Updates the object
+    #
+    # @return [ActiveFedora::Core]
+    def update_object!
+      object = import.record_for(id: object_id).build_object
+      object.save!
+    end
+  end
+end

--- a/app/views/hyrax/metadata_imports/new.html.erb
+++ b/app/views/hyrax/metadata_imports/new.html.erb
@@ -1,0 +1,17 @@
+<h1>Raw Metadata Batch Replacement</h1>
+
+<%= form_for [main_app, @import] do |f| %>
+  <% if @import.errors[:base].present? %>
+    <div class="alert alert-danger">
+      <h4>There were errors that prevented this batch metadata import from being saved:</h4>
+      <ul>
+        <% @import.errors[:base].each do |error| %>
+          <li><%= error %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= f.file_field :metadata_file, id: 'metadata_file' %>
+  <%= f.submit 'Next' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,9 @@ Rails.application.routes.draw do
   resources :metadata_exports,
             controller: 'hyrax/metadata_exports',
             only:       [:create]
+  resources :metadata_imports,
+            controller: 'hyrax/metadata_imports',
+            only:       [:new, :create]
   resources :xml_imports,
             controller: 'hyrax/xml_imports',
             only:       [:show, :create, :new, :edit, :update]

--- a/db/migrate/20171009170516_create_metadata_imports.rb
+++ b/db/migrate/20171009170516_create_metadata_imports.rb
@@ -1,0 +1,8 @@
+class CreateMetadataImports < ActiveRecord::Migration[5.0]
+  def change
+    create_table :metadata_imports do |t|
+      t.string :metadata_file
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171003153633) do
+ActiveRecord::Schema.define(version: 20171009170516) do
 
   create_table "batch_tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "batch_type"
@@ -202,6 +202,12 @@ ActiveRecord::Schema.define(version: 20171003153633) do
     t.string   "filename"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "metadata_imports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "metadata_file"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
   create_table "minter_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/controllers/hyrax/metadata_imports_controller_spec.rb
+++ b/spec/controllers/hyrax/metadata_imports_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::MetadataImportsController, type: :controller do
+  let(:import) { FactoryGirl.create(:metadata_import) }
+
+  context 'as admin' do
+    include_context 'as admin'
+
+    describe 'GET #new' do
+      it 'renders the form' do
+        get :new
+        expect(response).to render_template :new
+      end
+    end
+
+    describe 'POST #create' do
+      let(:file_upload) { fixture_file_upload('files/mira_export.xml') }
+      let(:params)      { { metadata_import: { metadata_file: file_upload } } }
+
+      before { ActiveJob::Base.queue_adapter = :test }
+
+      it 'enqueues jobs for items in file' do
+        expect { post :create, params: params }
+          .to enqueue_job(MetadataImportJob)
+          .exactly(5).times
+      end
+    end
+  end
+end

--- a/spec/factories/metadata_imports.rb
+++ b/spec/factories/metadata_imports.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :metadata_import do
+    batch
+    metadata_file File.open('spec/fixtures/files/mira_export.xml')
+  end
+end

--- a/spec/features/metadata_import_spec.rb
+++ b/spec/features/metadata_import_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Import Metadata', :clean, js: true, batch: true do
+  let(:file)     { file_fixture('mira_export.xml') }
+  let!(:objects) { FactoryGirl.create_list(:pdf, 2) }
+  let(:object)   { objects.first }
+  let(:other)    { objects[1] }
+
+  before { ActiveJob::Base.queue_adapter = :test }
+
+  context 'as admin' do
+    let(:user) { FactoryGirl.create(:admin) }
+
+    before { login_as user }
+
+    scenario 'import metadata from file' do
+      visit '/metadata_imports/new'
+
+      attach_file 'metadata_file', file
+
+      expect { click_button 'Next' }
+        .to enqueue_job(MetadataImportJob)
+        .exactly(5).times
+
+      expect(page).to have_content 'Batch'
+    end
+  end
+end

--- a/spec/fixtures/files/mira_export_invalid.xml
+++ b/spec/fixtures/files/mira_export_invalid.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+</OAI-PMH>

--- a/spec/fixtures/files/mira_xml.xml
+++ b/spec/fixtures/files/mira_xml.xml
@@ -22,10 +22,13 @@ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
                      xmlns:dcadesc="http://nils.lib.tufts.edu/dcadesc/"
                      xmlns:dcatech="http://nils.lib.tufts.edu/dcatech/"
                      xmlns:dcterms="http://purl.org/dc/terms/"
+                     xmlns:model="info:fedora/fedora-system:def/model#"
+                     xmlns:terms="http://dl.tufts.edu/terms#"
                      xmlns:admin="http://nils.lib.tufts.edu/dcaadmin/"
                      xmlns:xlink="http://www.w3.org/TR/xlink">
-          <dcterms:source>pdf-sample.pdf</dcterms:source>
-          <dc:title>President Jean Mayer speaking at commencement, 1987</dc:title>
+          <terms:filename>pdf-sample.pdf</terms:filename>
+          <model:hasModel>Pdf</model:hasModel>
+          <dcterms:title>President Jean Mayer speaking at commencement, 1987</dcterms:title>
           <dc:description>5x7</dc:description>
           <dc:source>UA136</dc:source>
           <dc:coverage>Medford;7014023;42.417;-71.100</dc:coverage>
@@ -70,9 +73,12 @@ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
                      xmlns:dcadesc="http://nils.lib.tufts.edu/dcadesc/"
                      xmlns:dcatech="http://nils.lib.tufts.edu/dcatech/"
                      xmlns:dcterms="http://purl.org/dc/terms/"
+                     xmlns:model="info:fedora/fedora-system:def/model#"
+                     xmlns:terms="http://dl.tufts.edu/terms#"
                      xmlns:admin="http://nils.lib.tufts.edu/dcaadmin/"
                      xmlns:xlink="http://www.w3.org/TR/xlink">
-          <dcterms:source>2.pdf</dcterms:source>
+          <terms:filename>2.pdf</terms:filename>
+          <model:hasModel>Pdf</model:hasModel>
           <dc:title>President Jean Mayer speaking at commencement, 1988</dc:title>
           <dc:description>5x7</dc:description>
           <dc:source>UA136</dc:source>

--- a/spec/jobs/metadata_import_job_spec.rb
+++ b/spec/jobs/metadata_import_job_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe MetadataImportJob, type: :job do
+  subject(:job) { described_class }
+
+  it_behaves_like 'an ActiveJob job'
+
+  describe '#perform' do
+    let(:id)      { import.ids.first }
+    let(:import)  { FactoryGirl.create(:metadata_import) }
+    let!(:object) { FactoryGirl.create(:populated_pdf, id: id, title: old) }
+    let(:old)     { ['Old Title Data'] }
+
+    it 'updates the metadata' do
+      expect { job.perform_now(import, id) }
+        .to change { object.reload.title }
+        .from(old)
+        .to contain_exactly('I Married a Electric Ninjas')
+    end
+  end
+end

--- a/spec/lib/tufts/mira_xml_mapping_spec.rb
+++ b/spec/lib/tufts/mira_xml_mapping_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 RSpec.describe Tufts::MiraXmlMapping do

--- a/spec/models/metadata_import_spec.rb
+++ b/spec/models/metadata_import_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe MetadataImport, type: :model do
+  subject(:batchable) { FactoryGirl.create(:metadata_import) }
+
+  it_behaves_like 'a batchable' do
+    let(:parser) { parser_class.new(ids: ids) }
+
+    # rubocop:disable RSpec/InstanceVariable
+    let(:parser_class) do
+      Class.new do
+        def initialize(ids:)
+          @ids = ids
+        end
+
+        def records
+          @ids.map { |id| ImportRecord.new(id: id) }
+        end
+
+        class ImportRecord
+          attr_accessor :id
+
+          def initialize(id: '')
+            @id = id
+          end
+        end
+      end
+    end
+
+    before { batchable.parser = parser }
+  end
+
+  it { is_expected.to have_attributes(batch_type: 'Metadata Import') }
+
+  describe '#enqueue' do
+    it 'enqueues an import job for each record' do
+      ActiveJob::Base.queue_adapter = :test
+
+      expect { batchable.enqueue! }
+        .to enqueue_job(MetadataImportJob)
+        .exactly(5).times
+    end
+  end
+
+  describe '#ids' do
+    it 'has ids parsed from the file' do
+      expect(batchable.ids)
+        .to contain_exactly('7s75dc36z', 'wm117n96b', 'pk02c9724',
+                            'xs55mc046', 'j67313767')
+    end
+  end
+
+  describe '#metadata_file' do
+    subject(:batchable) { FactoryGirl.build(:metadata_import, metadata_file: nil) }
+    let(:file)          { file_fixture('mira_export.xml') }
+
+    it 'is an uploader' do
+      expect { batchable.metadata_file = File.open(file) }
+        .to change { batchable.metadata_file }
+        .to(an_instance_of(Tufts::MetadataFileUploader))
+    end
+  end
+end

--- a/spec/services/tufts/metadata_import_service_spec.rb
+++ b/spec/services/tufts/metadata_import_service_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Tufts::MetadataImportService, :workflow do
+  subject(:service) { described_class.new(import: import, object_id: object.id) }
+  let(:import)      { FactoryGirl.create(:metadata_import) }
+
+  let!(:object) do
+    FactoryGirl.create(:pdf, id: import.ids.first, title: ['Moomin'])
+  end
+
+  it 'has import and object_ids attributes' do
+    is_expected.to have_attributes(import:    import,
+                                   object_id: object.id)
+  end
+
+  describe '#update_object!' do
+    it 'updates the object' do
+      expect { service.update_object! }
+        .to change { object.reload.title }
+        .to contain_exactly('I Married a Electric Ninjas')
+    end
+  end
+end


### PR DESCRIPTION
Creates a `Batchable` for handling `MetadataImport`, to re-import exported records for existing files. In support of this:

  - `MiraXmlImporter` is wired up to `MiraXmlMapping`; the mapping is now used
    to handle data transformations bidirectionally.
  - `ImportRecord` is refactored to project directly on an XML document, instead
    of being populated on initialize to avoid repeated inline parsing.