### PR TITLE
Add to `Batch#job_ids` instead of overwriting when new jobs are enqueued

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -31,6 +31,9 @@ class Batch < ApplicationRecord
 
     id_map.each { |o, j| add_job_for_object(object_id: o, job_id: j) }
 
+    jobs = ActiveJobStatus::JobBatch.find(batch_id: id)
+    return jobs.add_jobs(job_ids: id_map.values) if jobs
+
     ActiveJobStatus::JobBatch.new(batch_id:   id,
                                   job_ids:    id_map.values,
                                   store_data: true)
@@ -60,7 +63,7 @@ class Batch < ApplicationRecord
     # @param id       [#to_s]
     # @param batch_id [#to_s]
     # @param store [#to_s]
-    def initialize(id, batch_id, store: Tufts::JobItemStore)
+    def initialize(id, batch_id, store: STATUS_STORE)
       @id       = id
       @batch_id = batch_id
       @store    = store
@@ -110,11 +113,11 @@ class Batch < ApplicationRecord
     # @private
     # @note Don't expose clients to `ActiveJobStatus::JobBatch`
     # @return [ActiveJobStatus::JobBatch]
-    def job_batch
+    def job_batch(writable: false)
       ActiveJobStatus::JobBatch.find(batch_id: id) ||
         ActiveJobStatus::JobBatch.new(batch_id:   id,
                                       job_ids:    [],
-                                      store_data: false)
+                                      store_data: writable)
     end
 
     ##

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -35,6 +35,21 @@ RSpec.describe Batch, type: :model, batch: true do
 
         it { is_expected.to have_attributes(job_ids: be_empty) }
       end
+
+      context 'when enqueued again with new jobs' do
+        let(:new_jobs) { { 'obj4' => 'job4', 'obj5' => 'job5' } }
+
+        before do
+          allow(batch.batchable).to receive(:enqueue!).and_return(job_hash, new_jobs)
+          batch.enqueue!
+        end
+
+        it 'adds the new job ids' do
+          expect { batch.enqueue! }
+            .to change { batch.job_ids.to_a }
+            .to contain_exactly(*(job_hash.values + new_jobs.values))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Some kinds of Batchables (especially `XmlImport`) can be updated and
re-enqueued. In this case we need to add jobs to `job_ids`, instead of
overwriting as we did previously. This allows new jobs to be added to existing
ones.

This fixes some intermittently failing tests, which are unskipped here.

Attached to #785.