### PR TITLE
Enqueue jobs from XmlImport jobs with only matching ids

### DIFF
--- a/spec/models/xml_import_spec.rb
+++ b/spec/models/xml_import_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe XmlImport, :batch, type: :model do
 
   before do
     allow(Collection).to receive(:find).and_return(true)
+    allow(described_class::NOID_SERVICE)
+      .to receive(:mint)
+      .and_return('123', '124', 'some', 'other', 'id', 'values')
   end
 
   it_behaves_like 'a batchable' do
@@ -13,11 +16,12 @@ RSpec.describe XmlImport, :batch, type: :model do
     end
 
     let(:uploads) do
-      [FactoryGirl.create(:hyrax_uploaded_file),
-       FactoryGirl.create(:hyrax_uploaded_file,
+      # run these in a different order from the xml to confirm looping logic
+      [FactoryGirl.create(:hyrax_uploaded_file,
                           file: File.open('spec/fixtures/files/2.pdf')),
        FactoryGirl.create(:hyrax_uploaded_file,
-                          file: File.open('spec/fixtures/files/3.pdf'))]
+                          file: File.open('spec/fixtures/files/3.pdf')),
+       FactoryGirl.create(:hyrax_uploaded_file)]
     end
   end
 


### PR DESCRIPTION
The original enqueue logic was somewhat tortured, this cleans it up and
clarifies the intent, fixing several bugs in the process.

When enqueuing, we now loop through the uploaded files, checking that:

  - an id has been minted for the file;
  - the batch item is 'processable', meaning that:
    - the batch contains the item;
    - the batch item does not already have a job;
    - the batch item does not already a persisted object;
  - that a record exists for the file in the import document;
  - that all the files for the record have been uploaded

Only in the case that all of these conditions are met do we enqueue a job. Like
other `Batchable#enqueue!` methods, we return a hash mapping from object ids to
job ids for use by the `Batch`.

The previous logic was less careful about ensuring ids were mapped directly to
filenames. This led to unexpected behavior when enqueuing records with multiple
files and in tracking job status. Tests were updated to fail if these errors are
manifesting.

Setup for shared batchable specs had to be adjusted to ensure that the
identifiers assigned to files match the ones the shared examples provide for the
batch.

Closes #772