### PR TITLE
Simplify persistence across production deployments

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -6,4 +6,4 @@ test: &test
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
 production:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/epigaea" %>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,13 +23,6 @@ set :deploy_to, "/opt/epigaea"
 # Default value for :linked_files is []
 append :linked_files, "config/database.yml"
 append :linked_files, "config/secrets.yml"
-append :linked_files, "config/blacklight.yml"
-append :linked_files, "config/fedora.yml"
-append :linked_files, "config/redis.yml"
-append :linked_files, "config/secrets.yml"
-append :linked_files, "config/solr.yml"
-append :linked_files, "config/handle.yml"
-append :linked_files, "config/honeybadger.yml"
 
 # Default value for linked_dirs is []
 # append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
@@ -38,23 +31,6 @@ append :linked_dirs, "tmp/pids"
 append :linked_dirs, "tmp/cache"
 append :linked_dirs, "tmp/sockets"
 append :linked_dirs, "log"
-
-# link the draft dir specified in config/environments/production.rb config.drafts_storage_dir
-append :linked_dirs, "tmp/drafts"
-
-# link the export dir specified in config/environments/production.rb config.exports_storage_dir
-append :linked_dirs, "tmp/exports"
-
-# link the template dir specified in config/environments/production.rb config.templates_storage_dir
-append :linked_dirs, "tmp/templates"
-
-# link the metadata store and cache dirs specified in config/environments/production.rb
-# config.metadata_upload_dir
-append :linked_dirs, "tmp/metadata"
-
-# link the hyrax uploaded file store and cache dirs specified in config/initializers/hyrax.rb
-# config.templates_storage_dir
-append :linked_dirs, "tmp/uploads"
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,11 +84,15 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Configure the drafts strorage directory
-  config.drafts_storage_dir    = Rails.root.join('tmp', 'drafts')
-  config.exports_storage_dir   = Rails.root.join('tmp', 'exports')
-  config.templates_storage_dir = Rails.root.join('tmp', 'templates')
-  config.metadata_upload_dir   = Rails.root.join('tmp', 'metadata')
+  # Configure the application strorage directories
+  config.drafts_storage_dir    = Pathname.new('/opt/drafts')
+  config.exports_storage_dir   = Pathname.new('/opt/exports')
+  config.templates_storage_dir = Pathname.new('/opt/templates')
+  config.metadata_upload_dir   = Pathname.new('/opt/metadata')
 end
 
-Hyrax.config.derivatives_path = '/opt/derivatives'
+Hyrax.config do |config|
+  config.derivatives_path = Pathname.new('/opt/derivatives')
+  config.upload_path = ->() { Pathname.new('/opt/uploads') }
+  config.cache_path  = ->() { Pathname.new('/opt/cache') }
+end

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -11,5 +11,5 @@ test:
 production:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora/rest
+  url: http://127.0.0.1:8080/fedora/rest
   base_path: /prod

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -4,4 +4,4 @@ development:
 test:
   url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/hydra-test
 production:
-  url: http://your.production.server:8080/bl_solr/core0
+  url: http://127.0.0.1:8983/solr/epigaea


### PR DESCRIPTION
* Check-in production ready configurations where there are no secrets or passwords being saved.
* Store persistent and long-lived ephemeral data in `/opt` instead to `./tmp` in production.