### PR TITLE
 Check for required fields in XML Batch import

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,12 +17,13 @@ Metrics/MethodLength:
    Exclude:
     - 'app/models/forms/contribution.rb'
     - 'app/models/forms/generic_tisch_deposit.rb'
+    - 'lib/tasks/import_test_file.rake'
 Performance/StringReplacement:
    Exclude:
     - 'app/controllers/tufts/works_controller.rb'
 Rails/TimeZone:
   Exclude:
-    - 'config/initializers/git_sha.rb'  
+    - 'config/initializers/git_sha.rb'
 RSpec/ExampleLength:
    Exclude:
     - 'spec/features/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/MethodLength:
     - 'app/models/forms/contribution.rb'
     - 'app/models/forms/generic_tisch_deposit.rb'
     - 'lib/tasks/import_test_file.rake'
+    - 'app/lib/tufts/importer.rb'
 Performance/StringReplacement:
    Exclude:
     - 'app/controllers/tufts/works_controller.rb'

--- a/app/lib/tufts/importer.rb
+++ b/app/lib/tufts/importer.rb
@@ -177,8 +177,7 @@ module Tufts
       # @private
       def validate_filenames
         records.each_with_object(Set.new) do |record, files_touched|
-          errors << MissingFileError.new if record.files.empty?
-
+          errors << MissingFileError.new(record.metadata.line) if record.files.empty?
           record.files.each do |file|
             errors << DuplicateFileError.new(nil, file: file) unless
               files_touched.add?(file)

--- a/app/lib/tufts/importer.rb
+++ b/app/lib/tufts/importer.rb
@@ -54,9 +54,6 @@ module Tufts
     def initialize(file:)
       raise(ArgumentError, "file must be an IO, got a #{file.class}") unless
         file.respond_to? :read
-
-      check_for_well_formed_xml(file.read)
-
       @file = file
     end
 
@@ -83,6 +80,7 @@ module Tufts
     # @return [Enumerable<Error>]
     # @see #errors
     def validate!
+      check_for_well_formed_xml(@file.read)
       validate_filenames
       errors
     end
@@ -152,8 +150,26 @@ module Tufts
       # Create a new Importer::Error for each error found by the Nokogiri parser
       def check_for_well_formed_xml(file)
         doc = Nokogiri::XML file
-        doc.errors.each do |e|
-          errors << Importer::Error.new(e.line, type: :serious, message: e.message)
+        if doc.errors.count > 0
+          e = doc.errors.first
+          errors << Importer::Error.new(e.line, type: :serious, message: "Malformed XML error: #{e.message}")
+        end
+        check_for_required_fields(doc)
+      end
+
+      # Given a record, check that it has all required fields
+      def check_for_required_fields(doc)
+        doc.root.add_namespace("dc", "http://purl.org/dc/terms/")
+        doc.root.add_namespace("tufts", "http://dl.tufts.edu/terms#")
+        doc.root.add_namespace("model", "info:fedora/fedora-system:def/model#")
+        required_fields = ["dc:title", "tufts:displays_in", "model:hasModel"]
+        doc.xpath("//xmlns:record/xmlns:metadata/xmlns:mira_import").each do |record|
+          required_fields.each do |field|
+            if record.xpath(field).text.empty?
+              filename = record.xpath('tufts:filename').text || "Unknown filename"
+              errors << Importer::Error.new(record.line, type: :serious, message: "Missing required field: #{filename} is missing #{field}")
+            end
+          end
         end
       end
 

--- a/app/models/xml_import.rb
+++ b/app/models/xml_import.rb
@@ -95,8 +95,12 @@ class XmlImport < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     def file_is_correctly_formatted
       return unless metadata_file_changed?
-
-      parser.validate!.each { |err| errors.add(:base, err.message) }
+      number_of_errors_to_display = 5
+      validation_errors = parser.validate!
+      validation_errors_count = validation_errors.count
+      validation_errors = validation_errors.first(number_of_errors_to_display)
+      validation_errors.each { |err| errors.add(:base, err.message) }
+      errors.add(:base, "There were #{validation_errors_count} errors total, too many to display") if validation_errors_count > number_of_errors_to_display
     end
 
     ##

--- a/docs/sonnets.xml
+++ b/docs/sonnets.xml
@@ -28,6 +28,7 @@
           <tufts:visibility>open</tufts:visibility>
           <model:hasModel>Pdf</model:hasModel>
           <dc:title>The Project Gutenberg EBook of Sonnets from the Portuguese by Browning</dc:title>
