### PR TITLE
Fix resource type attribute

### DIFF
--- a/app/lib/tufts/terms.rb
+++ b/app/lib/tufts/terms.rb
@@ -4,7 +4,7 @@ module Tufts
                     :abstract, :table_of_contents, :primary_date, :date_accepted,
                     :date_available, :date_copyrighted, :date_issued, :steward,
                     :internal_note, :audience, :embargo_note, :end_date, :accrual_policy,
-                    :rights_note, :resource_type,
+                    :rights_note,
                     :bibliographic_citation, :rights_holder, :format_label, :replaces, :is_replaced_by,
                     :has_format, :is_format_of, :has_part, :tufts_license,
                     :retention_period, :admin_start_date, :qr_status, :rejection_reason,

--- a/app/lib/tufts/terms.rb
+++ b/app/lib/tufts/terms.rb
@@ -4,13 +4,12 @@ module Tufts
                     :abstract, :table_of_contents, :primary_date, :date_accepted,
                     :date_available, :date_copyrighted, :date_issued, :steward,
                     :internal_note, :audience, :embargo_note, :end_date, :accrual_policy,
-                    :rights_note,
-                    :bibliographic_citation, :rights_holder, :format_label, :replaces, :is_replaced_by,
-                    :has_format, :is_format_of, :has_part, :tufts_license,
+                    :rights_note, :rights_holder, :format_label, :replaces, :is_replaced_by,
+                    :has_format, :is_format_of, :bibliographic_citation, :has_part, :tufts_license,
                     :retention_period, :admin_start_date, :qr_status, :rejection_reason,
-                    :qr_note, :creator_department, :legacy_pid, :spatial, :temporal, :extent,
+                    :qr_note, :creator_department, :legacy_pid, :temporal, :extent,
                     :personal_name, :corporate_name, :genre, :provenance, :funder, :createdby, :tufts_is_part_of, :has_draft].freeze
-    REMOVE_TERMS = [:license, :keyword, :based_near].freeze
+    REMOVE_TERMS = [:license, :keyword, :based_near, :has_draft].freeze
     def self.shared_terms
       SHARED_TERMS
     end

--- a/app/models/concerns/tufts/metadata/adminstrative.rb
+++ b/app/models/concerns/tufts/metadata/adminstrative.rb
@@ -30,9 +30,6 @@ module Tufts
         property :rights_note, predicate: ::RDF::Vocab::DC11.rights, multiple: false do |index|
           index.as :stored_searchable
         end
-        property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|
-          index.as :stored_searchable, :facetable
-        end
         property :retention_period, predicate: ::Tufts::Vocab::Tufts.retention_period do |index|
           index.as :stored_searchable
         end

--- a/app/models/concerns/tufts/metadata/descriptive.rb
+++ b/app/models/concerns/tufts/metadata/descriptive.rb
@@ -33,8 +33,6 @@ module Tufts
         property :date_issued, predicate: ::RDF::Vocab::EBUCore.dateIssued do |index|
           index.as :stored_searchable
         end
-        property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
-        end
         property :rights_holder, predicate: ::RDF::Vocab::DC.rightsHolder do |index|
           index.as :stored_searchable
         end
@@ -71,13 +69,7 @@ module Tufts
         property :provenance, predicate: ::RDF::Vocab::DC.provenance do |index|
           index.as :stored_searchable
         end
-        property :spatial, predicate: ::RDF::Vocab::DC.provenance do |index|
-          index.as :stored_searchable
-        end
         property :temporal, predicate: ::RDF::Vocab::DC.temporal do |index|
-          index.as :stored_searchable
-        end
-        property :spatial, predicate: ::RDF::Vocab::DC.spatial do |index|
           index.as :stored_searchable
         end
         property :funder, predicate: ::RDF::Vocab::MARCRelators.fnd do |index|

--- a/spec/support/shared_examples/metadata_attributes.rb
+++ b/spec/support/shared_examples/metadata_attributes.rb
@@ -153,12 +153,6 @@ shared_examples 'a work with Tufts metadata attributes' do
         .to match(/purl.org\/dc\/terms\/provenance/)
     end
 
-    it 'has spatial' do
-      work.spatial = ['12,23']
-      expect(work.resource.dump(:ttl))
-        .to match(/purl.org\/dc\/terms\/spatial/)
-    end
-
     it 'has temporal' do
       work.temporal = ['20th century']
       expect(work.resource.dump(:ttl))

--- a/spec/support/shared_examples/metadata_form.rb
+++ b/spec/support/shared_examples/metadata_form.rb
@@ -6,26 +6,15 @@ shared_examples 'a form with Tufts metadata attributes' do
     end
 
     it 'has Tufts terms' do
-      expect(form.terms)
-        .to include(:displays_in, :geographic_name, :held_by,
-                    :alternative_title, :abstract, :table_of_contents,
-                    :primary_date, :date_accepted, :date_available,
-                    :date_copyrighted, :date_issued, :steward,
-                    :internal_note, :audience, :embargo_note, :end_date,
-                    :accrual_policy, :tufts_license, :rights_note, :resource_type,
-                    :bibliographic_citation, :rights_holder, :format_label,
-                    :replaces, :is_replaced_by, :has_format, :is_format_of,
-                    :has_part, :extent, :genre, :tufts_is_part_of)
-    end
-
-    it 'has Tufts admin terms' do
-      expect(form.terms)
-        .to include(:steward, :internal_note, :audience, :end_date,
-                    :accrual_policy, :tufts_license, :retention_period,
-                    :admin_start_date, :qr_status, :rejection_reason, :qr_note,
-                    :creator_department, :legacy_pid, :personal_name,
-                    :corporate_name, :provenance, :funder, :creator_department,
-                    :createdby)
+      expect(form.terms).to include(:provenance, :displays_in, :geographic_name, :held_by, :alternative_title,
+                                    :abstract, :table_of_contents, :primary_date, :date_accepted,
+                                    :date_available, :date_copyrighted, :date_issued, :steward,
+                                    :internal_note, :audience, :embargo_note, :end_date, :accrual_policy,
+                                    :rights_note, :rights_holder, :format_label, :replaces, :is_replaced_by,
+                                    :has_format, :is_format_of, :has_part, :tufts_license,
+                                    :retention_period, :admin_start_date, :qr_status, :rejection_reason,
+                                    :qr_note, :creator_department, :legacy_pid, :temporal, :extent,
+                                    :personal_name, :corporate_name, :genre, :provenance, :funder, :createdby, :tufts_is_part_of, :has_draft)
     end
   end
 end

--- a/spec/support/shared_examples/tufts_presenter.rb
+++ b/spec/support/shared_examples/tufts_presenter.rb
@@ -26,7 +26,6 @@ shared_examples 'a Tufts presenter' do
     it { is_expected.to delegate_method(:corporate_name).to(:solr_document) }
     it { is_expected.to delegate_method(:genre).to(:solr_document) }
     it { is_expected.to delegate_method(:provenance).to(:solr_document) }
-    it { is_expected.to delegate_method(:spatial).to(:solr_document) }
     it { is_expected.to delegate_method(:temporal).to(:solr_document) }
     it { is_expected.to delegate_method(:funder).to(:solr_document) }
   end


### PR DESCRIPTION
Resource Type was duplicated in `Hyrax::BasicMetadata`  and in the Tufts attributes. This removes moves the custom Tufts one and uses the Hyrax version because they share the same predicate

This also

closes #442 
closes #271 

and fixes a problem with multiple spatial attributes 
