### PR TITLE
Render rights statement as label, not URI

### DIFF
--- a/app/lib/tufts/vocab/tufts.rb
+++ b/app/lib/tufts/vocab/tufts.rb
@@ -28,6 +28,7 @@ module Tufts
       term :creator_department
       term :is_part_of
       term :has_draft
+      term :tufts_license
     end
   end
 end

--- a/app/models/concerns/tufts/metadata/adminstrative.rb
+++ b/app/models/concerns/tufts/metadata/adminstrative.rb
@@ -54,7 +54,7 @@ module Tufts
         property :createdby, predicate: ::Tufts::Vocab::Tufts.createdby, multiple: false do |index|
           index.as :stored_searchable, :facetable
         end
-        property :tufts_license, predicate: ::RDF::Vocab::DC.rights do |index|
+        property :tufts_license, predicate: ::Tufts::Vocab::Tufts.tufts_license, mulitple: false do |index|
           index.as :stored_searchable
         end
         property :has_draft, predicate: ::Tufts::Vocab::Tufts.has_draft, multiple: false do |index|

--- a/app/renderers/rights_statement_renderer.rb
+++ b/app/renderers/rights_statement_renderer.rb
@@ -1,0 +1,16 @@
+class RightsStatementRenderer < Hyrax::Renderers::AttributeRenderer
+  private
+
+    def attribute_value_to_html(value)
+      begin
+        parsed_uri = URI.parse(value)
+      rescue
+        nil
+      end
+      if parsed_uri.nil?
+        ERB::Util.h(value)
+      else
+        %(<a href=#{ERB::Util.h(value)} target="_blank">#{Tufts::RightsStatementService.label(value)}</a>)
+      end
+    end
+end

--- a/app/services/tufts/rights_statement_service.rb
+++ b/app/services/tufts/rights_statement_service.rb
@@ -1,0 +1,16 @@
+module Tufts
+  module RightsStatementService
+    mattr_accessor :authority
+    self.authority = Qa::Authorities::Local.subauthority_for('rights_statements')
+
+    def self.select_options
+      authority.all.map do |element|
+        [element[:label], element[:id]]
+      end
+    end
+
+    def self.label(id)
+      authority.find(id).fetch('term')
+    end
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -7,6 +7,7 @@
 
 <%= presenter.attribute_to_html(:creator, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>

--- a/app/views/records/edit_fields/_rights_statement.html.erb
+++ b/app/views/records/edit_fields/_rights_statement.html.erb
@@ -1,0 +1,5 @@
+<% rights_statements = Tufts::RightsStatementService %>
+<%= f.input :rights_statement,
+    collection: rights_statements.select_options,
+    include_blank: true,
+    input_html: { class: 'form-control' } %>


### PR DESCRIPTION
This fixes a duplicate predicate error that was still present after my last PR and adds a renderer and service for rights_statement. 