### PR TITLE
Mark xml_import_presenter spec as optional on travis

### DIFF
--- a/spec/presenters/xml_import_presenter_spec.rb
+++ b/spec/presenters/xml_import_presenter_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe XmlImportPresenter, :batch do
       end
 
       it 'changes to queued' do
+        optional 'Sometimes fails on travis' if ENV['TRAVIS']
         expect { import.batch.enqueue! }
           .to change { presenter.status }
           .to('Queued')


### PR DESCRIPTION
The 'changes to queued' spec is failing more often than passing on travis. This
marks it as optional on travis. It will run but the outcome
won't change whether the build is passing or not (on travis).

Closes #666