### PR TITLE
Refactor publication/draft badges

### DIFF
--- a/app/controllers/tufts/draft_controller.rb
+++ b/app/controllers/tufts/draft_controller.rb
@@ -4,8 +4,6 @@ module Tufts
 
     def save_draft
       model = ActiveFedora::Base.find(params[:id])
-      model.has_draft = 'true'
-      model.save
 
       model_type = model_type(model)
       scalar_fix(model_type)
@@ -21,8 +19,7 @@ module Tufts
     def delete_draft
       model = ActiveFedora::Base.find(params[:id])
       model.delete_draft
-      model.has_draft = 'false'
-      model.save
+
       render json: { status: "Deleted the draft." }
     end
 

--- a/app/controllers/tufts/publication_status_controller.rb
+++ b/app/controllers/tufts/publication_status_controller.rb
@@ -6,6 +6,7 @@ module Tufts
 
     def publish
       work = ActiveFedora::Base.find(params[:id])
+      work.delete_draft
       subject = Hyrax::WorkflowActionInfo.new(work, current_user)
       sipity_workflow_action = PowerConverter.convert_to_sipity_action("publish", scope: subject.entity.workflow) { nil }
       Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Published by #{current_user}")

--- a/app/lib/tufts/terms.rb
+++ b/app/lib/tufts/terms.rb
@@ -9,8 +9,8 @@ module Tufts
                     :retention_period, :admin_start_date, :qr_status, :rejection_reason,
                     :qr_note, :creator_department, :legacy_pid, :temporal, :extent,
                     :personal_name, :corporate_name, :genre, :provenance, :funder, :createdby,
-                    :tufts_is_part_of, :resource_type, :has_draft].freeze
-    REMOVE_TERMS = [:license, :keyword, :based_near, :has_draft].freeze
+                    :tufts_is_part_of, :resource_type].freeze
+    REMOVE_TERMS = [:license, :keyword, :based_near].freeze
     def self.shared_terms
       SHARED_TERMS
     end

--- a/app/lib/tufts/vocab/tufts.rb
+++ b/app/lib/tufts/vocab/tufts.rb
@@ -27,7 +27,6 @@ module Tufts
       term :qr_note
       term :creator_department
       term :is_part_of
-      term :has_draft
     end
   end
 end

--- a/app/lib/tufts/workflow_status.rb
+++ b/app/lib/tufts/workflow_status.rb
@@ -1,0 +1,33 @@
+module Tufts
+  module WorkflowStatus
+    def self.status(id)
+      work_id = id
+      solr_doc_status = solr_status(work_id)
+      if solr_doc_status == 'unpublished' || solr_doc_status == 'deposited'
+        'unpublished'
+      else
+        # Only look for this status in Fedora if necessary
+        work = ActiveFedora::Base.find(id)
+        draft_status = work.draft_saved?
+        if draft_status
+          'edited'
+        else
+          'published'
+        end
+      end
+    end
+
+    def self.solr_status(id)
+      document = SolrDocument.find(id)
+      begin
+        document['workflow_state_name_ssim'][0]
+      rescue
+        'unpublished'
+      end
+    end
+
+    class << self
+      private :solr_status
+    end
+  end
+end

--- a/app/models/concerns/tufts/metadata/adminstrative.rb
+++ b/app/models/concerns/tufts/metadata/adminstrative.rb
@@ -57,9 +57,6 @@ module Tufts
         property :tufts_license, predicate: ::RDF::Vocab::DC.rights do |index|
           index.as :stored_searchable
         end
-        property :has_draft, predicate: ::Tufts::Vocab::Tufts.has_draft, multiple: false do |index|
-          index.as :stored_searchable
-        end
       end
 
       def mark_reviewed

--- a/app/views/catalog/_batch_select.html.erb
+++ b/app/views/catalog/_batch_select.html.erb
@@ -1,5 +1,3 @@
-<%= render 'tufts/workflow_status_badge', locals: {id: document.id} %>
-    
 <span data-behavior="batch-add-button">
   <%= check_box_tag "batch", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}" %>
 </span>

