### PR TITLE
Refactor user factories to use `add_role` and `remove_role`

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,9 +7,10 @@ FactoryGirl.define do
     end
     password 'password'
     display_name FFaker::Name.name
+    after(:create) { |user| user.remove_role(:admin) }
 
     factory :admin do
-      roles { [Role.where(name: 'admin').first_or_create] }
+      after(:create) { |user| user.add_role(:admin) }
     end
   end
 end


### PR DESCRIPTION
A few months ago these methods were added to the `User` object
to add or remove a role. It works like this: `user.add_role(:admin)`

This changes the `User` factories to use those methods to add roles.

There were intermittent failures caused by Roles that this should address.

Closes #602