### PR TITLE
Remove access to admin areas for non-admin users

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -1,50 +1,56 @@
-<% if can? :review, :submissions %>
-<li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
-<%= menu.nav_link(hyrax.admin_workflows_path) do %>
-<span class="fa fa-flag"></span><span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_review') %></span>
-<% end %>
+<% if current_user.admin? %>
+    <% if can? :review, :submissions %>
+        <li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
+        <%= menu.nav_link(hyrax.admin_workflows_path) do %>
+            <span class="fa fa-flag"></span><span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_review') %></span>
+        <% end %>
+    <% end %>
+
+    <%= menu.nav_link('/advanced') do %>
+        <span class="fa fa-search"></span><span class="sidebar-action-text">Advanced Search</span>
+    <% end %>
+
+    <%= menu.nav_link('/deposit_types') do %>
+        <span class="fa fa-list"></span><span class="sidebar-action-text">Manage Self-Deposit Types</span>
+    <% end %>
 <% end %>
 
-<%= menu.nav_link('/advanced') do %>
-<span class="fa fa-search"></span><span class="sidebar-action-text">Advanced Search</span>
-<% end %>
-
-<%= menu.nav_link('/deposit_types') do %>
-<span class="fa fa-list"></span><span class="sidebar-action-text">Manage Self-Deposit Types</span>
-<% end %>
-
+<!-- non-admin users can contribute new documents -->
 <%= menu.nav_link('/contribute') do %>
-<span class="fa fa-book"></span><span class="sidebar-action-text">New Self-Deposit Item</span>
+    <span class="fa fa-book"></span><span class="sidebar-action-text">New Self-Deposit Item</span>
 <% end %>
+<!-- end contribution -->
 
-<%= menu.nav_link('/handle/log.html') do %>
-<span class="fa fa-exclamation-triangle"></span><span class="sidebar-action-text">View Handle.net Error Log</span>
-<% end %>
+<% if current_user.admin? %>
+    <%= menu.nav_link('/handle/log.html') do %>
+        <span class="fa fa-exclamation-triangle"></span><span class="sidebar-action-text">View Handle.net Error Log</span>
+    <% end %>
 
-<%= menu.nav_link('/batches') do %>
-<span class="fa fa-info-circle"></span><span class="sidebar-action-text">View Batch Statuses</span>
-<% end %>
+    <%= menu.nav_link('/batches') do %>
+        <span class="fa fa-info-circle"></span><span class="sidebar-action-text">View Batch Statuses</span>
+    <% end %>
 
-<%= menu.nav_link('/sidekiq',  data: { turbolinks: false }) do %>
-<span class="fa fa-hourglass-half"></span><span class="sidebar-action-text">View Background Job Queues</span>
-<% end %>
+    <%= menu.nav_link('/sidekiq',  data: { turbolinks: false }) do %>
+        <span class="fa fa-hourglass-half"></span><span class="sidebar-action-text">View Background Job Queues</span>
+    <% end %>
 
-<%= menu.nav_link('/templates') do %>
-<span class="fa fa-list-alt"></span><span class="sidebar-action-text">Manage Metadata Templates</span>
-<% end %>
+    <%= menu.nav_link('/templates') do %>
+        <span class="fa fa-list-alt"></span><span class="sidebar-action-text">Manage Metadata Templates</span>
+    <% end %>
 
-<li class="h5">Import/Export</li>
+    <li class="h5">Import/Export</li>
 
-<%= menu.nav_link('/xml_imports/new') do %>
-<span class="fa fa-archive"></span><span class="sidebar-action-text">Import Objects</span>
-<% end %>
+    <%= menu.nav_link('/xml_imports/new') do %>
+        <span class="fa fa-archive"></span><span class="sidebar-action-text">Import Objects</span>
+    <% end %>
 
-<%= menu.nav_link('/metadata_imports/new') do %>
-<span class="fa fa-code"></span><span class="sidebar-action-text">Import Metadata</span>
-<% end %>
+    <%= menu.nav_link('/metadata_imports/new') do %>
+        <span class="fa fa-code"></span><span class="sidebar-action-text">Import Metadata</span>
+    <% end %>
 
