### PR TITLE
Error out when trying to import existing objects

### DIFF
--- a/app/actors/application_model_actor.rb
+++ b/app/actors/application_model_actor.rb
@@ -1,0 +1,15 @@
+##
+# A base actor which model actors in this application should inherit from.
+#
+# @see Hyrax::Actors::ModelActor
+class ApplicationModelActor < Hyrax::Actors::BaseActor
+  ##
+  # Extends BaseActor to reject attempts to create an item that already exists.
+  #
+  # @param [Hyrax::Actors::Environment] env
+  # @return [Boolean] true if create was successful
+  def create(env)
+    return false unless env.curation_concern.new_record?
+    super
+  end
+end

--- a/app/actors/hyrax/actors/audio_actor.rb
+++ b/app/actors/hyrax/actors/audio_actor.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Audio`
 module Hyrax
   module Actors
-    class AudioActor < Hyrax::Actors::BaseActor
+    class AudioActor < ApplicationModelActor
     end
   end
 end

--- a/app/actors/hyrax/actors/ead_actor.rb
+++ b/app/actors/hyrax/actors/ead_actor.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Ead`
 module Hyrax
   module Actors
-    class EadActor < Hyrax::Actors::BaseActor
+    class EadActor < ApplicationModelActor
     end
   end
 end

--- a/app/actors/hyrax/actors/generic_object_actor.rb
+++ b/app/actors/hyrax/actors/generic_object_actor.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work GenericObject`
 module Hyrax
   module Actors
-    class GenericObjectActor < Hyrax::Actors::BaseActor
+    class GenericObjectActor < ApplicationModelActor
     end
   end
 end

--- a/app/actors/hyrax/actors/image_actor.rb
+++ b/app/actors/hyrax/actors/image_actor.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Image`
 module Hyrax
   module Actors
-    class ImageActor < Hyrax::Actors::BaseActor
+    class ImageActor < ApplicationModelActor
     end
   end
 end

--- a/app/actors/hyrax/actors/pdf_actor.rb
+++ b/app/actors/hyrax/actors/pdf_actor.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Pdf`
 module Hyrax
   module Actors
-    class PdfActor < Hyrax::Actors::BaseActor
+    class PdfActor < ApplicationModelActor
     end
   end
 end

--- a/app/actors/hyrax/actors/rcr_actor.rb
+++ b/app/actors/hyrax/actors/rcr_actor.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Rcr`
 module Hyrax
   module Actors
-    class RcrActor < Hyrax::Actors::BaseActor
+    class RcrActor < ApplicationModelActor
     end
   end
 end

--- a/app/actors/hyrax/actors/tei_actor.rb
+++ b/app/actors/hyrax/actors/tei_actor.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Tei`
 module Hyrax
   module Actors
-    class TeiActor < Hyrax::Actors::BaseActor
+    class TeiActor < ApplicationModelActor
     end
   end
 end

--- a/app/actors/hyrax/actors/video_actor.rb
+++ b/app/actors/hyrax/actors/video_actor.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Video`
 module Hyrax
   module Actors
-    class VideoActor < Hyrax::Actors::BaseActor
+    class VideoActor < ApplicationModelActor
     end
   end
 end