+          <tufts:displays_in>dl</tufts:displays_in>
           <dc11:description>
             This eBook is for the use of anyone anywhere at no cost and with almost no restrictions whatsoever. You may copy it, give it away or re-use it under the terms of the Project Gutenberg License included with this eBook or online at www.gutenberg.net</dc11:description>
           <dc:abstract>

--- a/lib/tasks/import_test_file.rake
+++ b/lib/tasks/import_test_file.rake
@@ -1,0 +1,75 @@
+require 'fileutils'
+require 'nokogiri'
+require 'ffaker'
+
+namespace :import do
+  desc 'Create a file for testing bulk import'
+  task :make_test_file, [:count] => :environment do |_t, args|
+    puts "Making an import file with #{args[:count]} entries"
+    dir_path = make_directory(args[:count])
+    import_file = create_import_file(args[:count])
+    File.open("#{dir_path}/#{args[:count]}_sample.xml", 'w') { |file| file.write(import_file) }
+    copy_files(args[:count])
+    puts "See #{dir_path}/#{args[:count]}_sample.xml"
+  end
+
+  def make_directory(count)
+    dir_path = Rails.root.join('tmp', 'import_testing', count)
+    FileUtils.mkdir_p dir_path
+    dir_path
+  end
+
+  def copy_files(count)
+    count.to_i.times do |i|
+      FileUtils.cp Rails.root.join('spec', 'fixtures', 'files', 'pdf-sample.pdf'), Rails.root.join('tmp', 'import_testing', count, "pdf_sample#{i}.pdf")
+    end
+  end
+
+  def create_import_file(number_of_records)
+    namespace = define_namespace
+    builder = Nokogiri::XML::Builder.new do |xml|
+      xml.OAIPMH(namespace) do
+        xml.ListRecords do
+          number_of_records.to_i.times do |i|
+            xml.record do
+              xml.metadata do
+                xml.mira_import do
+                  xml.send("tufts:filename", "pdf_sample#{i}.pdf")
+                  xml.send("tufts:visibility", "open")
+                  xml.send("model:hasModel", "Pdf")
+                  xml.send("dc:title", "Sample Data: #{FFaker::Book.title}")
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+    CGI.unescapeHTML(builder.to_xml)
+  end
+
+  def define_namespace
+    {
+      "xsi:schemaLocation" => "http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd",
+      "xmlns" => "http://www.openarchives.org/OAI/2.0/",
+      "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance",
+      "xmlns:model" => "info:fedora/fedora-system:def/model#",
+      "xmlns:fcrepo4" => "http://fedora.info/definitions/v4/repository#",
+      "xmlns:iana" => "http://www.iana.org/assignments/relation/",
+      "xmlns:marcrelators" => "http://id.loc.gov/vocabulary/relators/",
+      "xmlns:dc" => "http://purl.org/dc/terms/",
+      "xmlns:fedoraresourcestatus" => "http://fedora.info/definitions/1/0/access/ObjState#",
+      "xmlns:scholarsphere" => "http://scholarsphere.psu.edu/ns",
+      "xmlns:opaquehydra" => "http://opaquenamespace.org/ns/hydra/",
+      "xmlns:bibframe" => "http://bibframe.org/vocab/",
+      "xmlns:dc11" => "http://purl.org/dc/elements/1.1/",
+      "xmlns:ebucore" => "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#",
+      "xmlns:premis" => "http://www.loc.gov/premis/rdf/v1#",
+      "xmlns:mads" => "http://www.loc.gov/mads/rdf/v1#",
+      "xmlns:tufts" => "http://dl.tufts.edu/terms#",
+      "xmlns:edm" => "http://www.europeana.eu/schemas/edm/",
+      "xmlns:foaf" => "http://xmlns.com/foaf/0.1/",
+      "xmlns:rdfs" => "http://www.w3.org/2000/01/rdf-schema#"
+    }
+  end
+end

--- a/lib/tasks/import_test_file.rake
+++ b/lib/tasks/import_test_file.rake
@@ -38,6 +38,7 @@ namespace :import do
                   xml.send("tufts:visibility", "open")
                   xml.send("model:hasModel", "Pdf")
                   xml.send("dc:title", "Sample Data: #{FFaker::Book.title}")
+                  xml.send("tufts:displays_in", "dl")
                 end
               end
             end

