### PR TITLE
Display `date_uploaded` and `date_modified` on show page

### DIFF
--- a/app/assets/stylesheets/tufts.scss
+++ b/app/assets/stylesheets/tufts.scss
@@ -8,3 +8,4 @@
 @import 'tufts/nav_header';
 @import 'tufts/show_actions';
 @import 'tufts/stats';
+@import 'tufts/show_view';

--- a/app/assets/stylesheets/tufts/_show_view.scss
+++ b/app/assets/stylesheets/tufts/_show_view.scss
@@ -1,0 +1,8 @@
+.modified-info {
+  list-style-type:none;
+  margin-left:0;
+  padding-left:0;
+}
+.modified-info__label {
+  font-weight: bold;  
+}

--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -2,6 +2,16 @@ module Hyrax
   class GenericWorkPresenter < Hyrax::WorkShowPresenter
     Tufts::Terms.shared_terms.each { |term| delegate term, to: :solr_document }
 
+    def date_modified
+      return if solr_document[:date_modified_dtsi].nil?
+      DateTime.parse(solr_document[:date_modified_dtsi]).in_time_zone.strftime('%F')
+    end
+
+    def date_uploaded
+      return if solr_document[:date_uploaded_dtsi].nil?
+      DateTime.parse(solr_document[:date_uploaded_dtsi]).in_time_zone.strftime('%F')
+    end
+
     ##
     # @return [Boolean] true; all works in the app are templatable.
     def work_templatable?

--- a/app/views/hyrax/base/_work_description.html.erb
+++ b/app/views/hyrax/base/_work_description.html.erb
@@ -3,3 +3,17 @@
     <p class="work_description"><%= iconify_auto_link(description) %></p>
   <% end %>
 <% end %>
+<ul class="modified-info">
+    <li>
+        <span class="modified-info__label">Ingested</span>
+        <span class="modified-info__date">
+            <%= presenter.date_uploaded %>
+        </span>
+    </li>
+    <li>
+        <span class="modified-info__label">Modified</span>
+        <span class="modified-info__date">
+            <%= presenter.date_modified %>
+        </span>
+    </li>
+</ul>

--- a/spec/features/create_pdf_spec.rb
+++ b/spec/features/create_pdf_spec.rb
@@ -7,7 +7,7 @@ include Warden::Test::Helpers
 RSpec.feature 'Create a PDF', :clean, js: true do
   context 'a logged in admin user' do
     let(:user) { FactoryGirl.create(:admin) }
-
+    let(:today) { DateTime.now.in_time_zone.strftime('%F') }
     before { login_as user }
 
     scenario do
@@ -142,9 +142,6 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       expect(page).to have_content 'Rights Holder'
       expect(page).to have_content 'Rights Note'
       expect(page).to have_content 'Tufts License'
-      # This is not working with Capybara, but does work
-      # there is a view test for the Rights Statement
-      # in spec/views/hyrax/_attribute_rows.html.erb_spec.rb
       expect(page).to have_content 'Springer Policy'
       expect(page).to have_content 'Source'
       expect(page).to have_content 'Start Date'
@@ -154,6 +151,9 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       expect(page).to have_content 'Temporal'
       expect(page).to have_content 'Tufts License'
       expect(page).to have_content 'Text'
+
+      expect(page).to have_content "Ingested #{today}"
+      expect(page).to have_content "Modified #{today}"
     end
   end
 end


### PR DESCRIPTION
This adds `date_uploaded` and `date_modified` to the work
show page underneath the title and description. This adds
CSS to style the display of the dates.

The `GenericWorkPresenter` needed to be updated to display
these attributes. They were returning `nil` before but were
present in the `SolrDocument`.

The PDF feature spec is updated to check for the elements showing
up with the correct values.

Closes #613 