--- a/app/actors/hyrax/actors/voting_record_actor.rb
+++ b/app/actors/hyrax/actors/voting_record_actor.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work VotingRecord`
 module Hyrax
   module Actors
-    class VotingRecordActor < Hyrax::Actors::BaseActor
+    class VotingRecordActor < ApplicationModelActor
     end
   end
 end

--- a/app/services/tufts/import_service.rb
+++ b/app/services/tufts/import_service.rb
@@ -55,7 +55,8 @@ module Tufts
       attributes = { uploaded_files: file_ids }
       env        = Hyrax::Actors::Environment.new(object, ability, attributes)
 
-      Hyrax::CurationConcern.actor.create(env)
+      Hyrax::CurationConcern.actor.create(env) ||
+        raise(ImportError, "Failed to create object #{object.id}\n The actor stack returned `false`.")
       object
     end
 
@@ -65,6 +66,8 @@ module Tufts
       # UploadedFile -> Uploader -> CarrierWave::SanitizedFile -> String
       import.record_for(file: file.file.file.filename)
     end
+
+    class ImportError < RuntimeError; end
 
     private
 

--- a/spec/actors/application_model_actor_spec.rb
+++ b/spec/actors/application_model_actor_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationModelActor do
+  subject(:actor) { described_class.new(next_actor) }
+
+  let(:ability)    { ::Ability.new(create(:admin)) }
+  let(:env)        { Hyrax::Actors::Environment.new(object, ability, {}) }
+  let(:next_actor) { instance_double(Hyrax::Actors::Terminator, create: true) }
+  let(:object)     { build(:pdf) }
+
+  describe '#create' do
+    it 'saves an object' do
+      expect { actor.create(env) }
+        .to change { object.new_record? }
+        .from(true)
+        .to(false)
+    end
+
+    it 'hits next actor' do
+      actor.create(env)
+      expect(next_actor).to have_received(:create).with(env)
+    end
+
+    it 'returns truthy' do
+      expect(actor.create(env)).to be_truthy
+    end
+
+    context 'when the object exists' do
+      let(:object) { create(:pdf, date_uploaded: date) }
+      let(:date)   { Hyrax::TimeService.time_in_utc }
+
+      it 'does not change date submitted' do
+        expect { actor.create(env) }
+          .not_to change { object.date_uploaded }
+          .from date
+      end
+
+      it 'pops out of stack' do
+        actor.create(env)
+        expect(next_actor).not_to have_received(:create)
+      end
+
+      it 'returns false' do
+        expect(actor.create(env)).to eq false
+      end
+    end
+  end
+end

--- a/spec/controllers/tufts/publication_status_controller_spec.rb
+++ b/spec/controllers/tufts/publication_status_controller_spec.rb
@@ -1,16 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Tufts::PublicationStatusController, :workflow, type: :controller do
-  let(:work) { FactoryGirl.create(:pdf) }
+  let(:work) { FactoryGirl.actor_create(:pdf, user: depositing_user) }
   let(:depositing_user) { FactoryGirl.create(:user) }
   let(:admin) { FactoryGirl.create(:admin) }
 
   before do
-    allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-    current_ability = ::Ability.new(depositing_user)
-    attributes = {}
-    env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
-    Hyrax::CurationConcern.actor.create(env)
     allow(controller).to receive(:authenticate_user!).and_return(true)
     allow(controller).to receive(:current_user).and_return(admin)
   end

--- a/spec/factories/pdf.rb
+++ b/spec/factories/pdf.rb
@@ -13,16 +13,10 @@ FactoryGirl.define do
 
     factory :published_pdf do
       after(:create) do |work, evaluator|
-        Tufts::WorkflowStatus.publish(work: work, current_user: evaluator.user, comment: 'Published by :published_pdf factory in `after_create` hook.')
-        # action_info = Hyrax::WorkflowActionInfo.new(work, evaluator.user)
-        # scope       = action_info.entity.workflow
-        # action      = PowerConverter
-        #               .convert_to_sipity_action("publish", scope: scope) { nil }
-        #
-        # Hyrax::Workflow::WorkflowActionService
-        #   .run(subject: action_info,
-        #        action:  action,
-        #        comment: 'Published by :published_pdf factory in `after_create` hook.')
+        Tufts::WorkflowStatus
+          .publish(work:         work,
+                   current_user: evaluator.user,
+                   comment:      'Published by :published_pdf factory in `after_create` hook.')
       end
     end
   end

--- a/spec/features/create_draft_spec.rb
+++ b/spec/features/create_draft_spec.rb
@@ -4,8 +4,9 @@ include Warden::Test::Helpers
 RSpec.feature 'Create and revert a draft', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
-    let(:pdf) { FactoryGirl.create(:pdf) }
+    let(:pdf) { FactoryGirl.build(:pdf) }
 
+    # @todo add support for file creation to actor_create build strategy
     before do
       login_as user
       pdf_file = File.open(Rails.root.join('spec', 'fixtures', 'hello.pdf'))

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe PublishJob, :workflow, type: :job do
   subject(:job) { described_class }
   let(:pdf) { FactoryGirl.create(:pdf) }
 
+  before { ActiveJob::Base.queue_adapter = :test }
+
   describe '#perform_later' do
     it 'enqueues the job' do
-      ActiveJob::Base.queue_adapter = :test
       expect { job.perform_later(pdf.id) }
         .to enqueue_job(described_class)
         .with(pdf.id)
@@ -15,15 +16,9 @@ RSpec.describe PublishJob, :workflow, type: :job do
   end
 
   context "workflow transition" do
-    let(:work) { FactoryGirl.create(:pdf) }
+    let(:work) { FactoryGirl.actor_create(:pdf, user: depositing_user) }
     let(:depositing_user) { FactoryGirl.create(:user) }
-    before do
-      allow(CharacterizeJob).to receive(:perform_later) # Don't run fits
-      current_ability = ::Ability.new(depositing_user)
-      attributes = {}
-      env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
-      Hyrax::CurationConcern.actor.create(env)
-    end
+
     it 'sets the workflow status to published' do
       expect(work.to_sipity_entity.reload.workflow_state_name).to eq "unpublished"
       job.perform_now(work.id)

--- a/spec/services/hyrax/workflow/comment_notification_spec.rb
+++ b/spec/services/hyrax/workflow/comment_notification_spec.rb
@@ -1,27 +1,21 @@
-libdir = File.expand_path('../../../../', __FILE__)
-$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
-require 'active_fedora/cleaner'
-require 'database_cleaner'
 
-RSpec.describe Hyrax::Workflow::CommentNotification, :workflow do
+RSpec.describe Hyrax::Workflow::CommentNotification, :workflow, :clean do
   let(:depositor) { FactoryGirl.create(:user) }
-  let(:admin) { FactoryGirl.create(:admin) }
-  let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }
-  let(:ability) { ::Ability.new(depositor) }
+  let!(:admin)    { FactoryGirl.create(:admin) }
+  let(:work)      { FactoryGirl.actor_create(:pdf, depositor: depositor.user_key, user: depositor) }
+
   let(:recipients) do
     { 'to' => [depositor] }
   end
+
   let(:notification) do
-    current_ability = ::Ability.new(depositor)
-    admin # ensure admin user exists
-    attributes = {}
-    env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
-    Hyrax::CurationConcern.actor.create(env)
     work_global_id = work.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
+
     described_class.new(entity, '', depositor, recipients)
   end
+
   it "includes a full url in the message" do
     expect(notification).to be_instance_of(described_class)
     expect(notification.message).to match(/http/)

--- a/spec/services/hyrax/workflow/published_notification_spec.rb
+++ b/spec/services/hyrax/workflow/published_notification_spec.rb
@@ -1,27 +1,21 @@
-libdir = File.expand_path('../../../../', __FILE__)
-$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
-require 'active_fedora/cleaner'
-require 'database_cleaner'
 
 RSpec.describe Hyrax::Workflow::PublishedNotification, :workflow do
   let(:depositor) { FactoryGirl.create(:user) }
-  let(:admin) { FactoryGirl.create(:admin) }
-  let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }
-  let(:ability) { ::Ability.new(depositor) }
+  let!(:admin)    { FactoryGirl.create(:admin) }
+  let(:work)      { FactoryGirl.actor_create(:pdf, depositor: depositor.user_key, user: depositor) }
+
   let(:recipients) do
     { 'to' => [depositor] }
   end
+
   let(:notification) do
-    current_ability = ::Ability.new(depositor)
-    admin # ensure admin user exists
-    attributes = {}
-    env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
-    Hyrax::CurationConcern.actor.create(env)
     work_global_id = work.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
+
     described_class.new(entity, '', depositor, recipients)
   end
+
   it "includes a full url in the message" do
     expect(notification).to be_instance_of(described_class)
     expect(notification.message).to match(/http/)

--- a/spec/services/hyrax/workflow/self_deposit_notification_spec.rb
+++ b/spec/services/hyrax/workflow/self_deposit_notification_spec.rb
@@ -1,27 +1,21 @@
-libdir = File.expand_path('../../../../', __FILE__)
-$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
-require 'active_fedora/cleaner'
-require 'database_cleaner'
 
 RSpec.describe Hyrax::Workflow::SelfDepositNotification, :workflow do
   let(:depositor) { FactoryGirl.create(:user) }
-  let(:admin) { FactoryGirl.create(:admin) }
-  let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }
-  let(:ability) { ::Ability.new(depositor) }
+  let!(:admin)    { FactoryGirl.create(:admin) }
+  let(:work)      { FactoryGirl.actor_create(:pdf, depositor: depositor.user_key, user: depositor) }
+
   let(:recipients) do
     { 'to' => [depositor] }
   end
+
   let(:notification) do
-    current_ability = ::Ability.new(depositor)
-    admin # ensure admin user exists
-    attributes = {}
-    env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
-    Hyrax::CurationConcern.actor.create(env)
     work_global_id = work.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
+
     described_class.new(entity, '', depositor, recipients)
   end
+
   it "includes a full url in the message" do
     expect(notification).to be_instance_of(described_class)
     expect(notification.message).to match(/http/)

--- a/spec/services/hyrax/workflow/unpublished_notification_spec.rb
+++ b/spec/services/hyrax/workflow/unpublished_notification_spec.rb
@@ -1,27 +1,21 @@
-libdir = File.expand_path('../../../../', __FILE__)
-$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
-require 'active_fedora/cleaner'
-require 'database_cleaner'
 
 RSpec.describe Hyrax::Workflow::UnpublishedNotification, :workflow do
   let(:depositor) { FactoryGirl.create(:user) }
-  let(:admin) { FactoryGirl.create(:admin) }
-  let(:work) { FactoryGirl.create(:pdf, depositor: depositor.user_key) }
-  let(:ability) { ::Ability.new(depositor) }
+  let!(:admin) { FactoryGirl.create(:admin) }
+  let(:work) { FactoryGirl.actor_create(:pdf, depositor: depositor.user_key, user: depositor) }
+
   let(:recipients) do
     { 'to' => [depositor] }
   end
+
   let(:notification) do
-    current_ability = ::Ability.new(depositor)
-    admin # ensure admin user exists
-    attributes = {}
-    env = Hyrax::Actors::Environment.new(work, current_ability, attributes)
-    Hyrax::CurationConcern.actor.create(env)
     work_global_id = work.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
+
     described_class.new(entity, '', depositor, recipients)
   end
+
   it "includes a full url in the message" do
     expect(notification).to be_instance_of(described_class)
     expect(notification.message).to match(/http/)

--- a/spec/services/tufts/import_service_spec.rb
+++ b/spec/services/tufts/import_service_spec.rb
@@ -36,6 +36,14 @@ describe Tufts::ImportService, :workflow, :clean do
 
       expect(service.import_object!).to have_attributes(title: [title])
     end
+
+    context 'when the object exists' do
+      before { object.save }
+
+      it 'raises an error' do
+        expect { service.import_object! }.to raise_error described_class::ImportError
+      end
+    end
   end
 
   describe '#record' do

--- a/spec/support/build_strategies/actor_create.rb
+++ b/spec/support/build_strategies/actor_create.rb
@@ -29,7 +29,7 @@ class ActorCreate
       user = evaluator.user
 
       if user.nil? || user.new_record?
-        raise 'You must pass a created depositing user to use the `actor_create` ' /
+        raise 'You must pass a created depositing user to use the `actor_create` ' \
               "build strategy; received: #{user}"
       end
 


### PR DESCRIPTION
This is to improve the codebase around #680. Currently, it appears we are trying to create the same objects twice in import. We don't yet know why this is happening, but it is hard to debug mainly because we don't get a real error from the actor stack when we try to do this.

Hyrax's default actor stack calls `#save` and updates timestamps when an item that already exists enters actor stack's `#create` stack. This instead fails at the point of the model actor (which would normally handle the save). In service of this, we introduce an `ApplicationActor` which the various model actors inherit from.

In the `ImportService`, we raise an error when the stack returns `false`. This will allow us to tell whether the bugs we are currently seeing are in our code, or whether we are triggering something in Sipity.

An upstream issue report for the Hyrax issue exists at: samvera/hyrax#2330

Connected to #680.