### PR TITLE
Allow setting file types on file_sets within a work via XmlImport

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_and_pass_types_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_and_pass_types_actor.rb
@@ -1,0 +1,31 @@
+module Hyrax
+  module Actors
+    # Creates a work and attaches files to the work,
+    # passes types through to the attach files job
+    class CreateWithFilesAndPassTypesActor < CreateWithFilesActor
+      def create(env)
+        @thumbnail      = env.attributes.delete(:thumbnail)
+        @transcript     = env.attributes.delete(:transcript)
+        @representative = env.attributes.delete(:representative)
+        super
+      end
+
+      ##
+      # @return [TrueClass]nnn
+      def attach_files(files, env)
+        return true if files.blank?
+        attributes = env.attributes.merge(file_type_attributes)
+        AttachTypedFilesToWorkJob.perform_later(env.curation_concern, files, attributes.to_h.symbolize_keys)
+        true
+      end
+
+      def file_type_attributes
+        types = {}
+        types[:thumbnail]      = @thumbnail      if @thumbnail.present?
+        types[:transcript]     = @transcript     if @transcript.present?
+        types[:representative] = @representative if @representative.present?
+        types
+      end
+    end
+  end
+end

--- a/app/jobs/attach_typed_files_to_work_job.rb
+++ b/app/jobs/attach_typed_files_to_work_job.rb
@@ -1,0 +1,44 @@
+# Converts UploadedFiles into FileSets and attaches them to works.
+class AttachTypedFilesToWorkJob < AttachFilesToWorkJob
+  # @param [ActiveFedora::Base] work - the work object
+  # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
+  def perform(work, uploaded_files, **work_attributes)
+    validate_files!(uploaded_files)
+    user = User.find_by_user_key(work.depositor) # BUG? file depositor ignored
+    work_permissions = work.permissions.map(&:to_hash)
+    metadata = visibility_attributes(work_attributes)
+    uploaded_files.each do |uploaded_file|
+      actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
+      actor.create_metadata(metadata)
+      actor.create_content(uploaded_file)
+      set_filetypes(work: work, file_set: actor.file_set, filename: uploaded_file.file.file.original_filename, **work_attributes)
+      actor.attach_to_work(work)
+      actor.file_set.permissions_attributes = work_permissions
+      uploaded_file.update(file_set_uri: actor.file_set.uri)
+    end
+  end
+
+  ##
+  # Sets the file types on the work.
+  #
+  # Simply returns if no opts are passed. Otherwise, sets representative,
+  # thumbnail, and transcript roles for the given fileset if filename matches
+  # the set name for that role.
+  #
+  # If the work does not support a file type, attempts to set this relation are
+  # ignored.
+  #
+  # @return [Boolean] true if the file types have been set sucessfully
+  def set_filetypes(work:, file_set:, filename:, **opts)
+    return true if opts.empty?
+
+    [:representative, :thumbnail, :transcript].each do |type|
+      work.public_send(:"#{type}_id=", file_set.id) if
+        work.respond_to?(:"#{type}_id=") && opts[type] == filename
+    end
+
+    # NOTE: the work may not be valid, in which case this save doesn't do anything
+    # see https://github.com/samvera/hyrax/blob/403d95cb2ada27fe366dd9e8df91240f3b46c461/app/actors/hyrax/actors/file_set_actor.rb#L81
+    work.save
+  end
+end

--- a/app/lib/tufts/import_record.rb
+++ b/app/lib/tufts/import_record.rb
@@ -11,6 +11,8 @@ module Tufts
   #   record      = ImportRecord.new
   #   record.file = 'filename.png'
   #
+  # @todo This class has gotten quite large. A refactor may be beneficial.
+  # rubocop:disable Metrics/ClassLength
   class ImportRecord
     include Tufts::Normalizer
 
@@ -20,6 +22,10 @@ module Tufts
        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE,
        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE].freeze
