### PR TITLE
Fix the default Hyrax batch create work forms

### DIFF
--- a/app/views/hyrax/base/_form_metadata.html.erb
+++ b/app/views/hyrax/base/_form_metadata.html.erb
@@ -1,13 +1,16 @@
+
 <%= render 'form_media', f: f %>
 
 <% if @curation_concern.class.to_s == 'Audio' || @curation_concern.class.to_s == 'Video' %>
-  <div class="well transcript-selection">
-    <%= render_edit_field_partial(:transcript_id, f: f) %>
-  </div>
+    <div class="well transcript-selection">
+        <%= render_edit_field_partial(:transcript_id, f: f) %>
+    </div>
 <% end %>
 
 <div class='base-terms'>
-<%= render_edit_field_partial(:title,  f: f) %>
+<% unless current_page?(:controller => 'batch_uploads', :action => 'new') %>
+  <%= render_edit_field_partial(:title,  f: f) %>
+<% end %>
 <%= render_edit_field_partial(:displays_in,  f: f) %>
 <%= render_edit_field_partial(:abstract,  f: f) %>
 <%= render_edit_field_partial(:accrual_policy,  f: f) %>
@@ -63,5 +66,7 @@
 <%= render_edit_field_partial(:table_of_contents,  f: f) %>
 <%= render_edit_field_partial(:temporal,  f: f) %>
 <%= render_edit_field_partial(:tufts_license,  f: f) %>
-<%= render_edit_field_partial(:resource_type,  f: f) %>
+<% unless current_page?(:controller => 'batch_uploads', :action => 'new') %>
+  <%= render_edit_field_partial(:resource_type,  f: f) %>
+<% end %>
 </div>

--- a/config/initializers/batch_form_terms.rb
+++ b/config/initializers/batch_form_terms.rb
@@ -1,0 +1,4 @@
+# This sets up the correct terms for the batch works forms
+Hyrax::Forms::BatchUploadForm.terms = Tufts::Terms.shared_terms
+Hyrax::Forms::BatchUploadForm.terms -= [:title, :resource_type]
+Hyrax::Forms::BatchUploadForm.required_fields = [:displays_in]

--- a/spec/features/create_audio_spec.rb
+++ b/spec/features/create_audio_spec.rb
@@ -20,6 +20,8 @@ RSpec.feature 'Create a Audio', :clean, js: true do
         click_button "Create work"
       end
       expect(page).to have_content "Add New Audio"
+      # We want the transcription UI to show up on the form
+      expect(page).to have_content('You will need to attach an XML file to to this work to select a transcript.')
     end
   end
 end

--- a/spec/features/create_batch_of_works.rb
+++ b/spec/features/create_batch_of_works.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Create a batch of works', :clean, js: true do
+  context 'a logged in admin user' do
+    let(:user) { FactoryGirl.create(:admin) }
+
+    before { login_as user }
+
+    scenario do
+      visit '/dashboard'
+      click_link 'Works'
+      expect(page).to have_content 'Create batch of works'
+      click_link 'Create batch of works'
+      within('form.new-work-select') do
+        select 'PDF', from: 'work-type-select-box'
+        click_button "Create work"
+      end
+      expect(page).to have_content 'Descriptions'
+      click_link 'Descriptions'
+      expect(page).not_to have_selector '#batch_upload_item_title'
+      expect(page).to have_content 'Displays in'
+      click_link 'Files'
+      execute_script("$('.fileinput-button input:first').css({'opacity':'1', 'display':'block', 'position':'relative'})")
+      attach_file('files[]', File.absolute_path(file_fixture('pdf-sample.pdf')))
+      expect(page).to have_content('Display label')
+      click_link 'Descriptions'
+      find(:xpath, '//option[contains(text(), "nowhere")]').select_option
+      click_link 'Files'
+      find('#with_files_submit').click
+      expect(page).to have_content 'Your Works'
+      expect(page).to have_content 'Your files are being processed by MIRA in the background.'
+    end
+  end
+end

--- a/spec/features/create_pdf_spec.rb
+++ b/spec/features/create_pdf_spec.rb
@@ -22,6 +22,8 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       # Hyrax::BasicMetadata attributes that we don't want in the form
       expect(page).to have_no_content('Keywords')
       expect(page).to have_no_content('Location')
+      # We don't want the transcript UI to show up on the Pdf form
+      expect(page).not_to have_content('You will need to attach an XML file to to this work to select a transcript.')
       # Fill out the form with everything
       within('.pdf_title') do
         fill_in "Title", with: "Example \nTitle   "

--- a/spec/features/create_video_spec.rb
+++ b/spec/features/create_video_spec.rb
@@ -20,6 +20,8 @@ RSpec.feature 'Create a Video', :clean, js: true do
         click_button "Create work"
       end
       expect(page).to have_content "Add New Video"
+      # We want the transcription UI to show up on the form
+      expect(page).to have_content('You will need to attach an XML file to to this work to select a transcript.')
     end
   end
 end

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -1,15 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
+  before do
+    allow(view).to receive(:current_page?).with(
+      controller: 'batch_uploads',
+      action: 'new'
+    ).and_return(false)
+  end
   context 'a video form' do
     let(:work) { FactoryGirl.create(:video) }
     let(:form) do
       Hyrax::VideoForm.new(work, ability, controller)
     end
+
     it_behaves_like 'a work that has transcript UI on the form'
   end
 
-  context 'a video form' do
+  context 'an audio form' do
     let(:work) { FactoryGirl.create(:audio) }
     let(:form) do
       Hyrax::AudioForm.new(work, ability, controller)


### PR DESCRIPTION
This commit fixes the batch create work forms by setting the
`Hyrax::Forms::BatchUploadForm.terms` variable to the terms
that we use in forms via an initializer. The `_form_metadata` partial
has also been tweaked so that it displays properly on the batch
create work pages.

This is tested  with a feature spec that adds a `Pdf` work via the
batch upload form.

This removes the `_form_metadata` view specs and shared examples in favor of checking for the transcript UI in the Audio / Video feature specs and checking that the transcript UI doesn't show up in the create Pdf feature spec. The create Pdf / Audio / Video feature specs are already being run and this replaces the 40+ lines of view specs with 3 lines of additional expectations in the feature specs.

I think that it is important to keep the default Hyrax batch new work features working.

Fixes #641