### PR TITLE
Boost travis-ci environment size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-sudo: false
+sudo: required
 cache: bundler
 dist: trusty
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: 8d686d73644d448fd6a2bae35a1447d4ef524ca9
+  revision: 4b160bd19ecca7f97d7ac22dccd5fde9b0da5a9f
   branch: rails-5
   specs:
     shoulda-matchers (3.1.2)
@@ -812,7 +812,8 @@ GEM
       select2-rails (~> 3.5.9)
       signet
       tinymce-rails (~> 4.1)
-    i18n (0.8.6)
+    i18n (0.9.0)
+      concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
     jbuilder (2.7.0)


### PR DESCRIPTION
Trusty envs with `sudo` enabled have a larger memory size. See: https://docs.travis-ci.com/user/reference/overview/

This is an experiment.