### PR TITLE
Keep newlines for description and abstract fields

### DIFF
--- a/app/controllers/contribute_controller.rb
+++ b/app/controllers/contribute_controller.rb
@@ -34,9 +34,16 @@ class ContributeController < ApplicationController
   # object creation
   # @param [ActionController::Parameters] params
   def normalize_whitespace(params)
+    # For keep_newline_fields, keep single newlines, compress 2+ newlines to 2,
+    # and otherwise strip whitespace as usual
+    keep_newline_fields = ['description', 'abstract']
     params["contribution"].keys.each do |key|
       next unless params["contribution"][key].class == String
-      params["contribution"][key] = params["contribution"][key].gsub(/\s+/, " ").strip
+      params["contribution"][key] = if keep_newline_fields.include?(key)
+                                      params["contribution"][key].gsub(/[ \t]+?[\n]{2,}[ \t]+?/, "\n\n").gsub(/[ \t]+/, " ").strip
+                                    else
+                                      params["contribution"][key].gsub(/\s+/, " ").strip
+                                    end
     end
   end
 

--- a/spec/controllers/contribute_controller_spec.rb
+++ b/spec/controllers/contribute_controller_spec.rb
@@ -169,7 +169,8 @@ describe ContributeController do
           "creator" => " Name   with  Spaces ",
           "bibliographic_citation" => " bibliographic   citation   with     spaces    ",
           "embargo_note" => "0",
-          "description" => " A short   description \n   with  wonky spaces   "
+          "description" => " A short   description \n   with  wonky spaces   \n\n\n\n\n But keep two newlines between paragraphs. ",
+          "abstract" => " A short   description \n   with  wonky spaces   \n\n\n\n\n But keep two newlines between paragraphs. "
         },
         "deposit_type" => "1",
         "commit" => "Agree & Deposit",
@@ -181,7 +182,8 @@ describe ContributeController do
       described_class.new.normalize_whitespace(params)
       expect(params["contribution"]["title"]).to eq "Space non normalized title"
       expect(params["contribution"]["creator"]).to eq "Name with Spaces"
-      expect(params["contribution"]["description"]).to eq "A short description with wonky spaces"
+      expect(params["contribution"]["description"]).to eq "A short description \n with wonky spaces\n\nBut keep two newlines between paragraphs."
+      expect(params["contribution"]["abstract"]).to eq "A short description \n with wonky spaces\n\nBut keep two newlines between paragraphs."
     end
   end
 end


### PR DESCRIPTION
Closes #417 