### PR TITLE
Render page even if rights_statement is empty or invalid

### DIFF
--- a/app/renderers/tufts_rights_statement_attribute_renderer.rb
+++ b/app/renderers/tufts_rights_statement_attribute_renderer.rb
@@ -1,0 +1,26 @@
+# This is used by PresentsAttributes to show licenses
+#   e.g.: presenter.attribute_to_html(:rights_statement, render_as: :rights_statement)
+# We are overriding the Hyrax RightsStatementAttributeRenderer because it crashes when rights_statement is invalid
+# See https://github.com/samvera/hyrax/issues/2323 for bug report
+class TuftsRightsStatementAttributeRenderer < Hyrax::Renderers::RightsStatementAttributeRenderer
+  private
+
+    ##
+    # Special treatment for license/rights.  A URL from the Hyrax gem's config/hyrax.rb is stored in the descMetadata of the
+    # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
+    def attribute_value_to_html(value)
+      return if value == ""
+      begin
+        parsed_uri = URI.parse(value)
+      rescue
+        nil
+      end
+      if parsed_uri.nil?
+        ERB::Util.h(value)
+      else
+        %(<a href=#{ERB::Util.h(value)} target="_blank">#{Hyrax.config.rights_statement_service_class.new.label(value)}</a>)
+      end
+    rescue => exception
+      Rails.logger.error("Could not render rights statement #{value}: #{exception}")
+    end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -43,7 +43,7 @@
 <%= presenter.attribute_to_html(:rejection_reason, render_as: :linked, search_field: 'all_fields') %>
 <%= presenter.attribute_to_html(:replaces, render_as: :linked, search_field: 'all_fields') %>
 <%= presenter.attribute_to_html(:retention_period, render_as: :linked, search_field: 'all_fields') %>
-<%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement) %>
+<%= presenter.attribute_to_html(:rights_statement, render_as: :tufts_rights_statement, include_empty: false) %>
 <%= presenter.attribute_to_html(:rights_holder, render_as: :linked, search_field: 'all_fields') %>
 <%= presenter.attribute_to_html(:rights_note, render_as: :linked, search_field: 'all_fields') %>
 <%= presenter.attribute_to_html(:source, render_as: :linked, search_field: 'all_fields') %>

--- a/spec/features/show_empty_rights_statement_spec.rb
+++ b/spec/features/show_empty_rights_statement_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Empty string in rights statement', :clean, js: false do
+  context 'a logged in admin user' do
+    let(:user) { FactoryGirl.create(:admin) }
+    let(:pdf) { FactoryGirl.create(:pdf) }
+
+    before do
+      login_as user
+      pdf.rights_statement = [""]
+      pdf.save
+    end
+
+    scenario do
+      visit "/concern/pdfs/#{pdf.id}"
+      expect(page).to have_content pdf.title.first
+    end
+  end
+end


### PR DESCRIPTION
Currently, objects with an invalid rights_statement, e.g., [""],
will not render. We are overriding Hyrax::Renderers::RightsStatementAttributeRenderer
to fix this bug locally, and we have also reported the error upstream, at
https://github.com/samvera/hyrax/issues/2323

Fixes #665 