### PR TITLE
Use the Normalizer to ensure that single-valued attributes remain nil until they are a non-empty string

### DIFF
--- a/app/lib/tufts/normalizer.rb
+++ b/app/lib/tufts/normalizer.rb
@@ -1,18 +1,21 @@
 module Tufts
   module Normalizer
     def strip_whitespace(param_value)
+      return nil if param_value.empty?
       return strip_whitespace_transformation(param_value) if param_value.class == String
       return param_value.map { |m| strip_whitespace_transformation(m) } if param_value.class == Array
       param_value
     end
 
     def strip_whitespace_keep_newlines(param_value)
+      return nil if param_value.empty?
       return strip_whitespace_keep_newlines_transformation(param_value) if param_value.class == String
       return param_value.map { |m| strip_whitespace_keep_newlines_transformation(m) } if param_value.class == Array
       param_value
     end
 
     def strip_whitespace_keep_newlines_transformation(string)
+      return nil if string.empty?
       string.delete("\r").gsub(/[\n]{2,}/, "\n\n").gsub(/[ \t]+/, " ").strip
     end
 

--- a/spec/controllers/hyrax/audios_controller_spec.rb
+++ b/spec/controllers/hyrax/audios_controller_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Generated via
 #  `rails generate hyrax:work Audio`
 require 'rails_helper'
@@ -10,12 +11,13 @@ RSpec.describe Hyrax::AudiosController do
         "audio" =>
         {
           "title" => " Space   non normalized  \t title    ",
+          "accrual_policy" => "",
           "creator" => " Name   with  Spaces ",
-          "bibliographic_citation" => [" bibliographic   citation   with     spaces    ", ""],
-          "rights_holder" => ["blah     spaces   ", ""],
-          "publisher" => ["Publisher  ", ""],
-          "description" => [" A short   description \n   with  wonky spaces.\r\n\r\n\r\nBut keep two newlines between paragraphs. ", ""],
-          "abstract" => [" A short   description \n   with  wonky spaces.\r\n\r\n\r\nBut keep two newlines between paragraphs. ", ""]
+          "bibliographic_citation" => [" bibliographic   citation   with     spaces    "],
+          "rights_holder" => ["blah     spaces   "],
+          "publisher" => ["Publisher  "],
+          "description" => [" A short   description \n   with  wonky spaces.\r\n\r\n\r\nBut keep two newlines between paragraphs. "],
+          "abstract" => [" A short   description \n   with  wonky spaces.\r\n\r\n\r\nBut keep two newlines between paragraphs. "]
         },
         "controller" => "hyrax/audios",
         "action" => "update"
@@ -25,10 +27,11 @@ RSpec.describe Hyrax::AudiosController do
       described_class.new.normalize_whitespace(params)
       expect(params["audio"]["title"]).to eq "Space non normalized title"
       expect(params["audio"]["creator"]).to eq "Name with Spaces"
-      expect(params["audio"]["bibliographic_citation"]).to contain_exactly("bibliographic citation with spaces", "")
-      expect(params["audio"]["rights_holder"]).to contain_exactly("blah spaces", "")
-      expect(params["audio"]["description"]).to contain_exactly("A short description \n with wonky spaces.\n\nBut keep two newlines between paragraphs.", "")
-      expect(params["audio"]["abstract"]).to contain_exactly("A short description \n with wonky spaces.\n\nBut keep two newlines between paragraphs.", "")
+      expect(params["audio"]["accrual_policy"]).to eq nil
+      expect(params["audio"]["bibliographic_citation"]).to contain_exactly("bibliographic citation with spaces")
+      expect(params["audio"]["rights_holder"]).to contain_exactly("blah spaces")
+      expect(params["audio"]["description"]).to contain_exactly("A short description \n with wonky spaces.\n\nBut keep two newlines between paragraphs.")
+      expect(params["audio"]["abstract"]).to contain_exactly("A short description \n with wonky spaces.\n\nBut keep two newlines between paragraphs.")
     end
   end
 end


### PR DESCRIPTION
This adds methods to the `Tufts::Normalizer` to ensure that single-valued attributes remain `nil` until they are not empty strings.

Fixes #617 