### PR TITLE
Re-factor batch page to use ajax for pagination

### DIFF
--- a/app/assets/javascripts/tufts.js
+++ b/app/assets/javascripts/tufts.js
@@ -6,7 +6,7 @@ var Tufts = {
   autocomplete: function () {
     var Autocomplete = require('hyrax/autocomplete')
     var autocomplete = new Autocomplete()
-    
+
     autocomplete.setup($('#contribution_department'),'default','/authorities/search/local/departments')
   },
   selectAllOfHyrax: function() {
@@ -24,7 +24,28 @@ var Tufts = {
       }
     })
     $(document).on("turbolinks:before-cache", function() {
-      $(options.selector).DataTable().destroy()  
+      $(options.selector).DataTable().destroy()
+    })
+  },
+  activateBatchesTable: function() {
+    $(document).on('turbolinks:load', function() {
+      if ($.fn.dataTable.isDataTable('#batch-table')) {
+        table = $('#batch-table').DataTable()
+      }
+      else {
+        $('#batch-table').DataTable( {
+          "stateSave": true,
+          "processing": true,
+          "paging": true,
+          "serverSide": true,
+          "searching": false,
+          "ajax": "/batches.json"
+        })
+
+      }
+    })
+    $(document).on("turbolinks:before-cache", function() {
+      $('#batch-table').DataTable().destroy()
     })
   }
 }

--- a/app/assets/stylesheets/tufts.scss
+++ b/app/assets/stylesheets/tufts.scss
@@ -9,3 +9,4 @@
 @import 'tufts/show_actions';
 @import 'tufts/stats';
 @import 'tufts/show_view';
+@import 'tufts/batches';

--- a/app/assets/stylesheets/tufts/_batches.scss
+++ b/app/assets/stylesheets/tufts/_batches.scss
@@ -1,0 +1,3 @@
+.no-sort::after { display: none!important; }
+
+.no-sort { pointer-events: none!important; cursor: default!important; }

--- a/app/views/hyrax/batches/index.html.erb
+++ b/app/views/hyrax/batches/index.html.erb
@@ -6,28 +6,18 @@
       <thead>
         <tr>
           <th>ID</th>
-          <th>Batch Type</th>
+          <th class="no-sort">Batch Type</th>
           <th>Creator</th>
           <th>Created at</th>
-          <th>Items</th>
-          <th>Status</th>
+          <th class="no-sort">Items</th>
+          <th class="no-sort">Status</th>
         </tr>
         <thead>
         <tbody>
-      <% @batches.each do |batch| %>
-        <tr>
-          <td class="batch_id"><%= link_to batch.id, batch.path %></td>
-          <td class="type"><%= batch.type%></td>
-          <td class="creator"><%= batch.creator %></td>
-          <td class="created_at"><%= time_ago_in_words(batch.created_at) %> ago</td>
-          <td class="count"><%= batch.count %></td>
-          <td class="status"><%= batch.status %></td>
-        </tr>
-      <% end %>
        </tbody>
     </table>
     <script>
-      Tufts.activateDataTable({selector: '#batch-table', paging: true})
+     Tufts.activateBatchesTable()
     </script>
   </div>
 </div>

--- a/app/views/hyrax/batches/index.json.jbuilder
+++ b/app/views/hyrax/batches/index.json.jbuilder
@@ -1,0 +1,6 @@
+json.draw params[:draw]
+json.recordsTotal @batches_length
+json.recordsFiltered @batches_length
+json.data do
+  json.array! @batches.collect { |b| ["<a href='/batches/#{b.id}'>#{b.id}</a>", b.type, b.creator, b.created_at.to_formatted_s(:short), b.count, b.status] }
+end

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -26,7 +26,7 @@
         <span class="fa fa-exclamation-triangle"></span><span class="sidebar-action-text">View Handle.net Error Log</span>
     <% end %>
 
-    <%= menu.nav_link('/batches') do %>
+    <%= menu.nav_link('/batches', data: { turbolinks: false }) do %>
         <span class="fa fa-info-circle"></span><span class="sidebar-action-text">View Batch Statuses</span>
     <% end %>
 

--- a/spec/features/batches_spec.rb
+++ b/spec/features/batches_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'viewing the batches page', :clean, js: true do
+  context 'a logged in admin user' do
+    let(:user) { FactoryGirl.create(:admin) }
+    before do
+      login_as user
+      rand(25..100).times { FactoryGirl.create(:batch) }
+      visit '/batches'
+    end
+
+    scenario 'the server only renders 10 batches even if there are more' do
+      expect(page).to have_css('tbody tr', count: 10)
+    end
+
+    scenario 'selecting more fetches more and renders them' do
+      select '25', from: 'batch-table_length'
+      expect(page).to have_css('tbody tr', count: 25)
+    end
+  end
+end


### PR DESCRIPTION
This commit uses a jbuilder view that is structured the
way that DataTable requires to do pagination via ajax.

Before this commit all batches are rendered then DataTable
reads the HTML table structure. This way is more efficient
when dealing with large numbers of batches.

Closes #770