### PR TITLE
Use Hyrax::User.batch_user

### DIFF
--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -3,17 +3,6 @@
 class PublishJob < BatchableJob
   def perform(id)
     work = ActiveFedora::Base.find(id)
-    Tufts::WorkflowStatus.publish(work: work, current_user: workflow_user, comment: "Published by #{workflow_user.display_name} #{Time.zone.now}")
-  end
-
-  # The workflow needs the action to be performed by a user with admin rights
-  # @return [::User] an admin user to perform the batch publish operation
-  def workflow_user
-    ::User.find_or_create_by(email: 'batch_workflow_user@example.com') do |user|
-      user.display_name = "Batch Publish Job"
-      user.password = SecureRandom.uuid
-      admin_role = Role.where(name: 'admin').first_or_create
-      user.roles << admin_role
-    end
+    Tufts::WorkflowStatus.publish(work: work, current_user: ::User.batch_user, comment: "Published by PublishJob #{Time.zone.now}")
   end
 end

--- a/app/jobs/unpublish_job.rb
+++ b/app/jobs/unpublish_job.rb
@@ -3,17 +3,6 @@
 class UnpublishJob < BatchableJob
   def perform(id)
     work = ActiveFedora::Base.find(id)
-    Tufts::WorkflowStatus.unpublish(work: work, current_user: workflow_user, comment: "Unpublished by #{workflow_user.display_name} #{Time.zone.now}")
-  end
-
-  # The workflow needs the action to be performed by a user with admin rights
-  # @return [::User] an admin user to perform the batch publish operation
-  def workflow_user
-    ::User.find_or_create_by(email: 'batch_workflow_user@example.com') do |user|
-      user.display_name = "Batch Publish Job"
-      user.password = SecureRandom.uuid
-      admin_role = Role.where(name: 'admin').first_or_create
-      user.roles << admin_role
-    end
+    Tufts::WorkflowStatus.unpublish(work: work, current_user: ::User.batch_user, comment: "Unpublished by UnpublishJob #{Time.zone.now}")
   end
 end

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -14,14 +14,6 @@ RSpec.describe PublishJob, :workflow, type: :job do
     end
   end
 
-  describe '#workflow_user' do
-    it "finds or creates an admin user who can perform the workflow action" do
-      user = job.new.workflow_user
-      expect(user.user_key).to eq "batch_workflow_user@example.com"
-      expect(user.admin?).to eq true
-    end
-  end
-
   context "workflow transition" do
     let(:work) { FactoryGirl.create(:pdf) }
     let(:depositing_user) { FactoryGirl.create(:user) }

--- a/spec/jobs/unpublish_job_spec.rb
+++ b/spec/jobs/unpublish_job_spec.rb
@@ -14,14 +14,6 @@ RSpec.describe UnpublishJob, :workflow, type: :job do
     end
   end
 
-  describe '#workflow_user' do
-    it "finds or creates an admin user who can perform the workflow action" do
-      user = job.new.workflow_user
-      expect(user.user_key).to eq "batch_workflow_user@example.com"
-      expect(user.admin?).to eq true
-    end
-  end
-
   context "workflow transition" do
     let(:work) { FactoryGirl.create(:pdf) }
     let(:depositing_user) { FactoryGirl.create(:user) }


### PR DESCRIPTION
Instead of redefining our own batch_user, we should use the batch_user
method defined in the Hyrax::User module. This gives us less code
to maintain, and allows for configuration of the user id in hyrax.rb.

Fixes #604 