### PR TITLE
fix intermittent test failures by unchecking check all at end of firs…

### DIFF
--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe 'batch', :batch, type: :feature, js: true do
   describe 'publishing' do
     it 'has tufts-buttons on the page' do
       expect(page).to have_selector('.tufts-buttons')
+
+      # un-check all to reset page for remaining tests
+      check 'check_all'
     end
 
     it 'sends the user to the batch status page like on the catalog' do


### PR DESCRIPTION
…t spec

This might resolve an issue seemingly caused by the state of check all in the first spec; I tested locally with a seed that had previously caused a failure and it was resolved. Since the remaining specs all leave the page after checking check all, they effectively clear themselves. But if you run the first spec and the before code checks all and then another, the before code checks all again - unchecking it. 