### PR TITLE
Default admin set does not have a creator and needs to display anyway

### DIFF
--- a/app/views/hyrax/admin/admin_sets/index.html.erb
+++ b/app/views/hyrax/admin/admin_sets/index.html.erb
@@ -1,0 +1,41 @@
+<% provide :page_header do %>
+  <h1><span class="fa fa-sitemap"></span> Administrative Sets</h1>
+  <%if can? :create, AdminSet %>
+    <div class="pull-right">
+      <%= link_to hyrax.new_admin_admin_set_path, class: 'btn btn-primary' do %>
+        <span class="fa fa-edit"></span> <%= t(:'helpers.action.admin_set.new') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+    <% if @admin_sets.present? %>
+      <div class="table-responsive">
+        <table class="table table-striped datatable">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Date created</th>
+              <th>Creator</th>
+              <th>Works</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @admin_sets.each do |admin_set| %>
+              <tr>
+                <td><%= link_to admin_set.title.first, [hyrax, :admin, admin_set] %></td>
+                <td><%= admin_set.create_date %></td>
+                <td><%= safe_join(admin_set.creator || [""]) %></td>
+                <td><%= controller.presenter_class.new(admin_set, current_ability).total_items %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <% else %>
+        <p>No administrative sets have been created.</p>
+      <% end %>
+  </div>
+</div>


### PR DESCRIPTION
This appears to be a hyrax bug. The default admin set does not have a
`creator` field, but the Administrative Sets display page expects it to
have one and errors when that value is nil.

Bug filed for Hyrax at https://github.com/samvera/hyrax/issues/2396

Fixes #791 