### PR TITLE
Add visibility to export

### DIFF
--- a/app/lib/tufts/xml_metadata_builder.rb
+++ b/app/lib/tufts/xml_metadata_builder.rb
@@ -30,6 +30,7 @@ module Tufts
                 xml.metadata do
                   xml.mira_import(@mapping.namespaces) do
                     xml.parent << tm.to_s
+                    xml['tufts'].visibility { xml.text object.visibility }
                     @mapping.map_sorted do |field|
                       if field.property == :id
                         xml[field.namespace.to_s]

--- a/spec/support/shared_examples/metadata_builder.rb
+++ b/spec/support/shared_examples/metadata_builder.rb
@@ -31,6 +31,12 @@ shared_examples 'a MetadataBuilder' do
         .to include(*values)
     end
 
+    it 'adds the object visibility' do
+      expect { builder.add(*objects) }
+        .to change { builder.build }
+        .to include 'open'
+    end
+
     it 'adds datatypes' do
       object.date_accepted = [Time.zone.today]
 
@@ -46,7 +52,7 @@ shared_examples 'a MetadataBuilder' do
       end
 
       it 'handles uris' do
-        expect { builder.add(*objects) }
+        expect { builder.add(object) }
           .to change { builder.build }
           .to include "uri=\"#{object.rdf_subject}\""
       end
@@ -54,8 +60,15 @@ shared_examples 'a MetadataBuilder' do
   end
 
   describe '#build' do
+    let(:xml_string) { builder.build.to_str }
+    let(:xml_doc) { Nokogiri::XML(xml_string) }
+
     it 'builds a string' do
-      expect(builder.build.to_str).to be_a String
+      expect(xml_string).to be_a String
+    end
+
+    it 'builds a string that is well-formed XML' do
+      expect(xml_doc.errors).to eq []
     end
   end
 


### PR DESCRIPTION
Visibility is already handled in XML and metadata imports via
`Tufts::ImportRecord`. To handle round trips and changes to visibility on
re-import, we need to include visibility on export.

In the status quo, removing visibility entirely from an exported record and
reimporting it will move the visibility to
`Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE`.

Closes #624.