### PR TITLE
Add to collections on import

### DIFF
--- a/app/lib/tufts/import_record.rb
+++ b/app/lib/tufts/import_record.rb
@@ -61,7 +61,6 @@ module Tufts
     # @return [String]
     def file
       return '' if files.empty?
-
       files.first
     end
 
@@ -69,11 +68,7 @@ module Tufts
     # @return [Array<String>]
     def files
       return [] if metadata.nil?
-
-      metadata
-        .xpath('./tufts:filename', mapping.namespaces)
-        .children
-        .map(&:content)
+      metadata.xpath('./tufts:filename', mapping.namespaces).children.map(&:content)
     end
 
     ##
@@ -84,6 +79,13 @@ module Tufts
       @title ||=
         metadata.xpath('./dc:title', mapping.namespaces)
                 .children.map(&:content).first || file
+    end
+
+    ##
+    # @return [Array<String>]
+    def collections
+      return [] if metadata.nil?
+      metadata.xpath('./tufts:memberOf', mapping.namespaces).children.map(&:content)
     end
 
     ##

--- a/app/services/tufts/import_service.rb
+++ b/app/services/tufts/import_service.rb
@@ -52,7 +52,8 @@ module Tufts
       object     = record.build_object(id: object_id)
       creator    = User.find(file.user_id)
       ability    = ::Ability.new(creator)
-      attributes = { uploaded_files: file_ids }
+      attributes = { uploaded_files: file_ids, member_of_collection_ids: record.collections }
+
       env        = Hyrax::Actors::Environment.new(object, ability, attributes)
 
       Hyrax::CurationConcern.actor.create(env) ||

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :collection do
+    title ['A moomin collection']
+
+    transient do
+      user { create(:admin) }
+    end
+
+    after(:build) do |collection, evaluator|
+      collection.apply_depositor_metadata(evaluator.user.user_key) if evaluator.user
+    end
+  end
+end

--- a/spec/fixtures/files/mira_xml.xml
+++ b/spec/fixtures/files/mira_xml.xml
@@ -22,6 +22,8 @@ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
           <tufts:visibility>open</tufts:visibility>
           <tufts:filename>3.pdf</tufts:filename>
           <model:hasModel>Pdf</model:hasModel>
+          <tufts:memberOf>a_collection_id</tufts:memberOf>
+          <tufts:memberOf>another_collection_id</tufts:memberOf>
           <dc:title>President Jean Mayer speaking
           at commencement, 1987</dc:title>
           <dc11:description>

--- a/spec/lib/tufts/import_record_spec.rb
+++ b/spec/lib/tufts/import_record_spec.rb
@@ -65,6 +65,21 @@ RSpec.describe Tufts::ImportRecord do
     end
   end
 
+  describe '#collections' do
+    it 'is empty by default' do
+      expect(record.collections).to be_empty
+    end
+
+    context 'with metadata' do
+      include_context 'with metadata'
+
+      it 'has a collection' do
+        expect(record.collections).to contain_exactly(an_instance_of(String),
+                                                      an_instance_of(String))
+      end
+    end
+  end
+
   describe '#metadata' do
     it 'is nil by default' do
       expect(record.metadata).to be_nil


### PR DESCRIPTION
Introduces a `<tufts:collection>` term that accepts collection ids. Ids passed
into this node will be added to the item on create. If the collection does not
exist, the object import fails in the actor stack with
`ActiveFedora::ObjectNotFoundError`.

There is not currently handling for deleting collections, or validating that
collections exist on object upload. Export is also not handled.

Connected to #703.