--- a/app/views/catalog/_batch_select.html.erb
+++ b/app/views/catalog/_batch_select.html.erb
@@ -1,16 +1,5 @@
-<% if document["workflow_state_name_ssim"] %>
-    <% workflow_state = document["workflow_state_name_ssim"].first %>
-    <% if document["has_draft_tesim"] %>
-        <% has_draft = document["has_draft_tesim"].first %>
-    <% end  %>
-      <% if has_draft && has_draft == 'true' %>
-          <span class="state state-edited catalog-state label label-warning">Edited</span>
-         
-<% else %>
-    <span class="state state-<%= workflow_state %> label catalog-state label-primary"><%= workflow_state.capitalize %></span>
-<% end %>
-<% end  %>
-
+<%= render 'tufts/workflow_status_badge', locals: {id: document.id} %>
+    
 <span data-behavior="batch-add-button">
   <%= check_box_tag "batch", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}" %>
 </span>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,4 +1,5 @@
 <h2>
   <%= link_to document.title_or_label, document %>
+  <%= render 'tufts/workflow_status_badge', locals: {id: document.id} %>
   <%= render 'catalog/batch_select', document: document %>
 </h2>

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -49,7 +49,8 @@
       </div>   
     </div>
     <% if @curation_concern.persisted?  %>
-      <% if workflow_status(curation_concern) == ["published"] %>
+      <% workflow_status_with_draft = Tufts::WorkflowStatus.status(@curation_concern.id) %>
+      <% if workflow_status_with_draft == 'published' || workflow_status_with_draft == 'edited'  %>
      <div class="col-xs-12 col-sm-4">
         <div class="panel panel-default">
             <div class="panel-heading">

--- a/app/views/hyrax/base/_work_title.html.erb
+++ b/app/views/hyrax/base/_work_title.html.erb
@@ -2,11 +2,7 @@
     <% if index == 0 %>
         <h1>
           <%= title %> <%= presenter.permission_badge %>
-          <% if presenter.solr_document.has_draft == ['true'] %>
-          <span class="label label-warning">Edited</span>
-          <% else %>
-          <%= presenter.workflow.badge %>
-          <% end %>
+           <%= render 'tufts/workflow_status_badge', locals: {id: presenter.id} %>
         </h1>
     <% else %>
         <h1><%= title %></h1>

--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -1,0 +1,33 @@
+<tr id="document_<%= document.id %>">
+  <td>
+    <div class='media'>
+      <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+     
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("hyrax.dashboard.my.sr.show_label") %>
+            </span>
+            <%= document.title_or_label %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class='text-center'><%= document.date_uploaded %></td>
+  <td class='workflow-state'><%= render 'tufts/workflow_status_badge', locals: {id: document.id} %></td>
+  <td class='text-center'><%= render_visibility_link document %></td>
+
+  <td class='text-center'>
+    <%= render 'work_action_menu', document: document %>
+  </td>
+</tr>

--- a/app/views/hyrax/my/works/_default_group.html.erb
+++ b/app/views/hyrax/my/works/_default_group.html.erb
@@ -1,0 +1,21 @@
+<table class="table table-striped works-list">
+  <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
+  <% unless params[:display_type] == 'list' %>
+    <thead>
+    <tr>
+      <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
+      <th><%= t("hyrax.dashboard.my.heading.title") %></th>
+      <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+      <th><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
+      <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+      <th>Status</th>
+      <th><%= t("hyrax.dashboard.my.heading.action") %></th>
+    </tr>
+    </thead>
+  <% end %>
+  <tbody>
+  <% docs.each_with_index do |document, counter| %>
+      <%= render 'list_works', document: document, counter: counter, presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -1,0 +1,40 @@
+<tr id="document_<%= document.id %>">
+
+  <td>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%=t("hyrax.dashboard.my.sr.batch_checkbox")%></label>
+    <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
+  </td>
+
+  <td>
+    <div class='media'>
+      <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("hyrax.dashboard.my.sr.show_label") %>
+            </span>
+            <%= document.title_or_label %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class="date"><%= document.date_uploaded %></td>
+  <td class='text-center'>
+    <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>"></span></td>
+  <td><%= render_visibility_link document %></td>
+  <td><%= render 'tufts/workflow_status_badge', locals: {id: document.id} %></td>
+  <td>
+    <%= render 'work_action_menu', document: document %>
+  </td>
+</tr>

