### PR TITLE
Redirect any RecordNotFound exceptions to the main search page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,9 @@ class ApplicationController < ActionController::Base
   def default_url_options
     super.except(:locale)
   end
+
+  rescue_from Blacklight::Exceptions::RecordNotFound do |exception|
+    logger.error "Requested record not found: #{exception}"
+    redirect_to '/catalog'
+  end
 end

--- a/spec/controllers/hyrax/eads_controller_spec.rb
+++ b/spec/controllers/hyrax/eads_controller_spec.rb
@@ -2,8 +2,10 @@
 #  `rails generate hyrax:work Ead`
 require 'rails_helper'
 
-RSpec.describe Hyrax::EadsController do
-  it "has tests" do
-    skip "Add your tests here"
+RSpec.describe Hyrax::EadsController, type: :controller do
+  let(:params) { { id: 'impossible_id' } }
+
+  it 'catches and redirects RecordNotFound exceptions' do
+    expect { get :show, params: params }.not_to raise_error(Blacklight::Exceptions::RecordNotFound)
   end
 end


### PR DESCRIPTION
We shouldn't raise an exception when a record isn't found. Instead, we should redirect the user.

Addresses https://app.honeybadger.io/projects/54127/faults/35551573