### PR TITLE
Remove duplicated :help keyword

### DIFF
--- a/app/views/contribute/deposit_view/_gis_poster.html.erb
+++ b/app/views/contribute/deposit_view/_gis_poster.html.erb
@@ -33,7 +33,7 @@
 </div>
 
 <%= f.hidden_field :description, value: 'throw away' %>
-<%= f.text_field :geonames_placeholder, label: 'Place Keywords', help: 'Pick some keywords', class: 'geonames', help: 'Please select places this poster pertains to. Note: field with autocomplete with values via GeoNames API' %>
+<%= f.text_field :geonames_placeholder, label: 'Place Keywords', class: 'geonames', help: 'Please select places this poster pertains to. Note: field with autocomplete with values via GeoNames API' %>
 
 <div id="geotextarea" contenteditable="false">
   <% unless @contribution.geonames.nil? %>


### PR DESCRIPTION
There was a warning being logged about this that would have cluttered the logs. The behavior was correct, but the code was potentially confusing.