+
+    THUMBNAIL_VALUE      = 'thumbnail'.freeze
+    TRANSCRIPT_VALUE     = 'transcript'.freeze
+    REPRESENTATIVE_VALUE = 'representative'.freeze
 
     ##
     # @!attribute mapping [rw]
@@ -62,6 +68,24 @@ module Tufts
     def file
       return '' if files.empty?
       files.first
+    end
+
+    ##
+    # @return [String]
+    def thumbnail
+      file_by_type(THUMBNAIL_VALUE)
+    end
+
+    ##
+    # @return [String]
+    def transcript
+      file_by_type(TRANSCRIPT_VALUE)
+    end
+
+    ##
+    # @return [String]
+    def representative
+      file_by_type(REPRESENTATIVE_VALUE)
     end
 
     ##
@@ -145,6 +169,17 @@ module Tufts
 
     private
 
+      def file_by_type(type)
+        return '' if metadata.nil?
+
+        file_node =
+          metadata
+          .xpath("./tufts:filename[@type=\"#{type}\"]", mapping.namespaces)
+          .first
+
+        file_node.try(:content) || ''
+      end
+
       def singular_properties
         @singular_properties =
           GenericObject
@@ -165,4 +200,5 @@ module Tufts
         values
       end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/services/tufts/import_service.rb
+++ b/app/services/tufts/import_service.rb
@@ -49,12 +49,10 @@ module Tufts
     #
     # @return [ActiveFedora::Core]
     def import_object!
-      object     = record.build_object(id: object_id)
-      creator    = User.find(file.user_id)
-      ability    = ::Ability.new(creator)
-      attributes = { uploaded_files: file_ids, member_of_collection_ids: record.collections }
-
-      env        = Hyrax::Actors::Environment.new(object, ability, attributes)
+      object  = record.build_object(id: object_id)
+      creator = User.find(file.user_id)
+      ability = ::Ability.new(creator)
+      env     = Hyrax::Actors::Environment.new(object, ability, attributes)
 
       Hyrax::CurationConcern.actor.create(env) ||
         raise(ImportError, "Failed to create object #{object.id}\n The actor stack returned `false`.")
@@ -71,6 +69,17 @@ module Tufts
     class ImportError < RuntimeError; end
 
     private
+
+      ##
+      # @private
+      # @return [HashWithIndifferentAccess]
+      def attributes
+        { uploaded_files:           file_ids,
+          member_of_collection_ids: record.collections,
+          thumbnail:                record.thumbnail,
+          transcript:               record.transcript,
+          representative:           record.representative }.with_indifferent_access
+      end
 
       ##
       # @private

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,7 @@ module Epigaea
     config.to_prepare do
       factory = Hyrax::CurationConcern.actor_factory
       factory.use(Hyrax::Actors::HandleAssuranceActor)
+      factory.swap(Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::CreateWithFilesAndPassTypesActor)
 
       # Hyrax's instructions don't work
       # https://github.com/samvera/hyrax/blame/a992e37fba805665e1587f40870bde5cd3826b3f/app/services/hyrax/curation_concern.rb#L3-L18

--- a/spec/factories/hyrax_uploaded_files.rb
+++ b/spec/factories/hyrax_uploaded_files.rb
@@ -2,5 +2,9 @@ FactoryGirl.define do
   factory :hyrax_uploaded_file, class: Hyrax::UploadedFile do
     user
     file File.open('spec/fixtures/files/pdf-sample.pdf')
+
+    factory :second_uploaded_file do
+      file File.open('spec/fixtures/files/2.pdf')
+    end
   end
 end

