### PR TITLE
Recover from mistaken controlled values in the show view

### DIFF
--- a/app/renderers/resource_type_renderer.rb
+++ b/app/renderers/resource_type_renderer.rb
@@ -1,7 +1,11 @@
 class ResourceTypeRenderer < Hyrax::Renderers::AttributeRenderer
-  private
+  SERVICE = Tufts::ResourceTypeService
 
-    def attribute_value_to_html(value)
-      Tufts::ResourceTypeService.label(value)
-    end
+  ##
+  # @private
+  def attribute_value_to_html(value)
+    SERVICE.label(value)
+  rescue SERVICE::LookupError
+    value
+  end
 end

--- a/app/services/tufts/resource_type_service.rb
+++ b/app/services/tufts/resource_type_service.rb
@@ -1,16 +1,32 @@
 module Tufts
   module ResourceTypeService
+    ##
+    # @!attribute [rw] authority
+    #   @return [Qa::Authorities::Base]
     mattr_accessor :authority
     self.authority = Qa::Authorities::Local.subauthority_for('resource_types')
 
+    ##
+    # @return [Array<Array<String, String>>] a collection of [label, id] pairs
     def self.select_options
       authority.all.map do |element|
         [element[:label], element[:id]]
       end
     end
 
+    ##
+    # @param id [String] the authority id to look up
+    #
+    # @return [String] the `term` matching the authority id
+    #
+    # @raise [ResourceTypeService::LookupError]
     def self.label(id)
-      authority.find(id).fetch('term')
+      authority.find(id).fetch('term') do
+        raise LookupError,
+              "Tried to look up missing label for resource type: #{id}"
+      end
     end
+
+    class LookupError < ArgumentError; end
   end
 end

--- a/spec/renderers/resource_type_renderer_spec.rb
+++ b/spec/renderers/resource_type_renderer_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ResourceTypeRenderer do
+  subject(:renderer) { described_class.new(field, values) }
+  let(:field)        { :resource_type }
+  let(:labels)       { ['Collection', 'Image'] }
+
+  let(:values) { ['http://purl.org/dc/dcmitype/Collection', 'http://purl.org/dc/dcmitype/Image'] }
+
+  describe '#render' do
+    it 'has the labels' do
+      expect(renderer.render).to include(*labels)
+    end
+
+    context 'with unexpected values' do
+      let(:values) { ['moomin', 'hattifatteners'] }
+
+      it 'shows the values instead' do
+        expect(renderer.render).to include(*values)
+      end
+    end
+  end
+end

--- a/spec/services/tufts/resource_type_service_spec.rb
+++ b/spec/services/tufts/resource_type_service_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::ResourceTypeService do
+  describe '.label' do
+    let(:id)    { 'http://purl.org/dc/dcmitype/Collection' }
+    let(:label) { 'Collection' }
+
+    it 'finds the label of a known property' do
+      expect(described_class.label(id)).to eq label
+    end
+
+    it 'raises an error for an unknown property' do
+      expect { described_class.label('NOT A REAL TERM') }.to raise_error described_class::LookupError
+    end
+  end
+end


### PR DESCRIPTION
It is possible to save objects with uncontrolled values, so the show views need to be able to handle this case.

This fixes the renderer for the Resource Type vocabulary to render the requested value in the case that a label can't be found.

Fixes #661.