--- a/app/views/tufts/_workflow_status_badge.html.erb
+++ b/app/views/tufts/_workflow_status_badge.html.erb
@@ -1,0 +1,7 @@
+<% status = Tufts::WorkflowStatus.status(locals[:id]) %>
+  <% if status == 'edited' %>
+    <span class="state state-edited catalog-state label label-warning">Edited</span>
+  <% else %>
+    <span class="state state-<%= status %> label catalog-state label-primary"><%= status.capitalize %>
+    </span>
+  <% end %>

--- a/spec/lib/tufts/workflow_status_spec.rb
+++ b/spec/lib/tufts/workflow_status_spec.rb
@@ -1,9 +1,40 @@
 require 'rails_helper'
 
-describe Tufts::WorkflowStatus, :clean do
-  let(:work) { create(:pdf) }
+describe Tufts::WorkflowStatus, :workflow, :clean do
+  let(:work) { Pdf.new(title: ['Title'], displays_in: ['nowhere'], description: ['A desc']) }
+  let(:current_user) { FactoryGirl.create(:admin) }
   let(:workflow_status) { subject }
+
+  before do
+    work.save
+    current_ability = ::Ability.new(current_user)
+    uploaded_file = Hyrax::UploadedFile.create(user: current_user, file: File.open(Rails.root.join('spec', 'fixtures', 'hello.pdf'), 'r'))
+    attributes = { uploaded_files: [uploaded_file.id] }
+    env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
+    Hyrax::CurationConcern.actor.create(env)
+    work.update(admin_set: AdminSet.find(AdminSet::DEFAULT_ID))
+  end
+
   it 'returns unpublished for an unpublished work when given its ID' do
+    subject = Hyrax::WorkflowActionInfo.new(work, current_user)
+    sipity_workflow_action = PowerConverter.convert_to_sipity_action("unpublish", scope: subject.entity.workflow) { nil }
+    Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Published by #{current_user}")
     expect(workflow_status.status(work.id)).to eq('unpublished')
+  end
+
+  it 'returns published for an published work when given its ID' do
+    subject = Hyrax::WorkflowActionInfo.new(work, current_user)
+    sipity_workflow_action = PowerConverter.convert_to_sipity_action("publish", scope: subject.entity.workflow) { nil }
+    Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Published by #{current_user}")
+    expect(workflow_status.status(work.id)).to eq('published')
+  end
+
+  it 'returns edited for an published work that has a draft when given its ID' do # rubocop:disable RSpec/ExampleLength
+    subject = Hyrax::WorkflowActionInfo.new(work, current_user)
+    sipity_workflow_action = PowerConverter.convert_to_sipity_action("publish", scope: subject.entity.workflow) { nil }
+    Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Published by #{current_user}")
+    File.open(Rails.application.config.drafts_storage_dir.join(work.id), 'w+')
+    expect(workflow_status.status(work.id)).to eq('edited')
+    File.delete(Rails.application.config.drafts_storage_dir.join(work.id))
   end
 end

--- a/spec/lib/tufts/workflow_status_spec.rb
+++ b/spec/lib/tufts/workflow_status_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe Tufts::WorkflowStatus do
+  let(:work) { create(:pdf) }
+  let(:workflow_status) { subject }
+  it 'returns unpublished for an unpublished work when given its ID' do
+    expect(workflow_status.status(work.id)).to eq('unpublished')
+  end
+end

--- a/spec/lib/tufts/workflow_status_spec.rb
+++ b/spec/lib/tufts/workflow_status_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Tufts::WorkflowStatus do
+describe Tufts::WorkflowStatus, :clean do
   let(:work) { create(:pdf) }
   let(:workflow_status) { subject }
   it 'returns unpublished for an unpublished work when given its ID' do


### PR DESCRIPTION
This refactors the workflow status badges to use a module which determines what the state is by looking in the solr document, and if needed the model for the
draft status.

The module is used by a partial which creates the workflow status badges.

I went through the views and am calling that partial anywhere we need the badges to show up.

This also removes the attribute for has_draft. There will need to be another solution for faceting on the draft/publication status. 