--- a/spec/fixtures/files/mira_xml_file_types.xml
+++ b/spec/fixtures/files/mira_xml_file_types.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2017-09-01T19:20:30Z</responseDate>
+  <request verb="ListRecords" from="1998-01-15"
+           set="any:set"
+           metadataPrefix="mira_import">
+  http://example.com/OAI</request>
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import xmlns:model="info:fedora/fedora-system:def/model#" xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#" xmlns:iana="http://www.iana.org/assignments/relation/" xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/" xmlns:dc="http://purl.org/dc/terms/" xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#" xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#" xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dc11="http://purl.org/dc/elements/1.1/" xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" xmlns:mads="http://www.loc.gov/mads/rdf/v1#" xmlns:tufts="http://dl.tufts.edu/terms#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+          <tufts:filename type="transcript">2.pdf</tufts:filename>
+          <tufts:filename type="representative">pdf-sample.pdf</tufts:filename>
+	  <tufts:displays_in>dl</tufts:displays_in>
+          <model:hasModel>Audio</model:hasModel>
+          <dc:title>Record with Representative and Transcript</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+    <record>
+      <metadata>
+        <mira_import xmlns:model="info:fedora/fedora-system:def/model#" xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#" xmlns:iana="http://www.iana.org/assignments/relation/" xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/" xmlns:dc="http://purl.org/dc/terms/" xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#" xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#" xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dc11="http://purl.org/dc/elements/1.1/" xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" xmlns:mads="http://www.loc.gov/mads/rdf/v1#" xmlns:tufts="http://dl.tufts.edu/terms#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+          <tufts:filename>3.pdf</tufts:filename>
+          <tufts:filename type="thumbnail">fake.png</tufts:filename>
+	  <tufts:displays_in>dl</tufts:displays_in>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>Record with Representative and Thumbnail</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/lib/tufts/import_record_spec.rb
+++ b/spec/lib/tufts/import_record_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe Tufts::ImportRecord do
     end
   end
 
+  shared_context 'with file types' do
+    include_context 'with metadata'
+
+    let(:doc) { Nokogiri::XML(File.open(file_fixture('mira_xml_file_types.xml')).read) }
+
+    let(:thumbnail_record) { described_class.new(metadata: thumbnail_node) }
+
+    let(:thumbnail_node) do
+      doc.root.xpath('//xmlns:record/xmlns:metadata/xmlns:mira_import', doc.root.namespaces)[1]
+    end
+  end
+
   describe '#build_object' do
     it 'builds a GenericObject by default' do
       expect(record.build_object).to be_a GenericObject
@@ -138,6 +150,72 @@ RSpec.describe Tufts::ImportRecord do
       it 'uses specified visibility' do
         expect(record.visibility)
           .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      end
+    end
+  end
+
+  describe '#transcript' do
+    it 'is empty by default' do
+      expect(record.transcript).to eq ''
+    end
+
+    context 'with no types' do
+      include_context 'with metadata'
+
+      it 'is empty' do
+        expect(record.transcript).to eq ''
+      end
+    end
+
+    context 'with file types' do
+      include_context 'with file types'
+
+      it 'has a transcript' do
+        expect(record.transcript).to eq '2.pdf'
+      end
+    end
+  end
+
+  describe '#thumbnail' do
+    it 'is empty by default' do
+      expect(record.thumbnail).to eq ''
+    end
+
+    context 'with no types' do
+      include_context 'with metadata'
+
+      it 'is empty' do
+        expect(record.thumbnail).to eq ''
+      end
+    end
+
+    context 'with file types' do
+      include_context 'with file types'
+
+      it 'has a thumbnail' do
+        expect(thumbnail_record.thumbnail).to eq 'fake.png'
+      end
+    end
+  end
+
+  describe '#representative' do
+    it 'is empty by default' do
+      expect(record.representative).to eq ''
+    end
+
+    context 'with no types' do
+      include_context 'with metadata'
+
+      it 'is empty' do
+        expect(record.representative).to eq ''
+      end
+    end
+
+    context 'with file types' do
+      include_context 'with file types'
+
+      it 'has a thumbnail' do
+        expect(record.representative).to eq 'pdf-sample.pdf'
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -152,6 +152,26 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  ##
+  # Use this example group when you want to perform jobs inline during testing.
+  #
+  # Limit to specific job classes with:
+  #
+  #   ActiveJob::Base.queue_adapter.filter = [JobClass]
+  config.before(perform_enqueued: true) do
+    ActiveJob::Base.queue_adapter = :test
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+  end
+
+  config.after(perform_enqueued: true) do
+    ActiveJob::Base.queue_adapter.enqueued_jobs  = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = false
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+  end
+
   Shoulda::Matchers.configure do |shoulda_config|
     shoulda_config.integrate do |with|
       # Choose a test framework:

--- a/spec/services/tufts/import_service_spec.rb
+++ b/spec/services/tufts/import_service_spec.rb
@@ -29,13 +29,6 @@ describe Tufts::ImportService, :workflow, :clean do
       expect(service.import_object!).to have_attributes(id: object_id)
     end
 
-    it 'adds the file' do
-      ActiveJob::Base.queue_adapter = :test
-
-      expect { service.import_object! }
-        .to enqueue_job(AttachFilesToWorkJob).once
-    end
-
     it 'has the title from the imported record' do
       title = "President Jean Mayer speaking\n          at commencement, 1987"
 
@@ -45,6 +38,43 @@ describe Tufts::ImportService, :workflow, :clean do
     it 'adds the file to a collection' do
       expect(service.import_object!.member_of_collections.map(&:id))
         .to contain_exactly(*collection_ids)
+    end
+
+    context 'when attaching uploaded files', :perform_enqueued do
+      before { ActiveJob::Base.queue_adapter.filter = [AttachTypedFilesToWorkJob] }
+
+      it 'adds a representative file' do
+        result = service.import_object!
+        result.reload
+
+        expect(result.representative)
+          .to have_attributes(title: ['pdf-sample.pdf'])
+      end
+
+      context 'with types' do
+        let(:object) { FactoryGirl.build(:pdf, id: object_id) }
+        let(:user)   { FactoryGirl.create(:admin) }
+
+        let(:import) do
+          FactoryGirl.create(:xml_import,
+                             metadata_file: File.open(file_fixture('mira_xml_file_types.xml')),
+                             uploaded_file_ids: files.map(&:id))
+        end
+
+        let(:files) do
+          [FactoryGirl.create(:hyrax_uploaded_file,  user: user),
+           FactoryGirl.create(:second_uploaded_file, user: user)]
+        end
+
+        it 'adds a representative and transcript' do
+          result = service.import_object!
+          result.reload
+
+          expect(result)
+            .to have_attributes(representative: have_attributes(title: ['pdf-sample.pdf']),
+                                transcript:     have_attributes(title: ['2.pdf']))
+        end
+      end
     end
 
     context 'with missing collections' do


### PR DESCRIPTION
Supports setting filetypes in XML batch imports by passing `type="transcript"`
as an attribute on an XML file.

Callers to the Actor Stack's `#create` method can now pass a filename to each of
the `:transcript`, `:representative`, and `:thumbnail` to force the stack to set
these roles when an item is attached to the work.

Unfortunately, we need to overwrite significant parts of the Hyrax ActorStack to
achieve this goal. The attach files part of the stack is run in a background
job, making it challenging to extend. We create customized versions of a
standard Hyrax actor (`CreateWithFilesAndPassTypesActor`) and a job to handle
the setting (`AttachTypedFilesToWorkJob`). The first allows passthrough of the
required arguments to the job. These arguments must be deleted before the work`s
actor is called to prevent errors on the unknown attributes. The Job overwrite
ensures that the roles are set before the `FileSetActor` (which is, confusingly,
neither an actor, nor in the stack) runs and tries to use its own setting
strategies.

ImportRecord is extended to recognize file roles from the `type` XML attribute,
and the import service passes these roles to the actor stack, triggering the
above setting.

Closes #632.