### PR TITLE
Activate the revert draft button on batches page

### DIFF
--- a/app/jobs/revert_job.rb
+++ b/app/jobs/revert_job.rb
@@ -1,0 +1,8 @@
+##
+# A job to revert a draft for an object
+class RevertJob < BatchableJob
+  def perform(id)
+    work = ActiveFedora::Base.find(id)
+    work.delete_draft
+  end
+end

--- a/app/models/batch_task.rb
+++ b/app/models/batch_task.rb
@@ -15,7 +15,8 @@ class BatchTask < ApplicationRecord
 
   BATCH_TYPES = {
     publish: PublishJob,
-    unpublish: UnpublishJob
+    unpublish: UnpublishJob,
+    revert: RevertJob
   }.freeze
 
   validates :batch_type,

--- a/app/views/hyrax/batches/_controls.html.erb
+++ b/app/views/hyrax/batches/_controls.html.erb
@@ -14,6 +14,6 @@
     <%= button_to "Purge Batch", main_app.batches_path, method: :post, params: { batch: { batchable_attributes: { batch_type: "Publish" } } }, class: "btn btn-primary", disabled: true %>
   </li>
   <li>
-    <%= button_to "Revert Batch", main_app.batches_path, method: :post, params: { batch: { batchable_attributes: { batch_type: "Publish" } } }, class: "btn btn-primary", disabled: true %>
+    <%= button_to "Revert Drafts", main_app.batches_path, method: :post, params: { batch: { ids: @batch.object.ids, batchable_attributes: { batch_type: "Revert" } } }, class: "btn btn-primary" %>
   </li>
 </ul>

--- a/spec/jobs/revert_job_spec.rb
+++ b/spec/jobs/revert_job_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe RevertJob, :workflow, type: :job do
+  subject(:job) { described_class }
+  let(:pdf)     { FactoryGirl.create(:pdf) }
+
+  before { ActiveJob::Base.queue_adapter = :test }
+
+  describe '#perform_later' do
+    it 'enqueues the job' do
+      expect { job.perform_later(pdf.id) }
+        .to enqueue_job(described_class)
+        .with(pdf.id)
+        .on_queue('batch')
+    end
+  end
+
+  context "revert a draft" do
+    let(:work) { FactoryGirl.actor_create(:pdf, user: depositing_user) }
+    let(:depositing_user) { FactoryGirl.create(:user) }
+
+    before do
+      work.title = ['testing']
+      work.save_draft
+    end
+
+    it 'sets the workflow status to published' do
+      expect(work.draft_saved?).to eq(true)
+      RevertJob.perform_now(work.id)
+      expect(work.draft_saved?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
This creates a `RevertJob` for reverting drafts on the batches
page and adds it to the batch tasks. The button was disabled
before, but this enables it as well.

Closes #342