### PR TITLE
Removes blank wells from non-persisted form renderings

### DIFF
--- a/app/views/hyrax/base/_form_media.html.erb
+++ b/app/views/hyrax/base/_form_media.html.erb
@@ -1,0 +1,7 @@
+<% if f.object.persisted? && f.object.member_ids.present? %>
+  <div class="well form-media">
+    <%= render 'form_representative', f: f %>
+    <%= render 'form_thumbnail', f: f %>
+  </div>
+<% end %>
+

--- a/app/views/hyrax/base/_form_metadata.html.erb
+++ b/app/views/hyrax/base/_form_metadata.html.erb
@@ -1,6 +1,4 @@
-<div class="well">
-   <%= render 'form_media', f: f %>
-</div>
+<%= render 'form_media', f: f %>
 <div class="base-terms">
   <%  Tufts::Terms.shared_terms.each do |term| %>
   <%= render_edit_field_partial(term, f: f)  %>


### PR DESCRIPTION
I put the the thumbnail controls in a well so they would be more distinct in the form, but
this resulted in blank wells when we render the form without those controls. This fixes
that by having the well in another view that is only displayed if the work is persisted.