### PR TITLE
Configure google analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,24 @@ would work. If everything is working as expected, you should see:
 ```
 You can also check individual systems by adding their name to the end of the okcomputer url, e.g., `/okcomputer/smtp`.
 See [okcomputer on github](https://github.com/sportngin/okcomputer) for more configuration options.
+
+## Anayltics
+Hyrax has some built-in integration with Google analytics. Instructions for configuration are
+in the [Hyrax Management Guide](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#capturing-usage-and-download-counts). To track usage
+using google analytics:
+1. Follow the abovementioned guide and set up a google analytics account. Take note of the analytics tracking id you
+are assigned and the json key you are prompted to download.
+2. Put the .json key in `/opt/epigaea/shared/config` and call it `epigaea_private_key.json`
+3. Populate the `.env.production` file on the production server with the relevant values from `epigaea_private_key.json`:
+  ```
+  export GOOGLE_ANALYTICS_ID=UA-000000000-1
+  export GOOGLE_OAUTH_APP_NAME=epigaea (make up any value here)
+  export GOOGLE_OAUTH_APP_VERSION=2.0 (make up any value here)
+  export GOOGLE_OAUTH_PRIVATE_KEY_PATH=/opt/epigaea/config/epigaea_private_key.json
+  export GOOGLE_OAUTH_PRIVATE_KEY_SECRET=[key from your .json file]
+  export GOOGLE_OAUTH_CLIENT_EMAIL=epigaea@whatever.gserviceaccount.com (from your .json file)
+  ```
+
+**NOTE** The instructions above will allow you to track usage on the google analytics website.
+Integration into the Hyrax admin dashboard has not yet been completed but is expected
+eventually. See [Hyrax Analytics and Usage Statistics](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#analytics-and-usage-statistics) for more details.

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,9 +1,9 @@
 #
 # To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
 #
-# analytics:
-#   app_name: GOOGLE_OAUTH_APP_NAME
-#   app_version: GOOGLE_OAUTH_APP_VERSION
-#   privkey_path: GOOGLE_OAUTH_PRIVATE_KEY_PATH
-#   privkey_secret: GOOGLE_OAUTH_PRIVATE_KEY_SECRET
-#   client_email: GOOGLE_OAUTH_CLIENT_EMAIL
+analytics:
+  app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
+  app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
+  privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
+  privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
+  client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,6 +26,7 @@ set :deploy_to, "/opt/epigaea"
 # Default value for :linked_files is []
 append :linked_files, "config/database.yml"
 append :linked_files, "config/secrets.yml"
+append :linked_files, "config/epigaea_private_key.json"
 
 # Production secrets need to go in a file called .env.production on the server
 # in /opt/epigaea/shared

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -63,10 +63,10 @@ Hyrax.config do |config|
   # Enable displaying usage statistics in the UI
   # Defaults to false
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
-  # config.analytics = false
+  config.analytics = true
 
   # Google Analytics tracking ID to gather usage statistics
-  # config.google_analytics_id = 'UA-99999999-1'
+  config.google_analytics_id = ENV['GOOGLE_ANALYTICS_ID']
 
   # Date you wish to start collecting Google Analytic statistics for
   # Leaving it blank will set the start date to when ever the file was uploaded by

--- a/config/initializers/legato.rb
+++ b/config/initializers/legato.rb
@@ -1,0 +1,14 @@
+# Special loading needed in development environment for analytics.
+# See https://github.com/samvera/hyrax/wiki/Analytics-workaround-for-non-production-environments
+if Rails.env == 'development'
+  Rails.application.config.after_initialize do
+    # If Google Analytics are enabled, pre-load the models which rely on
+    # Legato::Model.extended(base) dynamic profile method generation. Non-production
+    # environments wouldn't necessarily have this eager loaded by default.
+    if Hyrax.config.analytics
+      require 'legato'
+      require 'hyrax/pageview'
+      require 'hyrax/download'
+    end
+  end
+end


### PR DESCRIPTION
Following guide from https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#analytics-and-usage-statistics
Document setup in README.
The google analytics account will need to be updated when the
application is deployed to it's production home.

Note that this does NOT activate the stats in the admin
dashboard. That integration is an incomplete feature.
See https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#analytics-and-usage-statistics

Fixes #673 