### PR TITLE
Avoid changing names at display time

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,12 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  ##
+  # @see https://github.com/samvera/hyrax/pull/2340
+  def name
+    display_name || user_key
+  end
+
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for
   # the account.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe User do
     expect(user.to_s).to eq user.display_name
   end
 
+  describe '#name' do
+    subject(:user) { build(:user, display_name: name) }
+    let(:name)     { 'MoominMama' }
+
+    it 'does not try to normalize names' do
+      expect(user.name).to eq name
+    end
+  end
+
   describe 'roles' do
     it 'is emplty for a new user' do
       new_user = create(:user)


### PR DESCRIPTION
Hyrax `User` titleizes names prior to display. This makes some fairly fragile (wrong) assumptions about how names work, and fails on relatively common western names like McCullough, presumably many international naming conventions are also left out of this, as well as famous cases from academia like bell
hooks.

Fixes #474.