### PR TITLE
Clean up drafts in the test suite

### DIFF
--- a/spec/controllers/hyrax/pdfs_controller_spec.rb
+++ b/spec/controllers/hyrax/pdfs_controller_spec.rb
@@ -4,11 +4,15 @@ RSpec.describe Hyrax::PdfsController, type: :controller do
   render_views
   let(:work) { FactoryGirl.create(:pdf) }
   let(:user) { FactoryGirl.create(:admin) }
+
   before do
     sign_in user
     work.title = ["a_drafted_title"]
     work.save_draft
   end
+
+  after { work.delete_draft }
+
   describe 'GET #edit' do
     it 'applies a draft if one exists' do
       get :edit, params: { id: work.id }
@@ -20,6 +24,7 @@ RSpec.describe Hyrax::PdfsController, type: :controller do
       expect(response.body.match('a_drafted_title')).to be_nil
     end
   end
+
   describe 'PATCH #update' do
     it "deletes the draft when updating" do
       post :update, params: { id: work.id, pdf: { title: 'new_title', description: 'test' } }

--- a/spec/support/shared_examples/draftable.rb
+++ b/spec/support/shared_examples/draftable.rb
@@ -13,6 +13,9 @@ RSpec.shared_examples 'a draftable model' do
       raise 'Define `change_map` with `let(:change_map)` before using the ' \
             'draftable model shared examples'
     end
+
+    model.delete_draft
+
     # The model has to be saved before drafts can be created
     model.save
   end
@@ -106,7 +109,6 @@ RSpec.shared_examples 'a draftable model' do
       end
 
       it 'overwrites changes for properties in the draft' do
-        optional "Sometimes fails on travis" if ENV['TRAVIS']
         model.send("#{change_map.keys.last}=", ['I SHOULD BE DELETED'])
         model.apply_draft
         expect(model).to have_unordered_attributes(change_map)
@@ -143,7 +145,6 @@ RSpec.shared_examples 'a draftable model' do
 
   describe '#draft_saved?' do
     it 'does not exist before save' do
-      optional 'is optional on travis' if ENV['TRAVIS']
       expect(model).not_to be_draft_saved
     end
   end


### PR DESCRIPTION
Some of our intermittent failures (at least #689) are due to tests creating
drafts for an object ID, but not cleaning up after themselves. Adding an `after`
block to clean up the tests fixes them.