-<% if can? :manage, User %>
-<%= menu.nav_link(hyrax.admin_users_path) do %>
-<span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
-<% end %>
+    <% if can? :manage, User %>
+        <%= menu.nav_link(hyrax.admin_users_path) do %>
+            <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
+        <% end %>
+    <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,48 +7,95 @@ Rails.application.routes.draw do
     request.env['warden'].authenticate? && !request.env['warden'].user.admin?
   end
 
-  mount Blacklight::Engine => '/'
-  mount BlacklightAdvancedSearch::Engine => '/'
-
-  # Mount sidekiq web ui and require authentication by an admin user
-  require 'sidekiq/web'
-  authenticate :user, ->(u) { u.admin? } do
-    mount Sidekiq::Web => '/sidekiq'
-  end
-
-  concern :searchable, Blacklight::Routes::Searchable.new
-
   constraints admin_constraint do
     root to: 'hyrax/dashboard#show'
+
+    concern :exportable, Blacklight::Routes::Exportable.new
+    concern :searchable, Blacklight::Routes::Searchable.new
+
     # Only admin users should be able to search
     resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
       concerns :searchable
     end
-  end
+    mount BlacklightAdvancedSearch::Engine => '/'
 
-  devise_for :users
+    # Mount sidekiq web ui and require authentication by an admin user
+    require 'sidekiq/web'
+    mount Sidekiq::Web => '/sidekiq'
+
+    resources :batches, controller: 'hyrax/batches', only: [:index, :show, :create]
+
+    resources :metadata_exports,
+              controller: 'hyrax/metadata_exports',
+              only:       [:create]
+    resources :metadata_imports,
+              controller: 'hyrax/metadata_imports',
+              only:       [:new, :create]
+    resources :xml_imports,
+              controller: 'hyrax/xml_imports',
+              only:       [:show, :create, :new, :edit, :update]
+    resources :templates,
+              controller: 'hyrax/templates',
+              only:       [:index, :destroy, :edit, :update, :new]
+    resources :template_updates,
+              controller: 'hyrax/template_updates',
+              only:       [:index, :new, :create]
+
+    get '/metadata_exports/:id/download', to: 'hyrax/metadata_exports#download'
+
+    # Routes for managing drafts
+    post '/draft/save_draft/:id', to: 'tufts/draft#save_draft'
+    post '/draft/delete_draft/:id', to: 'tufts/draft#delete_draft'
+    get '/draft/draft_saved/:id', to: 'tufts/draft#draft_saved'
+
+    # Routes for managing QR status
+    resources :qr_statuses, controller: 'tufts/qr_status', only: [:set_status, :status] do
+      member do
+        post 'set_status'
+        get 'status'
+      end
+    end
+
+    # Routes for managing publication status
+    resources :publication_statuses, controller: 'tufts/publication_status', only: [:publish, :unpublish, :status] do
+      member do
+        post 'publish'
+        post 'unpublish'
+        get 'status'
+      end
+    end
+
+    resources :deposit_types do
+      get 'export', on: :collection
+    end
+
+    # Routes for managing QR status
+
+    get '/handle/log/', to: 'tufts/handle_log#index'
+  end # end admin constraint
 
   constraints non_admin_constraint do
     root to: 'contribute#redirect'
     get '/dashboard', to: 'contribute#redirect'
   end
 
-  mount Hydra::RoleManagement::Engine => '/'
+  devise_for :users
 
+  # Mount Engines
+  mount Blacklight::Engine => '/'
+  mount Hydra::RoleManagement::Engine => '/'
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
+
+  # Home page for non-authenticated users
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
 
   curation_concerns_basic_routes
 
-  concern :exportable, Blacklight::Routes::Exportable.new
-
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
     concerns :exportable
   end
-
-  resources :batches, controller: 'hyrax/batches', only: [:index, :show, :create]
 
   resources :bookmarks do
     concerns :exportable
