### PR TITLE
Additional testing for Tufts::Drafts::Editable 

### DIFF
--- a/spec/controllers/hyrax/pdfs_controller_spec.rb
+++ b/spec/controllers/hyrax/pdfs_controller_spec.rb
@@ -1,12 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::PdfsController, type: :controller do
+  render_views
   let(:work) { FactoryGirl.create(:pdf) }
   let(:user) { FactoryGirl.create(:admin) }
   before do
     sign_in user
-    work.title = ["test"]
+    work.title = ["a_drafted_title"]
     work.save_draft
+  end
+  describe 'GET #edit' do
+    it 'applies a draft if one exists' do
+      get :edit, params: { id: work.id }
+      expect(response.body.match('a_drafted_title')).not_to be_nil
+    end
+    it 'does not display draft data if the draft has been deleted' do
+      work.delete_draft
+      get :edit, params: { id: work.id }
+      expect(response.body.match('a_drafted_title')).to be_nil
+    end
   end
   describe 'PATCH #update' do
     it "deletes the draft when updating" do


### PR DESCRIPTION
Our controllers include the Tufts::Drafts::Editable mixin that applies a draft when loading the edit form. This adds more testing for that behavior.