### PR TITLE
Avoid re-enequing XmlImport items that have already been enqueued

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -51,9 +51,10 @@ class Batch < ApplicationRecord
     #   @return [String]
     # @!attribute id [rw]
     #   @return [String]
-    # @!attribute object [rw]
-    #   @return [ActiveFedora::Base, String]
-    attr_accessor :batch_id, :id, :object, :store
+    # @!attribute object [w]
+    #   @return [ActiveFedora::Base, nil]
+    attr_accessor :batch_id, :id, :store
+    attr_writer   :object
 
     ##
     # @param id       [#to_s]
@@ -63,7 +64,12 @@ class Batch < ApplicationRecord
       @id       = id
       @batch_id = batch_id
       @store    = store
-      @object   = begin
+    end
+
+    ##
+    # @return [ActiveFedora::Base, nil]
+    def object
+      @object ||= begin
         ActiveFedora::Base.find(id)
       rescue Ldp::Gone, ActiveFedora::ObjectNotFoundError, ArgumentError
         nil


### PR DESCRIPTION
Items that have been or are set to be processed by other jobs could prevously be
re-uploaded, triggering an additional job for the same item. That job would
become stuck in queue, as it failed repeatedly to create an item that already
exists. This avoids the requeue.

A small performance refactor of `Batch::Item` is also included here, to avoid
unneeded Fedora calls while checking for job ids.

Fixes #680.