--- a/spec/features/xml_import_spec.rb
+++ b/spec/features/xml_import_spec.rb
@@ -49,7 +49,18 @@ RSpec.feature 'Create an XML Import', :clean, js: true do
     attach_file 'metadata_file', File.join(fixture_path, 'files', 'malformed_files', 'stray_element.xml')
 
     click_button 'Next'
-
     expect(page).to have_content 'Error'
+    expect(page).to have_content 'Malformed XML'
+  end
+
+  scenario 'importing a file with missing required fields' do
+    visit '/xml_imports/new'
+
+    attach_file 'metadata_file', File.join(fixture_path, 'files', 'malformed_files', 'missing_required_fields.xml')
+
+    click_button 'Next'
+    expect(page).to have_content 'Missing required field: Sonnet_1.pdf is missing tufts:displays_in'
+    expect(page).to have_content 'Missing required field: Sonnet_1.pdf is missing dc:title'
+    expect(page).to have_content 'Missing required field: Sonnet_1.pdf is missing model:hasModel'
   end
 end

--- a/spec/features/xml_import_spec.rb
+++ b/spec/features/xml_import_spec.rb
@@ -63,4 +63,25 @@ RSpec.feature 'Create an XML Import', :clean, js: true do
     expect(page).to have_content 'Missing required field: Sonnet_1.pdf is missing dc:title'
     expect(page).to have_content 'Missing required field: Sonnet_1.pdf is missing model:hasModel'
   end
+
+  scenario 'importing a file with missing filename gives line number' do
+    visit '/xml_imports/new'
+
+    attach_file 'metadata_file', File.join(fixture_path, 'files', 'malformed_files', 'missing_filename.xml')
+
+    click_button 'Next'
+    expect(page).to have_content 'Missing required field: Sonnet_1.pdf is missing tufts:displays_in'
+    expect(page).not_to have_content 'Unknown Line'
+  end
+
+  # When we produce lots of errors we've been getting "Failure/Error: raise CookieOverflow if options[:value].bytesize > MAX_COOKIE_SIZE"
+  scenario 'importing a very large file with missing required fields' do
+    visit '/xml_imports/new'
+
+    attach_file 'metadata_file', File.join(fixture_path, 'files', 'malformed_files', '100_sample.xml')
+
+    click_button 'Next'
+    expect(page).to have_content 'Missing required field'
+    expect(page).to have_content "too many to display"
+  end
 end

--- a/spec/features/xml_import_spec.rb
+++ b/spec/features/xml_import_spec.rb
@@ -70,11 +70,12 @@ RSpec.feature 'Create an XML Import', :clean, js: true do
     attach_file 'metadata_file', File.join(fixture_path, 'files', 'malformed_files', 'missing_filename.xml')
 
     click_button 'Next'
-    expect(page).to have_content 'Missing required field: Sonnet_1.pdf is missing tufts:displays_in'
     expect(page).not_to have_content 'Unknown Line'
+    expect(page).to have_content "A file was missing for the record at line: 6"
+    expect(page).to have_content "A file was missing for the record at line: 27"
   end
 
-  # When we produce lots of errors we've been getting "Failure/Error: raise CookieOverflow if options[:value].bytesize > MAX_COOKIE_SIZE"
+  # When we produce lots of errors we've been getting CookieOverflow exceptions
   scenario 'importing a very large file with missing required fields' do
     visit '/xml_imports/new'
 