@@ -58,61 +105,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :metadata_exports,
-            controller: 'hyrax/metadata_exports',
-            only:       [:create]
-  resources :metadata_imports,
-            controller: 'hyrax/metadata_imports',
-            only:       [:new, :create]
-  resources :xml_imports,
-            controller: 'hyrax/xml_imports',
-            only:       [:show, :create, :new, :edit, :update]
-  resources :templates,
-            controller: 'hyrax/templates',
-            only:       [:index, :destroy, :edit, :update, :new]
-  resources :template_updates,
-            controller: 'hyrax/template_updates',
-            only:       [:index, :new, :create]
-
-  get '/metadata_exports/:id/download', to: 'hyrax/metadata_exports#download'
-
-  # Routes for managing drafts
-  post '/draft/save_draft/:id', to: 'tufts/draft#save_draft'
-  post '/draft/delete_draft/:id', to: 'tufts/draft#delete_draft'
-  get '/draft/draft_saved/:id', to: 'tufts/draft#draft_saved'
-
-  # Routes for managing QR status
-  resources :qr_statuses, controller: 'tufts/qr_status', only: [:set_status, :status] do
-    member do
-      post 'set_status'
-      get 'status'
-    end
-  end
-
-  # Routes for managing publication status
-  resources :publication_statuses, controller: 'tufts/publication_status', only: [:publish, :unpublish, :status] do
-    member do
-      post 'publish'
-      post 'unpublish'
-      get 'status'
-    end
-  end
-
-  resources :deposit_types do
-    get 'export', on: :collection
-  end
-
   resources :contribute, as: 'contributions', controller: :contribute, only: [:index, :new, :create, :redirect] do
     collection do
       get 'license'
     end
   end
 
-  # Routes for managing QR status
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-
-  get '/handle/log/', to: 'tufts/handle_log#index'
-
   # needs to be last to redirect /bad/paths
-  get '*path', to: 'contribute#redirect'
+  get '*path' => redirect { |_, req| req.flash[:error] = "You are not authorized to access this page"; 'contribute#redirect' } # rubocop:disable  Style/Semicolon
 end

--- a/spec/features/sidebar_links_spec.rb
+++ b/spec/features/sidebar_links_spec.rb
@@ -2,15 +2,50 @@ require 'rails_helper'
 require 'tufts/workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Manage Deposit Types link in dashboard sidebar', :clean do
-  context 'a logged in user' do
+RSpec.feature 'Links in the dashboard sidebar', :clean, js: true do
+  context 'a logged in admin user' do
     let(:admin) { FactoryGirl.create(:admin) }
 
     before { login_as admin }
 
     scenario do
       visit '/dashboard'
-      expect(page).to have_content "Manage Self-Deposit Types"
+      # Site functionality that shouldn't be accessible to
+      # non-admin users
+      expect(page).to have_link('Advanced Search')
+      expect(page).to have_link('View Handle.net Error Log')
+      expect(page).to have_link('View Batch Statuses')
+      expect(page).to have_link('View Background Job Queues')
+      expect(page).to have_link('Manage Metadata Templates')
+      expect(page).to have_content('IMPORT/EXPORT')
+      expect(page).to have_link('Import Objects')
+      expect(page).to have_link('Import Metadata')
+      expect(page).to have_link('Manage Self-Deposit Types')
+    end
+  end
+
+  context 'a logged in non-admin user' do
+    let(:user) { FactoryGirl.create(:user) }
+
+    before { login_as user }
+
+    scenario do
+      visit '/notifications'
+      # Site functionality that shouldn't be accessible to
+      # non-admin users
+      expect(page).not_to have_link('Advanced Search')
+      expect(page).not_to have_link('View Handle.net Error Log')
+      expect(page).not_to have_link('View Batch Statues')
+      expect(page).not_to have_link('View Background Job Queues')
+      expect(page).not_to have_link('Manage Metadata Templates')
+      expect(page).not_to have_content('IMPORT/EXPORT')
+      expect(page).not_to have_link('Import Objects')
+      expect(page).not_to have_link('Import Metadata')
+      expect(page).not_to have_link('Manage Self-Deposit Types')
+      # Functionality that should still be accessible to
+      # non-admin users in the dashboard
+      expect(page).to have_content('REPOSITORY CONTENTS')
+      expect(page).to have_link('New Self-Deposit Item')
     end
   end
 end


### PR DESCRIPTION
This is a refactor of `routes.rb` to enforce access rules
for non-admin users.

Since non-admin users can notifications on the dashboard, this
updates the specs for the sidebar links to ensure that
non-admin users don't see links to admin functionality in the
dashboard.

This commit also ensures that there is a flash message when
users are redirected from paths that they don't have access
to or try access a non-existent path.

Closes #733