### PR TITLE
Save 'Other Authors' to the #contributor field

### DIFF
--- a/app/assets/javascripts/components/contribute/input_field.js.jsx
+++ b/app/assets/javascripts/components/contribute/input_field.js.jsx
@@ -5,7 +5,7 @@ var InputField = React.createClass({
   render: function() {
     return <ul>
       <li>
-        <input style={this.inputStyle} className='form-control'type='text' name="contribution[other_authors][]">
+        <input style={this.inputStyle} className='form-control'type='text' name="contribution[contributor][]">
         </input>
       </li>
       <li>

--- a/app/models/forms/faculty_scholarship.rb
+++ b/app/models/forms/faculty_scholarship.rb
@@ -1,6 +1,4 @@
 class FacultyScholarship < Contribution
-  self.attributes += [:other_authors]
-  self.ignore_attributes += [:other_authors]
   attr_accessor(*attributes)
 
   protected
@@ -9,7 +7,7 @@ class FacultyScholarship < Contribution
       super
       @tufts_pdf.description = [description] if description
       @tufts_pdf.bibliographic_citation = [bibliographic_citation] if bibliographic_citation
-      @tufts_pdf.creator << other_authors if other_authors && other_authors != [""]
+      @tufts_pdf.contributor << contributor if contributor && contributor != [""]
     end
 
     def parent_collection

--- a/spec/features/contribute/faculty_scholarship_contribute_spec.rb
+++ b/spec/features/contribute/faculty_scholarship_contribute_spec.rb
@@ -13,7 +13,8 @@ RSpec.feature 'Create a Faculty Scholarship self contribution', :clean, js: true
     let(:title) { FFaker::Movie.title }
     let(:bibliographic_citation) { FFaker::Book.genre }
     let(:abstract) { FFaker::Book.description }
-    let(:other_author) { FFaker::Name.name }
+    let(:coauthor1) { FFaker::Name.name }
+    let(:coauthor2) { FFaker::Name.name }
     before do
       importer = DepositTypeImporter.new('./config/deposit_type_seed.csv')
       importer.import_from_csv
@@ -31,12 +32,17 @@ RSpec.feature 'Create a Faculty Scholarship self contribution', :clean, js: true
       attach_file('contribution_attachment', File.absolute_path(file_fixture('pdf-sample.pdf')))
       fill_in "Title", with: title
       fill_in "Bibliographic Citation", with: bibliographic_citation
-      # fill_in "Other authors", with: other_author
+      click_button "Add Another Author"
+      # fill_in "Other Authors", with: coauthor1
+      page.all(:fillable_field, 'contribution[contributor][]')[0].set(coauthor1)
+      click_button "Add Another Author"
+      page.all(:fillable_field, 'contribution[contributor][]')[1].set(coauthor2)
       fill_in "Short Description", with: abstract
       click_button "Agree & Deposit"
       created_pdf = Pdf.last
       expect(created_pdf.title.first).to eq title
       expect(created_pdf.creator.first).to eq "Name with Spaces"
+      expect(created_pdf.contributor).to contain_exactly coauthor1, coauthor2
       expect(created_pdf.depositor).to eq user.user_key
       expect(created_pdf.admin_set.title.first).to eq "Default Admin Set"
       expect(created_pdf.active_workflow.name).to eq "mira_publication_workflow"


### PR DESCRIPTION
For Faculty Scholarship self-deposits, Tufts wants the "Other Authors" to
be saved to the #contributor field.  This change uses #contributor as the
underlying field source while leaving the lable on the form as "Other Authors".

Connected to #418