### PR TITLE
Keep documentation in a docs folder so github pages can build it

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,6 @@ You can run CI with `rake` (or `rake ci`). Or start a server with `rake hydra:se
 If you need to re-create derivatives, use these rake tasks:
 1. One at a time, by id: `RAILS_ENV=production bundle exec rake derivatives:recreate_by_id[2801pg32c]`
 1. Re-create derivatives for all PDF objects: `RAILS_ENV=production bundle exec rake derivatives:recreate_all_pdfs`
+
+## Importing data
+See [importing data documentation](docs/importing_data.md)

--- a/docs/importing_data.md
+++ b/docs/importing_data.md
@@ -1,0 +1,3 @@
+# Importing data
+
+This is a placeholder


### PR DESCRIPTION
Since it sounds like we're going to need to produce some documentation, let's make it easy to use by displaying it with github pages. Once we have a docs folder with markdown files in it, we just need to turn on github pages and tell it to look for a /docs folder. See, e.g., the way `ansible_samvera` publishes its docs at https://curationexperts.github.io/ansible-samvera/. If we do this, the docs will appear at https://curationexperts.github.io/epigaea/.