### PR TITLE
Clean ActiveFedora before MetadataImportService specs

### DIFF
--- a/spec/services/tufts/metadata_import_service_spec.rb
+++ b/spec/services/tufts/metadata_import_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Tufts::MetadataImportService, :workflow do
+describe Tufts::MetadataImportService, :workflow, :clean do
   subject(:service) { described_class.new(import: import, object_id: object.id) }
   let(:import)      { FactoryGirl.create(:metadata_import) }
 


### PR DESCRIPTION
The metadata import service specs could sometimes fail on:

> "Discovered tombstone resource at /test/7s/75/dc/36/7s75dc36z, departed:
>  2017-12-14T18:33:19.600Z"

Cleaning them up should avoid this error.