### PR TITLE
Check for well-formed XML at start of data import

### DIFF
--- a/app/lib/tufts/importer.rb
+++ b/app/lib/tufts/importer.rb
@@ -55,6 +55,8 @@ module Tufts
       raise(ArgumentError, "file must be an IO, got a #{file.class}") unless
         file.respond_to? :read
 
+      check_for_well_formed_xml(file.read)
+
       @file = file
     end
 
@@ -144,6 +146,16 @@ module Tufts
     end
 
     private
+
+      # Use Nokogiri's XML parser to check that the file is well formed
+      # See http://www.nokogiri.org/tutorials/ensuring_well_formed_markup.html
+      # Create a new Importer::Error for each error found by the Nokogiri parser
+      def check_for_well_formed_xml(file)
+        doc = Nokogiri::XML file
+        doc.errors.each do |e|
+          errors << Importer::Error.new(e.line, type: :serious, message: e.message)
+        end
+      end
 
       ##
       # @private

--- a/spec/features/xml_import_spec.rb
+++ b/spec/features/xml_import_spec.rb
@@ -42,4 +42,14 @@ RSpec.feature 'Create an XML Import', :clean, js: true do
 
     expect(page).to have_content 'Error'
   end
+
+  scenario 'importing a malformed file' do
+    visit '/xml_imports/new'
+
+    attach_file 'metadata_file', File.join(fixture_path, 'files', 'malformed_files', 'stray_element.xml')
+
+    click_button 'Next'
+
+    expect(page).to have_content 'Error'
+  end
 end

--- a/spec/fixtures/files/malformed_files/stray_element.xml
+++ b/spec/fixtures/files/malformed_files/stray_element.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH
+  xmlns="http://www.openarchives.org/OAI/2.0/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:model="info:fedora/fedora-system:def/model#"
+  xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#"
+  xmlns:iana="http://www.iana.org/assignments/relation/"
+  xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#"
+  xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#"
+  xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/"
+  xmlns:bibframe="http://bibframe.org/vocab/"
+  xmlns:dc11="http://purl.org/dc/elements/1.1/"
+  xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#"
+  xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+  xmlns:mads="http://www.loc.gov/mads/rdf/v1#"
+  xmlns:tufts="http://dl.tufts.edu/terms#"
+  xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>Sonnet_1.pdf</tufts:filename>
+         <tufts:visibility>open</tufts:visibility>
+         <model:hasModel>Pdf</model:hasModel>
+         <dc:title>The Project Gutenberg EBook of Sonnets from the Portuguese
+by Browning</dc:title><model:hasModel>
+         <dc11:description>
+           This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net</dc11:description>
+         <dc:abstract>
+           I thought once how Theocritus had sung
+Of the sweet years, the dear and wished-for years,
+Who each one in a gracious hand appears
+To bear a gift for mortals, old or young:</dc:abstract>
+         <dc11:creator>Browning, Elizabeth Barrett</dc11:creator>
+         <dc:publisher>Caradoc Press</dc:publisher>
+         <dc:created>09/14/2002</dc:created>
+         <dc:available>02/26/2017</dc:available>
+         <dc:type>http://purl.org/dc/dcmitype/Text</dc:type>
+         <dc:format>application/pdf</dc:format>
+         <mads:PersonalName>Browning, Elizabeth</mads:PersonalName>
+         <mads:CorporateName>PROJECT GUTENBERG</mads:CorporateName>
+         <dc:subject>Poetry</dc:subject>
+         <dc:subject>Portuguese</dc:subject>
+         <dc:subject>Sonnets</dc:subject>
+         <dc:subject>Project Gutenberg</dc:subject>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/lib/tufts/importer_spec.rb
+++ b/spec/lib/tufts/importer_spec.rb
@@ -1,13 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe Tufts::Importer do
-  let(:file) { StringIO.new('blah') }
+  let(:file) do
+    File.open(File.join(fixture_path, 'files', 'mira_xml.xml'), 'r')
+  end
+
+  after do
+    file.close
+  end
 
   it_behaves_like 'an importer'
 
   describe '.for' do
     it 'gives an importer instance' do
       expect(described_class.for(file: file)).to be_a described_class
+    end
+  end
+
+  describe '#initialize' do
+    let(:badly_formed_xml) do
+      File.open(File.join(fixture_path, 'files', 'malformed_files', 'stray_element.xml'), 'r')
+    end
+
+    after do
+      badly_formed_xml.close
+    end
+
+    it "reports parsing errors if the document contains a stray element" do
+      importer = described_class.new(file: badly_formed_xml)
+      expect(importer.errors).not_to be_empty
     end
   end
 


### PR DESCRIPTION
Previously, we have been checking for some aspects of what
makes an import file valid, but we have not actually been
checking whether the XML file was well formed. We are now
requiring that the file parse cleanly and reporting any
errors via the existing error mechanism.

Note, this also requires that all XML import tests use
a valid XML file from now on.

Connected to #634 