### PR TITLE
Ensure capistrano restarts consistently after deploy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ Metrics/MethodLength:
 Performance/StringReplacement:
    Exclude:
     - 'app/controllers/tufts/works_controller.rb'
+Rails/TimeZone:
+  Exclude:
+    - 'config/initializers/git_sha.rb'  
 RSpec/ExampleLength:
    Exclude:
     - 'spec/features/**/*'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,9 @@
 # config valid only for certain versions of Capistrano
 lock ">=3.9.0"
 
+# Restart options
+set :passenger_restart_wait, 20
+
 set :application, "epigaea"
 set :repo_url, "https://github.com/curationexperts/epigaea.git"
 

--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -19,7 +19,7 @@ BRANCH =
 LAST_DEPLOYED =
   if Rails.env.production? && File.exist?('/opt/epigaea/revisions.log')
     deployed = `tail -1 /opt/epigaea/revisions.log`.chomp.split(" ")[7]
-    Date.parse(deployed).strftime("%d %B %Y")
+    DateTime.parse(deployed).strftime("%e %b %Y %H:%M:%S")
   else
     "Not in deployed environment"
   end


### PR DESCRIPTION
Add delay to passenger restart
Add time of deploy to footer for easier debugging

Fixes #670 

With the `:passenger_restart_wait` option added I was able to deploy over and over again and see the deployed footer each time, using curl:

```
      Version <span title="45163a30696a84e452bde5242c6deabf40405bc2">restart_on_cap_deploy updated  7 Dec 2017 16:02:05</span>
      Version <span title="45163a30696a84e452bde5242c6deabf40405bc2">restart_on_cap_deploy updated  7 Dec 2017 16:02:57</span>
      Version <span title="45163a30696a84e452bde5242c6deabf40405bc2">restart_on_cap_deploy updated  7 Dec 2017 16:03:59</span>
      Version <span title="45163a30696a84e452bde5242c6deabf40405bc2">restart_on_cap_deploy updated  7 Dec 2017 16:05:01</span>
```