### PR TITLE
Generate unique filenames for imported metadata files

### DIFF
--- a/app/controllers/hyrax/xml_imports_controller.rb
+++ b/app/controllers/hyrax/xml_imports_controller.rb
@@ -13,7 +13,8 @@ module Hyrax
         redirect_to main_app.xml_import_path(@import)
       else
         messages    = @import.errors.messages[:base].join("\n")
-        flash.alert = " Errors were found in #{@import.metadata_file.filename}:" \
+        flash.alert = ' Errors were found in ' \
+                      "#{@import.metadata_file.file.original_filename}:" \
                       "\n#{messages}"
         redirect_to main_app.new_xml_import_path
       end

--- a/app/lib/tufts/metadata_file_uploader.rb
+++ b/app/lib/tufts/metadata_file_uploader.rb
@@ -5,6 +5,12 @@ module Tufts
     storage :file
 
     ##
+    # @see CarrierWave::Uploader::Base#filename
+    def filename
+      "#{token}.#{file.extension}" if original_filename.present?
+    end
+
+    ##
     # @see CarrierWave::Uploader::Base#store_dir
     def store_dir
       Rails.application.config.metadata_upload_dir.join('store').to_s
@@ -15,5 +21,14 @@ module Tufts
     def cache_dir
       Rails.application.config.metadata_upload_dir.join('cache').to_s
     end
+
+    private
+
+      def token
+        token_name = :"@#{mounted_as}_token"
+
+        model.instance_variable_get(token_name) ||
+          model.instance_variable_set(token_name, SecureRandom.uuid)
+      end
   end
 end

--- a/spec/controllers/hyrax/xml_imports_controller_spec.rb
+++ b/spec/controllers/hyrax/xml_imports_controller_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Hyrax::XmlImportsController, type: :controller do
   let(:import) { FactoryGirl.create(:xml_import) }
 
+  before { import.batch.save }
+
   context 'as admin' do
     include_context 'as admin'
 
@@ -18,7 +20,7 @@ RSpec.describe Hyrax::XmlImportsController, type: :controller do
 
       it 'uploads the file' do
         post :create, params: { xml_import: { metadata_file: file_upload } }
-        expect(assigns(:import).metadata_file.filename).to eq 'mira_xml.xml'
+        expect(assigns(:import).metadata_file.filename).to be_a String
       end
 
       it 'creates a batch' do

--- a/spec/factories/xml_imports.rb
+++ b/spec/factories/xml_imports.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :xml_import do
     metadata_file File.open('spec/fixtures/files/mira_xml.xml')
-    batch
+
+    association :batch
   end
 end

--- a/spec/lib/tufts/metadata_file_uploader_spec.rb
+++ b/spec/lib/tufts/metadata_file_uploader_spec.rb
@@ -9,6 +9,31 @@ RSpec.describe Tufts::MetadataFileUploader do
     expect(uploader).to be_a CarrierWave::Uploader::Base
   end
 
+  describe '#filename' do
+    let(:other_model)    { FactoryGirl.create(:xml_import) }
+    let(:other_uploader) { described_class.new(other_model, :metadata_file) }
+    let(:test_file)      { File.open(file_fixture('mira_xml.xml')) }
+
+    it 'generates a filename for uploads' do
+      expect { uploader.store!(test_file) }
+        .to change { uploader.file }
+        .from(nil)
+    end
+
+    it 'generates a filename is different for multiple uploads' do
+      uploader.store!(test_file)
+      other_uploader.store!(test_file)
+
+      expect(uploader.filename).not_to eq other_uploader.filename
+    end
+
+    it 'retains the generated filename' do
+      uploader.store!(test_file)
+
+      expect { model.reload }.not_to change { uploader.filename }
+    end
+  end
+
   describe '#store_dir' do
     it 'is the configured directory' do
       expect(uploader.store_dir)


### PR DESCRIPTION
When uploading a metadata file, we had previously been using the original
filename to identify the uploaded content. The users were frequently uploading
content with the same filenames, and the resulting name collisions caused
overwrites. This generates UUIDs for each uploaded metadata file.

Initially, the UUID token for filename is stored on a model variable to avoid
generating the filename repeatedly. We don't need to store it longer than this,
because the generated filename is stored on the model's `#metadata_file` field
once the upload is complete; `Uploader#original_filename` and `#filename` are
`nil` after reloads.

Closes #682.