### PR TITLE
Link CarrierWave upload dirs

### DIFF
--- a/app/lib/tufts/metadata_file_uploader.rb
+++ b/app/lib/tufts/metadata_file_uploader.rb
@@ -3,5 +3,17 @@ require 'carrierwave'
 module Tufts
   class MetadataFileUploader < CarrierWave::Uploader::Base
     storage :file
+
+    ##
+    # @see CarrierWave::Uploader::Base#store_dir
+    def store_dir
+      Rails.application.config.metadata_upload_dir.join('store').to_s
+    end
+
+    ##
+    # @see CarrierWave::Uploader::Base#cache_dir
+    def cache_dir
+      Rails.application.config.metadata_upload_dir.join('cache').to_s
+    end
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -39,14 +39,22 @@ append :linked_dirs, "tmp/cache"
 append :linked_dirs, "tmp/sockets"
 append :linked_dirs, "log"
 
-# link the draft dir specified in config/environments/produciton.rb config.drafts_storage_dir
+# link the draft dir specified in config/environments/production.rb config.drafts_storage_dir
 append :linked_dirs, "tmp/drafts"
 
-# link the draft dir specified in config/environments/production.rb config.exports_storage_dir
+# link the export dir specified in config/environments/production.rb config.exports_storage_dir
 append :linked_dirs, "tmp/exports"
 
-# link the template dir specified in config/environments/produciton.rb config.templates_storage_dir
+# link the template dir specified in config/environments/production.rb config.templates_storage_dir
 append :linked_dirs, "tmp/templates"
+
+# link the metadata store and cache dirs specified in config/environments/production.rb
+# config.metadata_upload_dir
+append :linked_dirs, "tmp/metadata"
+
+# link the hyrax uploaded file store and cache dirs specified in config/initializers/hyrax.rb
+# config.templates_storage_dir
+append :linked_dirs, "tmp/uploads"
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,5 @@ Rails.application.configure do
   config.drafts_storage_dir    = Rails.root.join('tmp', 'drafts')
   config.exports_storage_dir   = Rails.root.join('tmp', 'exports')
   config.templates_storage_dir = Rails.root.join('tmp', 'templates')
+  config.metadata_upload_dir   = Rails.root.join('tmp', 'metadata')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,7 @@ Rails.application.configure do
   config.drafts_storage_dir    = Rails.root.join('tmp', 'drafts')
   config.exports_storage_dir   = Rails.root.join('tmp', 'exports')
   config.templates_storage_dir = Rails.root.join('tmp', 'templates')
+  config.metadata_upload_dir   = Rails.root.join('tmp', 'metadata')
 end
 
 Hyrax.config.derivatives_path = '/opt/derivatives'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,5 @@ Rails.application.configure do
   config.drafts_storage_dir    = Rails.root.join('tmp', 'drafts')
   config.exports_storage_dir   = Rails.root.join('tmp', 'exports')
   config.templates_storage_dir = Rails.root.join('tmp', 'templates')
+  config.metadata_upload_dir   = Rails.root.join('tmp', 'metadata')
 end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -146,8 +146,8 @@ Hyrax.config do |config|
 
   # Temporary paths to hold uploads before they are ingested into FCrepo
   # These must be lambdas that return a Pathname. Can be configured separately
-  #  config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
-  #  config.cache_path = ->() { Rails.root + 'tmp' + 'uploads' + 'cache' }
+  config.upload_path = ->() { Rails.root.join('tmp', 'uploads') }
+  config.cache_path  = ->() { Rails.root.join('tmp', 'uploads', 'cache') }
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume

--- a/spec/lib/tufts/metadata_file_uploader_spec.rb
+++ b/spec/lib/tufts/metadata_file_uploader_spec.rb
@@ -8,4 +8,18 @@ RSpec.describe Tufts::MetadataFileUploader do
   it 'is a carrierwave uploader' do
     expect(uploader).to be_a CarrierWave::Uploader::Base
   end
+
+  describe '#store_dir' do
+    it 'is the configured directory' do
+      expect(uploader.store_dir)
+        .to eq Rails.root.join('tmp', 'metadata', 'store').to_s
+    end
+  end
+
+  describe '#cache_dir' do
+    it 'is the configured directory' do
+      expect(uploader.cache_dir)
+        .to eq Rails.root.join('tmp', 'metadata', 'cache').to_s
+    end
+  end
 end


### PR DESCRIPTION
CarrierWave uses specified storage and cache dirs for its uploaders, these were previously not linked across deployments. This makes the `MetadataFileUploader` directories configurable via the Rails application configuration. The directories for that uploader and the `Hyrax::UploadedFileUploader` are also
linked in `config/deploy.rb` to ensure stability.