### PR TITLE
Ensure `date_submitted` is ignored in imports

### DIFF
--- a/app/lib/tufts/import_record.rb
+++ b/app/lib/tufts/import_record.rb
@@ -112,7 +112,7 @@ module Tufts
         case field.property
         when :title
           yield [:title, Array.wrap(title)]
-        when :id, :has_model, :create_date, :modified_date, :head, :tail
+        when :id, :has_model, :date_uploaded, :modified_date, :head, :tail
           next
         else
           values = values_for(field: field)


### PR DESCRIPTION
The wrong term name was listed in ignores for import XML. `ImportRecord` now has the correct attribute for the `dc:dateSubmitted` term.

Closes #613 