### PR TITLE
Add technical metadata to export

### DIFF
--- a/app/lib/tufts/technical_metadata.rb
+++ b/app/lib/tufts/technical_metadata.rb
@@ -1,0 +1,84 @@
+module Tufts
+  # A class to generate an XML document that contains all the technical
+  # metadata that has been persisted in Fedora after characterization
+  # with FITS
+  #
+  # It does this by loading an ActiveFedora::Base object for a work
+  # and then iterating through the FileSets on the work. It then
+  # creates an Nokogiri::XML::Builder object with values from the
+  # FileSet member's characterization proxy
+  #
+  # @example
+  # tm = Tufts::TechnicalMetadata.new('zvcvcvc23')
+  # tm.to_s
+  #
+  class TechnicalMetadata
+    ##
+    # @!attribute base, builder [r]
+    # @!attribute file_set [rw]
+    attr_reader :base, :builder
+    ##
+    # @param work_id [String]
+    def initialize(work_id)
+      @base = ActiveFedora::Base.find(work_id)
+      @builder = xml_builder
+    end
+
+    # @return [String]
+    def to_s
+      @builder.doc.root.to_s
+    end
+
+    # @return [Object]
+    def to_xml
+      @builder.to_xml
+    end
+
+    # @return [String]
+    def file_name
+      return if @file_set.nil?
+      return if @file_set.characterization_proxy.nil?
+      @file_set.characterization_proxy.file_name[0]
+    end
+
+    private
+
+      # @return [Nokogiri::XML::Builder]
+      def xml_builder # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        @builder = Nokogiri::XML::Builder.new do |xml| # rubocop:disable Metrics/BlockLength
+          xml.technicalMetadata do # rubocop:disable Metrics/BlockLength
+            @base.file_sets.each do |fs| # rubocop:disable Metrics/BlockLength
+              @file_set = fs
+              xml.file do
+                xml.byte_order = fs.characterization_proxy.byte_order[0]
+                xml.compression  = fs.characterization_proxy.compression[0]
+                xml.height       = fs.characterization_proxy.height[0]
+                xml.color_space  = fs.characterization_proxy.color_space[0]
+                xml.profile_name = fs.characterization_proxy.profile_name[0]
+                xml.profile_version = fs.characterization_proxy.profile_version[0]
+                xml.orientation = fs.characterization_proxy.orientation[0]
+                xml.color_map = fs.characterization_proxy.color_map[0]
+                xml.image_producer = fs.characterization_proxy.image_producer[0]
+                xml.capture_device = fs.characterization_proxy.capture_device[0]
+                xml.scanning_software = fs.characterization_proxy.scanning_software[0]
+                xml.gps_timestamp = fs.characterization_proxy.gps_timestamp[0]
+                xml.latitude = fs.characterization_proxy.latitude[0]
+                xml.longitude = fs.characterization_proxy.longitude[0]
+                xml.file_title = fs.characterization_proxy.file_title[0]
+                xml.page_count = fs.characterization_proxy.page_count[0]
+                xml.duration = fs.characterization_proxy.duration[0]
+                xml.sample_rate = fs.characterization_proxy.sample_rate[0]
+                xml.format_label = fs.characterization_proxy.format_label[0]
+                xml.file_size = fs.characterization_proxy.file_size[0]
+                xml.file_name = fs.characterization_proxy.file_name[0]
+                xml.well_formed = fs.characterization_proxy.well_formed[0]
+                xml.original_checksum = fs.characterization_proxy.original_checksum[0]
+                xml.mime_type = fs.characterization_proxy.mime_type[0]
+                xml.size = fs.characterization_proxy.size[0]
+              end
+            end
+          end
+        end
+      end
+  end
+end

--- a/app/lib/tufts/technical_metadata.rb
+++ b/app/lib/tufts/technical_metadata.rb
@@ -9,7 +9,8 @@ module Tufts
   # FileSet member's characterization proxy
   #
   # @example
-  # tm = Tufts::TechnicalMetadata.new('zvcvcvc23')
+  # object = ActiveFedora::Base.find('mnvmbnvb')
+  # tm = Tufts::TechnicalMetadata.new(object)
   # tm.to_s
   #
   class TechnicalMetadata
@@ -18,9 +19,9 @@ module Tufts
     # @!attribute file_set [rw]
     attr_reader :base, :builder
     ##
-    # @param work_id [String]
-    def initialize(work_id)
-      @base = ActiveFedora::Base.find(work_id)
+    # @param work [Object]
+    def initialize(work)
+      @base = work
       @builder = xml_builder
     end
 

--- a/app/lib/tufts/xml_metadata_builder.rb
+++ b/app/lib/tufts/xml_metadata_builder.rb
@@ -25,9 +25,12 @@ module Tufts
                  'xmlns' => 'http://www.openarchives.org/OAI/2.0/') do
           xml.ListRecords do
             @objects.each do |object|
