### PR TITLE
Batch email user

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ would work. If everything is working as expected, you should see:
 ```
 You can also check individual systems by adding their name to the end of the okcomputer url, e.g., `/okcomputer/smtp`.
 See [okcomputer on github](https://github.com/sportngin/okcomputer) for more configuration options.
+
+## Email notifications
+To change how email notifications are sent, edit the values in a `.env.production` file on your server. The capistrano deploy task is set up to expect that file to exist, and ActionMailer is configured to get its mail values from environment variables, which we have set using [dotenv](https://github.com/bkeepers/dotenv). Please also change the email address of the batch_user to an address that can receive email. See `config/initializers/hyrax.rb` for batch_user configuration.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,9 +28,12 @@ Rails.application.configure do
 
   # Mail Settings
   config.action_mailer.default_url_options = { host: ENV["ACTION_MAILER_HOST"] }
-  config.action_mailer.raise_delivery_errors = true
+
+  # Set these to true if you need to debug email delivery in development mode
+  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.perform_deliveries = false
+
   config.action_mailer.perform_caching = false
-  config.action_mailer.perform_deliveries = true
   config.action_mailer.delivery_method = ENV['ACTION_MAILER_SMTP_DELIVERY_METHOD'].to_sym
   config.action_mailer.smtp_settings = {
     address: ENV['ACTION_MAILER_SMTP_ADDRESS'],

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -137,7 +137,7 @@ Hyrax.config do |config|
   # config.display_share_button_when_not_logged_in = true
 
   # The user who runs batch jobs. Update this if you aren't using emails
-  # config.batch_user_key = 'batchuser@example.com'
+  config.batch_user_key = 'systems@curationexperts.com'
 
   # The user who runs fixity check jobs. Update this if you aren't using emails
   # config.audit_user_key = 'audituser@example.com'


### PR DESCRIPTION
Because we have email notifications turned on, we are automatically
emailing the "batch_user", a special account hyrax expects to exist.
If that email is not set to something that can really receive
messages, we will get bounce notifications and our Amazon email
reputation will suffer.

I also include README instructions for how to change this in the
future, once the system is no longer configured to use
curationexperts.com mail settings.

Also, do not send email or raise delivery errors in development mode, i.e., do not require that individual devs have SMTP configured.