### PR TITLE
Handle `nil` ids in `Batch::Item`

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -37,7 +37,7 @@ class Batch < ApplicationRecord
   end
 
   ##
-  # @return [Enumerator<ActiveFedora::Base>]
+  # @return [Enumerator<Batch::Item>]
   def items
     ids.lazy.map { |obj_id| Item.new(obj_id, id, store: STATUS_STORE) }
   end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -65,7 +65,7 @@ class Batch < ApplicationRecord
       @store    = store
       @object   = begin
         ActiveFedora::Base.find(id)
-      rescue Ldp::Gone, ActiveFedora::ObjectNotFoundError
+      rescue Ldp::Gone, ActiveFedora::ObjectNotFoundError, ArgumentError
         nil
       end
     end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe Batch, type: :model, batch: true do
       end
     end
 
+    context 'when the object does not exist' do
+      it 'can initialize' do
+        expect { described_class.new('fake_af_id', batch.id) }.not_to raise_error
+      end
+
+      it 'can with initialize with nil' do
+        expect { described_class.new(nil, batch.id) }.not_to raise_error
+      end
+    end
+
     describe '#job_id' do
       context 'with nothing in the store' do
         it 'is nil' do


### PR DESCRIPTION
It's possible for `Batch::Item` to be passed a `nil` id, when this happens, we want the item to handle it gracefully.

In this case, this means catching `ArgumentError` which is unfortunately the level of specificity that `ActiveFedora` offers us when we pass a `nil` id.

Fixes #663.

Fixes the [Batches index view](http://epigaea.curationexperts.com/batches)