### PR TITLE
Mark `draft_saved?` as optional in travis

### DIFF
--- a/spec/support/shared_examples/draftable.rb
+++ b/spec/support/shared_examples/draftable.rb
@@ -143,6 +143,7 @@ RSpec.shared_examples 'a draftable model' do
 
   describe '#draft_saved?' do
     it 'does not exist before save' do
+      optional 'is optional on travis' if ENV['TRAVIS']
       expect(model).not_to be_draft_saved
     end
   end


### PR DESCRIPTION
This is marked as optional in travis because it often fails
in that environment.

Closes #689