### PR TITLE
This fixes an error with the `/batches` page. 

### DIFF
--- a/app/lib/tufts/mira_xml_importer.rb
+++ b/app/lib/tufts/mira_xml_importer.rb
@@ -63,6 +63,7 @@ module Tufts
     private
 
       def doc
+        return Nokogiri::XML(nil) unless file.exists?
         file.rewind if file.respond_to? :rewind
         Nokogiri::XML(file.read)
       end

--- a/spec/lib/tufts/mira_xml_importer_spec.rb
+++ b/spec/lib/tufts/mira_xml_importer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Tufts::MiraXmlImporter do
   subject(:importer) { described_class.new(file: file) }
-  let(:file)         { File.open(file_fixture('mira_xml.xml')) }
+  let(:file)         { CarrierWave::SanitizedFile.new(file_fixture('mira_xml.xml')) }
 
   it_behaves_like 'an importer'
 
@@ -51,7 +51,7 @@ RSpec.describe Tufts::MiraXmlImporter do
 
   describe 'validations' do
     context 'with missing filenames' do
-      let(:file) { File.open(file_fixture('mira_xml_invalid.xml')) }
+      let(:file) { CarrierWave::SanitizedFile.new(file_fixture('mira_xml_invalid.xml')) }
 
       it 'validates presence of filenames' do
         expect { importer.validate! }

--- a/spec/support/shared_examples/importer.rb
+++ b/spec/support/shared_examples/importer.rb
@@ -16,7 +16,7 @@ shared_examples 'an importer' do
 
   describe '#records' do
     context 'with empty file' do
-      let(:file) { StringIO.new('') }
+      let(:file) { CarrierWave::SanitizedFile.new(Tempfile.new('empty_file')) }
 
       it 'yields nothing' do
         expect { |b| importer.records(&b) }.not_to yield_control


### PR DESCRIPTION
The batches page attempts to load XML files that were uploaded

through `MiraXmlImporter`:

```
/opt/epigaea/current/log/production.log:F, [2017-11-12T09:12:46.377890 #10059] FATAL -- : [9efc8b3d-ee77-46e4-bcb5-cfc4eceb6561] ActionView::Template::Error (No such file or directory @ rb_sysopen - /opt/epigaea/releases/20171110154758/tmp/metadata/store/mira_xml.xml):
```

On production those files were remove as part of the deployment process. I added some checking in the importer to make
sure that an XML file exists before checking. This raised another error that caused by the importer using `CarrierWave::SanitizedFile` not `File`.

```
/opt/epigaea/current/log/production.log:F, [2017-11-12T09:34:57.481275 #11755] FATAL -- : [475ad141-3c47-4a14-a385-98170c49bfa1] ActionView::Template::Error (undefined method `exist?' for #<CarrierWave::SanitizedFile:0x00555b6fa75fb0>
```

So I also updated the import specs to use `SanitizedFile`.

Closes #554 