--- a/spec/fixtures/files/malformed_files/100_sample.xml
+++ b/spec/fixtures/files/malformed_files/100_sample.xml
@@ -1,0 +1,1005 @@
+<?xml version="1.0"?>
+<OAIPMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:model="info:fedora/fedora-system:def/model#" xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#" xmlns:iana="http://www.iana.org/assignments/relation/" xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/" xmlns:dc="http://purl.org/dc/terms/" xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#" xmlns:scholarsphere="http://scholarsphere.psu.edu/ns" xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dc11="http://purl.org/dc/elements/1.1/" xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" xmlns:mads="http://www.loc.gov/mads/rdf/v1#" xmlns:tufts="http://dl.tufts.edu/terms#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample0.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Tokyo Men</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample1.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Case of the Missing Death Tears</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample2.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Killer Pickpocket</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample3.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Champagne Clash</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample4.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Legend of Dangerous Ninjas</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample5.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Season of the Blue Beast</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample6.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Champagne Cousins</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample7.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Journey of the Electric Thief</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample8.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Codename: Death Beast</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample9.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: War of the Nuclear Friday</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample10.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Season of the Electric Demon</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample11.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Season of the Fake Dreams</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample12.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Fake Cat</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample13.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Rise of the Flying City</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample14.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: War of the Tokyo Beast</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample15.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Red Rain</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample16.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Death Diaries</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample17.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Dangerous Clash</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample18.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Green Wizard</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample19.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Time of the Green Ninja</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample20.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Bloody Witch</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample21.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Planet of the Action Women</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample22.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Season of the Green Hills</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample23.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: American Wizard</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample24.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: I Married a Dangerous Blow</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample25.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Red Demon</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample26.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Killer Ninjas</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample27.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Blue Diaries</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample28.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Return of the American Dreams</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample29.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Rise of the Nuclear Dreams</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample30.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Killer Identity</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample31.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Return of the Hungry Woman</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample32.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Danger Witch</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample33.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Legend of Red Witch</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample34.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Planet of the Action Wizard</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample35.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Time of the Death Woman</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample36.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Ultra Identity</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample37.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Hungry Blow</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample38.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Action Cat</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample39.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Killer Brain</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample40.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Death Thief</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample41.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Electric Friday</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample42.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Blue Tears</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample43.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: American Diaries</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample44.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: I Married a Dangerous Jungle</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample45.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Action Cousins</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample46.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Action Women</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample47.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: War of the Danger Cousins</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample48.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Curse of the American Woman</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample49.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Hungry Man</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample50.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Case of the Missing Electric Wizard</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample51.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Champagne Monster</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample52.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Journey of the Nuclear Men</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample53.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Legend of Fake Wizard</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample54.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Day of the Danger World</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample55.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Red Fly</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample56.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Day of the American Rain</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample57.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Bloody Friday</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample58.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Nuclear Rain</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample59.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Curse of the Flying Man</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample60.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Death Diaries</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample61.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Rise of the American Ninja</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample62.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Ultra Ninjas</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample63.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Danger Cousins</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample64.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Flying Man</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample65.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: I am Green Men</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample66.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Killer Fly</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample67.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Codename: Dangerous Witch</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample68.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Tokyo Friday</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample69.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Journey of the Green Ninjas</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample70.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Rise of the American Brain</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample71.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Blonde Women</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample72.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Tokyo Wolf</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample73.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: I Married a Fake Hills</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample74.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: American Diaries</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample75.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: The Ultra Dreams</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample76.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Champagne World</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample77.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Nuclear Wizard</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample78.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Return of the Bloody Mutant</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample79.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: A Fistful of Champagne Identity</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample80.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Curse of the Flying Men</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample81.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: War of the Blue Fly</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample82.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: A Fistful of Nuclear Wolves</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample83.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Journey of the Forbidden Mutant</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample84.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Season of the Flying Dreams</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample85.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Journey of the Champagne Witch</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample86.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: War of the American Dreams</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample87.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Return of the Green Mutant</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample88.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: I Married a Electric Gypsy</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample89.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Curse of the Nuclear Brain</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample90.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Planet of the Killer Hills</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample91.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Rise of the Electric Wizard</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample92.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Champagne Friday</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample93.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Nuclear Rain</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample94.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Ultra Women</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample95.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Curse of the Action Tears</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample96.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Invasion of the Red Men</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample97.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Rise of the Bloody Thief</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample98.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: The Tokyo Brains</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample99.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Tokyo Cat</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAIPMH>

--- a/spec/fixtures/files/malformed_files/missing_filename.xml
+++ b/spec/fixtures/files/malformed_files/missing_filename.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<OAIPMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:model="info:fedora/fedora-system:def/model#" xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#" xmlns:iana="http://www.iana.org/assignments/relation/" xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/" xmlns:dc="http://purl.org/dc/terms/" xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#" xmlns:scholarsphere="http://scholarsphere.psu.edu/ns" xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dc11="http://purl.org/dc/elements/1.1/" xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" xmlns:mads="http://www.loc.gov/mads/rdf/v1#" xmlns:tufts="http://dl.tufts.edu/terms#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Blue Diaries</dc:title>
+          <tufts:displays_in>dl</tufts:displays_in>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample1.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Champagne Monster</dc:title>
+          <tufts:displays_in>dl</tufts:displays_in>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Day of the Blue Diaries</dc:title>
+          <tufts:displays_in>dl</tufts:displays_in>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>pdf_sample3.pdf</tufts:filename>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Sample Data: Tokyo Wolf</dc:title>
+          <tufts:displays_in>dl</tufts:displays_in>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAIPMH>

