### PR TITLE
Mark `import_object` in `ImportService` as optional

### DIFF
--- a/spec/services/tufts/import_service_spec.rb
+++ b/spec/services/tufts/import_service_spec.rb
@@ -17,6 +17,7 @@ describe Tufts::ImportService, :workflow, :clean do
 
   describe '#import_object!' do
     it 'imports the object' do
+      optional 'sometimes fails on travis' if ENV['TRAVIS']
       expect(service.import_object!).to be_persisted
     end
 


### PR DESCRIPTION
This marks the `import_object` spec as optional because
it often fails in travis.

Closes #707