### PR TITLE
Fix optional specs caused by failure to clear job status store

### DIFF
--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe 'batch', type: :feature, js: true do
+RSpec.describe 'batch', :batch, type: :feature, js: true do
   let(:current_user) { create(:admin) }
   let(:work_first) { create(:populated_pdf) }
   let(:work_second) { create(:populated_pdf) }
@@ -16,12 +16,10 @@ RSpec.describe 'batch', type: :feature, js: true do
 
   describe 'publishing' do
     it 'has tufts-buttons on the page' do
-      optional "Sometimes fails" if ENV['TRAVIS']
       expect(page).to have_selector('.tufts-buttons')
     end
 
     it 'sends the user to the batch status page like on the catalog' do
-      optional "Sometimes fails" if ENV['TRAVIS']
       expect(page).to have_selector('.tufts-buttons')
       click_on 'Publish'
       expect(page).to have_content('Batch Status')
@@ -30,7 +28,6 @@ RSpec.describe 'batch', type: :feature, js: true do
 
   describe 'unpublishing' do
     it 'sends the user to the batch status page like on the catalog' do
-      optional "Sometimes fails" if ENV['TRAVIS']
       expect(page).to have_selector('.tufts-buttons')
       click_on 'Unpublish'
       expect(page).to have_content('Batch Status')
@@ -39,7 +36,6 @@ RSpec.describe 'batch', type: :feature, js: true do
 
   describe 'exporting metadata' do
     it 'sends the user to the batch status page like on the catalog' do
-      optional "Sometimes fails" if ENV['TRAVIS']
       expect(page).to have_selector('.tufts-buttons')
       click_on 'Export Metadata'
       expect(page).to have_content('Batch Status')
@@ -48,7 +44,6 @@ RSpec.describe 'batch', type: :feature, js: true do
 
   describe 'applying template' do
     it 'sends the user to the batch status page like on the catalog' do
-      optional "Sometimes fails" if ENV['TRAVIS']
       expect(page).to have_selector('.tufts-buttons')
       click_on 'Apply Template'
       expect(page).to have_content('Template Behavior')

--- a/spec/presenters/batch_presenter_spec.rb
+++ b/spec/presenters/batch_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BatchPresenter do
+RSpec.describe BatchPresenter, :batch do
   subject(:presenter) { described_class.new(batch) }
   let(:batch)         { FactoryGirl.build(:batch) }
 

--- a/spec/presenters/xml_import_presenter_spec.rb
+++ b/spec/presenters/xml_import_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe XmlImportPresenter do
+RSpec.describe XmlImportPresenter, :batch do
   subject(:presenter) { described_class.new(import) }
   let(:batch)         { FactoryGirl.build(:batch, ids: []) }
   let(:import)        { FactoryGirl.build(:xml_import, batch: batch) }
@@ -65,7 +65,6 @@ RSpec.describe XmlImportPresenter do
       end
 
       it 'changes to queued' do
-        optional "Sometimes fails" if ENV['TRAVIS']
         expect { import.batch.enqueue! }
           .to change { presenter.status }
           .to('Queued')


### PR DESCRIPTION
Many of the intermittently failing tests were caused by not clearing the batch job store; this fixes that class of tests and reinstates them.