### PR TITLE
Normalize whitespace for batch ingest

### DIFF
--- a/app/controllers/tufts/works_controller.rb
+++ b/app/controllers/tufts/works_controller.rb
@@ -3,7 +3,7 @@ module Tufts
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     include Tufts::Drafts::Editable
-
+    include Tufts::Normalizer
     def create
       normalize_whitespace(params)
       super
@@ -13,42 +13,6 @@ module Tufts
       normalize_whitespace(params)
       delete_draft(params)
       super
-    end
-
-    def strip_whitespace(param_value)
-      return strip_whitespace_transformation(param_value) if param_value.class == String
-      return param_value.map { |m| strip_whitespace_transformation(m) } if param_value.class == Array
-      param_value
-    end
-
-    def strip_whitespace_keep_newlines(param_value)
-      return strip_whitespace_keep_newlines_transformation(param_value) if param_value.class == String
-      return param_value.map { |m| strip_whitespace_keep_newlines_transformation(m) } if param_value.class == Array
-      param_value
-    end
-
-    def strip_whitespace_keep_newlines_transformation(string)
-      string.gsub(/\r/, '').gsub(/[\n]{2,}/, "\n\n").gsub(/[ \t]+/, " ").strip
-    end
-
-    def strip_whitespace_transformation(string)
-      string.gsub(/\s+/, " ").strip
-    end
-
-    # Go through the params hash and normalize whitespace before handing it off to
-    # object creation
-    # @param [ActionController::Parameters] params
-    def normalize_whitespace(params)
-      # For keep_newline_fields, keep single newlines, compress 2+ newlines to 2,
-      # and otherwise strip whitespace as usual
-      keep_newline_fields = ['description', 'abstract']
-      params[hash_key_for_curation_concern].keys.each do |key|
-        params[hash_key_for_curation_concern][key] = if keep_newline_fields.include?(key)
-                                                       strip_whitespace_keep_newlines(params[hash_key_for_curation_concern][key])
-                                                     else
-                                                       strip_whitespace(params[hash_key_for_curation_concern][key])
-                                                     end
-      end
     end
 
     private

--- a/app/lib/tufts/import_record.rb
+++ b/app/lib/tufts/import_record.rb
@@ -12,6 +12,8 @@ module Tufts
   #   record.file = 'filename.png'
   #
   class ImportRecord
+    include Tufts::Normalizer
+
     VISIBILITY_VALUES =
       [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO,
@@ -147,6 +149,7 @@ module Tufts
 
         values = values.map(&:content)
         values = values.first if singular_properties.include?(field.property)
+        values = normalize_import_field(field, values)
         values
       end
   end

--- a/app/lib/tufts/normalizer.rb
+++ b/app/lib/tufts/normalizer.rb
@@ -1,0 +1,48 @@
+module Tufts
+  module Normalizer
+    def strip_whitespace(param_value)
+      return strip_whitespace_transformation(param_value) if param_value.class == String
+      return param_value.map { |m| strip_whitespace_transformation(m) } if param_value.class == Array
+      param_value
+    end
+
+    def strip_whitespace_keep_newlines(param_value)
+      return strip_whitespace_keep_newlines_transformation(param_value) if param_value.class == String
+      return param_value.map { |m| strip_whitespace_keep_newlines_transformation(m) } if param_value.class == Array
+      param_value
+    end
+
+    def strip_whitespace_keep_newlines_transformation(string)
+      string.delete("\r").gsub(/[\n]{2,}/, "\n\n").gsub(/[ \t]+/, " ").strip
+    end
+
+    def strip_whitespace_transformation(string)
+      string.gsub(/\s+/, " ").strip
+    end
+
+    def normalize_import_field(field, values)
+      values = if field.name == :description || field.name == :abstract
+                 strip_whitespace_keep_newlines(values)
+               else
+                 strip_whitespace(values)
+               end
+      values
+    end
+
+    # Go through the params hash and normalize whitespace before handing it off to
+    # object creation
+    # @param [ActionController::Parameters] params
+    def normalize_whitespace(params)
+      # For keep_newline_fields, keep single newlines, compress 2+ newlines to 2,
+      # and otherwise strip whitespace as usual
+      keep_newline_fields = ['description', 'abstract']
+      params[hash_key_for_curation_concern].keys.each do |key|
+        params[hash_key_for_curation_concern][key] = if keep_newline_fields.include?(key)
+                                                       strip_whitespace_keep_newlines(params[hash_key_for_curation_concern][key])
+                                                     else
+                                                       strip_whitespace(params[hash_key_for_curation_concern][key])
+                                                     end
+      end
+    end
+  end
+end

--- a/spec/fixtures/files/mira_xml.xml
+++ b/spec/fixtures/files/mira_xml.xml
@@ -21,8 +21,16 @@ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
           <tufts:filename>pdf-sample.pdf</tufts:filename>
           <tufts:visibility>open</tufts:visibility>
           <model:hasModel>Pdf</model:hasModel>
-          <dc:title>President Jean Mayer speaking at commencement, 1987</dc:title>
-          <dc:description>5x7</dc:description>
+          <dc:title>President Jean Mayer speaking
+          at commencement, 1987</dc:title>
+          <dc11:description>
+            A long       description             with 
+                           plenty
+          of          whitespace</dc11:description>
+          <dc:abstract>
+            Another long       description             with 
+                           plenty
+          of          whitespace</dc:abstract>
           <dc:source>UA136</dc:source>
           <dc:coverage>Medford;7014023;42.417;-71.100</dc:coverage>
           <dc:temporal>1987</dc:temporal>

--- a/spec/lib/tufts/import_record_spec.rb
+++ b/spec/lib/tufts/import_record_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Tufts::ImportRecord do
   subject(:record) { described_class.new }
   let(:id)         { 'IMPORT_RECORD_FAKE_ID' }
-  let(:title)      { 'President Jean Mayer speaking at commencement, 1987' }
+  let(:title)      { "President Jean Mayer speaking\n          at commencement, 1987" }
 
   shared_context 'with metadata' do
     subject(:record) { described_class.new(metadata: node) }
@@ -89,6 +89,10 @@ RSpec.describe Tufts::ImportRecord do
 
       it 'has metadata' do
         expect(record.fields.to_a).not_to be_empty
+      end
+
+      it 'normalized metadata fields' do
+        expect(record.fields.to_a[1]).to eq([:abstract, ["Another long description with \n plenty\n of whitespace"]])
       end
     end
   end

--- a/spec/services/tufts/import_service_spec.rb
+++ b/spec/services/tufts/import_service_spec.rb
@@ -31,7 +31,7 @@ describe Tufts::ImportService, :workflow do
     end
 
     it 'has the title from the imported record' do
-      title = 'President Jean Mayer speaking at commencement, 1987'
+      title = "President Jean Mayer speaking\n          at commencement, 1987"
 
       expect(service.import_object!).to have_attributes(title: [title])
     end


### PR DESCRIPTION
This moves methods that were in the `works_controller` that did whitespacing into a new `Tufts::Normalizer` module.

That module is used in `works_controller` and in the `ImportRecord` class.

It noramlizes the field contents in `ImportRecord` in the same way that is being done in `works_controller`

I also updated the sample XML file with whitespace and the `abstract` and `description` elements. This lets me
test that those fields are being whitespaced correctly.

Closes #592 