+              tm = Tufts::TechnicalMetadata.new(object.id)
               xml.record do
                 xml.metadata do
+                  xml.parent << tm.to_s
                   xml.mira_import(@mapping.namespaces) do
+                    xml['tufts'].file_name tm.file_name unless tm.file_name.nil?
                     @mapping.map_sorted do |field|
                       if field.property == :id
                         xml[field.namespace.to_s]

--- a/app/lib/tufts/xml_metadata_builder.rb
+++ b/app/lib/tufts/xml_metadata_builder.rb
@@ -25,7 +25,7 @@ module Tufts
                  'xmlns' => 'http://www.openarchives.org/OAI/2.0/') do
           xml.ListRecords do
             @objects.each do |object|
-              tm = Tufts::TechnicalMetadata.new(object.id)
+              tm = Tufts::TechnicalMetadata.new(object)
               xml.record do
                 xml.metadata do
                   xml.parent << tm.to_s

--- a/spec/lib/tufts/technical_metadata_spec.rb
+++ b/spec/lib/tufts/technical_metadata_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+RSpec.describe Tufts::TechnicalMetadata do
+  subject(:tm) { described_class.new(work.id) }
+  let(:work)   { FactoryGirl.create(:pdf) }
+
+  describe 'to_s' do
+    it 'returns valid xml' do
+      expect(Nokogiri::XML(tm.to_s).errors).to eq([])
+    end
+
+    it 'has a technicalMedata root' do
+      expect(Nokogiri::XML(tm.to_s).xpath('/technicalMetadata')).not_to eq(nil)
+    end
+  end
+
+  describe 'to_xml' do
+    it 'returns valid xml' do
+      expect(Nokogiri::XML(tm.to_xml).errors).to eq([])
+    end
+
+    it 'has a technicalMedata root' do
+      expect(Nokogiri::XML(tm.to_xml).xpath('/technicalMetadata')).not_to eq(nil)
+    end
+  end
+
+  describe 'file_name' do
+    it 'returns nil if there is no filename' do
+      expect(tm.file_name).to be_nil
+    end
+  end
+end

--- a/spec/lib/tufts/technical_metadata_spec.rb
+++ b/spec/lib/tufts/technical_metadata_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 RSpec.describe Tufts::TechnicalMetadata do
-  subject(:tm) { described_class.new(work.id) }
+  subject(:tm) { described_class.new(work) }
   let(:work)   { FactoryGirl.create(:pdf) }
 
   describe 'to_s' do


### PR DESCRIPTION
For issue #519 

This commit introduces a `Tufts::TechnicalMetadata` class that can be used
generate XML that contains the persisted technical metadata for a work. Using
the persisted metadata saves us from having to do run another characterization
on the file.

That metadata is added to the `Tufts::XmlMetadataBuilder` so that when
you export a work, the technical metadata is exported as well.

The export also uses the original file name as the `<tufts:file_name>` in the
primary section of the XML. Before exports were being generated without
a filename and you needed to add one to the XML before an import.

Here is an example export:

```xml
<?xml version="1.0"?>
<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/">
  <ListRecords>
    <record>
      <metadata>
        <technicalmetadata>
  <file>
    <byte_order/>
    <compression/>
    <height/>
    <color_space/>
    <profile_name/>
    <profile_version/>
    <orientation/>
    <color_map/>
    <image_producer/>
    <capture_device/>
    <scanning_software/>
    <gps_timestamp/>
    <latitude/>
    <longitude/>
    <file_title>This is a test PDF file</file_title>
    <page_count>1</page_count>
    <duration/>
    <sample_rate/>
    <format_label>Portable Document Format</format_label>
    <file_size>7945</file_size>
    <file_name>pdf-sample.pdf</file_name>
    <well_formed>true</well_formed>
    <original_checksum>fa7d7e650b2cec68f302b31ba28235d8</original_checksum>
    <mime_type>a</mime_type>
    <size>1</size>
  </file>
</technicalmetadata>
        <mira_import xmlns:model="info:fedora/fedora-system:def/model#" xmlns:dc="http://purl.org/dc/terms/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dc11="http://purl.org/dc/elements/1.1/" xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" xmlns:mads="http://www.loc.gov/mads/rdf/v1#" xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/" xmlns:tufts="http://dl.tufts.edu/terms#" xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
          <tufts:file_name>pdf-sample.pdf</tufts:file_name>
          <dc:dateSubmitted datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-11-29T05:05:42+00:00</dc:dateSubmitted>
          <dc:modified datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-11-29T05:05:42+00:00</dc:modified>
          <dc:title>test</dc:title>
          <model:hasModel>Audio</model:hasModel>
          <tufts:displays_in>dl</tufts:displays_in>
          <tufts:id>st74cq459</tufts:id>
        </mira_import>
      </metadata>
    </record>
  </ListRecords>
</OAI-PMH>
```