### PR TITLE
Don't mint handles unless minimum requirements are met

### DIFF
--- a/app/actors/hyrax/actors/handle_assurance_actor.rb
+++ b/app/actors/hyrax/actors/handle_assurance_actor.rb
@@ -48,6 +48,10 @@ module Hyrax
       #
       # @return [Boolean] true
       def ensure_handle(object:)
+        return true unless
+          object.displays_in.include?('dl') &&
+          object.to_sipity_entity.try(:workflow_state_name) == 'published'
+
         if object.identifier.empty?
           HandleRegisterJob.perform_later(object)
         else

--- a/spec/factories/image.rb
+++ b/spec/factories/image.rb
@@ -3,5 +3,9 @@ FactoryGirl.define do
     id { ActiveFedora::Noid::Service.new.mint }
     title ["Image: #{FFaker::Movie.title}"]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+
+    transient do
+      user nil
+    end
   end
 end

--- a/spec/factories/pdf.rb
+++ b/spec/factories/pdf.rb
@@ -6,6 +6,24 @@ FactoryGirl.define do
     title [FFaker::Book.title]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     displays_in ['nowhere']
+
+    transient do
+      user nil
+    end
+
+    factory :published_pdf do
+      after(:create) do |work, evaluator|
+        action_info = Hyrax::WorkflowActionInfo.new(work, evaluator.user)
+        scope       = action_info.entity.workflow
+        action      = PowerConverter
+                      .convert_to_sipity_action("publish", scope: scope) { nil }
+
+        Hyrax::Workflow::WorkflowActionService
+          .run(subject: action_info,
+               action:  action,
+               comment: 'Published by :published_pdf factory in `after_create` hook.')
+      end
+    end
   end
 
   factory :populated_pdf, class: Pdf do

--- a/spec/features/publication_workflow_spec.rb
+++ b/spec/features/publication_workflow_spec.rb
@@ -1,25 +1,13 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
 require 'rails_helper'
-require 'active_fedora/cleaner'
 include Warden::Test::Helpers
 
-RSpec.feature 'deposit and publication' do
-  let(:depositing_user) { FactoryGirl.create(:user) }
-  let(:publishing_user) { FactoryGirl.create(:admin) }
-  let(:work) { FactoryGirl.create(:image) }
+RSpec.feature 'deposit and publication', :clean, :workflow do
+  let(:depositing_user)  { FactoryGirl.create(:user) }
+  let!(:publishing_user) { FactoryGirl.create(:admin) }
+
+  let(:work) { FactoryGirl.actor_create(:image, user: depositing_user) }
+
   context 'a logged in user' do
-    before do
-      ActiveFedora::Cleaner.clean!
-      DatabaseCleaner.clean_with(:truncation)
-      Tufts::WorkflowSetup.setup
-      allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-      publishing_user # Make sure publishing user exists before the work is submitted
-      current_ability = ::Ability.new(depositing_user)
-      attributes = {}
-      env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
-      Hyrax::CurationConcern.actor.create(env)
-    end
     scenario "non-admin user deposits, admin publishes", js: true do
       # All works go to the default admin set, which uses the mira_publication_workflow
       expect(work.active_workflow.name).to eq "mira_publication_workflow"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,8 @@ require 'selenium-webdriver'
 #
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
+FactoryGirl.register_strategy(:actor_create, ActorCreate)
+
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/build_strategies/actor_create.rb
+++ b/spec/support/build_strategies/actor_create.rb
@@ -1,0 +1,25 @@
+class ActorCreate
+  def initialize
+    @association_strategy = FactoryGirl.strategy_by_name(:create).new
+  end
+
+  delegate :association, to: :@association_strategy
+
+  def result(evaluation)
+    evaluation.object.tap do |instance|
+      evaluation.notify(:after_build, instance)
+
+      evaluator = evaluation.instance_variable_get(:@attribute_assigner)
+                            .instance_variable_get(:@evaluator)
+
+      ability = Ability.new(evaluator.user)
+      env     = Hyrax::Actors::Environment.new(instance, ability, {})
+
+      evaluation.notify(:before_create,       instance)
+      evaluation.notify(:before_actor_create, instance)
+      Hyrax::CurationConcern.actor.create(env)
+      evaluation.notify(:after_create,       instance)
+      evaluation.notify(:after_actor_create, instance)
+    end
+  end
+end

--- a/spec/support/build_strategies/actor_create.rb
+++ b/spec/support/build_strategies/actor_create.rb
@@ -12,7 +12,7 @@ class ActorCreate
       evaluator = evaluation.instance_variable_get(:@attribute_assigner)
                             .instance_variable_get(:@evaluator)
 
-      ability = Ability.new(evaluator.user)
+      ability = Ability.new(user(evaluator))
       env     = Hyrax::Actors::Environment.new(instance, ability, {})
 
       evaluation.notify(:before_create,       instance)
@@ -22,4 +22,17 @@ class ActorCreate
       evaluation.notify(:after_actor_create, instance)
     end
   end
+
+  private
+
+    def user(evaluator)
+      user = evaluator.user
+
+      if user.nil? || user.new_record?
+        raise 'You must pass a created depositing user to use the `actor_create` ' /
+              "build strategy; received: #{user}"
+      end
+
+      user
+    end
 end


### PR DESCRIPTION
We only want to mint and update handles for items that are in 'dl' and are published.

I had to play with the `publication_workflow_spec` to understand how to setup the tests for this, which led to a refactor for reusability there.