--- a/spec/fixtures/files/malformed_files/missing_required_fields.xml
+++ b/spec/fixtures/files/malformed_files/missing_required_fields.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH
+  xmlns="http://www.openarchives.org/OAI/2.0/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:model="info:fedora/fedora-system:def/model#"
+  xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#"
+  xmlns:iana="http://www.iana.org/assignments/relation/"
+  xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#"
+  xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#"
+  xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/"
+  xmlns:bibframe="http://bibframe.org/vocab/"
+  xmlns:dc11="http://purl.org/dc/elements/1.1/"
+  xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#"
+  xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+  xmlns:mads="http://www.loc.gov/mads/rdf/v1#"
+  xmlns:tufts="http://dl.tufts.edu/terms#"
+  xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:filename>Sonnet_1.pdf</tufts:filename>
+         <tufts:visibility></tufts:visibility>
+         <model:hasModel></model:hasModel>
+         <dc:title></dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/fixtures/files/mira_xml.xml
+++ b/spec/fixtures/files/mira_xml.xml
@@ -19,6 +19,7 @@ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
       <metadata>
         <mira_import xmlns:model="info:fedora/fedora-system:def/model#" xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#" xmlns:iana="http://www.iana.org/assignments/relation/" xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/" xmlns:dc="http://purl.org/dc/terms/" xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#" xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#" xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dc11="http://purl.org/dc/elements/1.1/" xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" xmlns:mads="http://www.loc.gov/mads/rdf/v1#" xmlns:tufts="http://dl.tufts.edu/terms#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
           <tufts:filename>pdf-sample.pdf</tufts:filename>
+	  <tufts:displays_in>dl</tufts:displays_in>
           <tufts:visibility>open</tufts:visibility>
           <tufts:filename>3.pdf</tufts:filename>
           <model:hasModel>Pdf</model:hasModel>
@@ -69,6 +70,7 @@ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
       <metadata>
         <mira_import xmlns:model="info:fedora/fedora-system:def/model#" xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#" xmlns:iana="http://www.iana.org/assignments/relation/" xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/" xmlns:dc="http://purl.org/dc/terms/" xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#" xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#" xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dc11="http://purl.org/dc/elements/1.1/" xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" xmlns:mads="http://www.loc.gov/mads/rdf/v1#" xmlns:tufts="http://dl.tufts.edu/terms#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
           <tufts:filename>2.pdf</tufts:filename>
+	  <tufts:displays_in>dl</tufts:displays_in>
           <model:hasModel>Pdf</model:hasModel>
           <dc:title>President Jean Mayer speaking at commencement, 1988</dc:title>
           <dc:description>5x7</dc:description>

--- a/spec/lib/tufts/importer_spec.rb
+++ b/spec/lib/tufts/importer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Tufts::Importer do
     end
   end
 
-  describe '#initialize' do
+  describe '#validate!' do
     let(:badly_formed_xml) do
       File.open(File.join(fixture_path, 'files', 'malformed_files', 'stray_element.xml'), 'r')
     end
@@ -28,6 +28,7 @@ RSpec.describe Tufts::Importer do
 
     it "reports parsing errors if the document contains a stray element" do
       importer = described_class.new(file: badly_formed_xml)
+      importer.validate!
       expect(importer.errors).not_to be_empty
     end
   end


### PR DESCRIPTION
1. Move the XML validation check to the validate! method

2. When there are XML validation errors only report the
first one. A single stray element causes six errors because
it cascades -- really, the user just needs to know the
document is malformed and they should go check it with
an XML parser.

3. Add a method to validate! that checks for required fields.
Right now this includes "dc:title", "tufts:displays_in",
and "model:hasModel". Eventually we might want to put this in
a config somewhere.

4. Explicitly add namespaces of the required fields we're
checking for to the in-memory XML document. The way we
declare XML namespaces varies across some of the test files
we're using, and this ensures the validation works across
that variation.

5. Add required displays_in element to sample import files

6. Only display the first five validation error messages, but include 
the total number of errors.

7. Add the line number to missing filename errors

Fixes #634 
Fixes #741 
Fixes #716 
Fixes #717 