### PR TITLE
Add support for collections in export

### DIFF
--- a/app/lib/tufts/xml_metadata_builder.rb
+++ b/app/lib/tufts/xml_metadata_builder.rb
@@ -25,12 +25,16 @@ module Tufts
                  'xmlns' => 'http://www.openarchives.org/OAI/2.0/') do
           xml.ListRecords do
             @objects.each do |object|
-              tm = Tufts::TechnicalMetadata.new(object)
               xml.record do
                 xml.metadata do
                   xml.mira_import(@mapping.namespaces) do
-                    xml.parent << tm.to_s
+                    xml.parent << Tufts::TechnicalMetadata.new(object).to_s
                     xml['tufts'].visibility { xml.text object.visibility }
+
+                    object.member_of_collection_ids.each do |collection_id|
+                      xml['tufts'].memberOf(collection_id)
+                    end
+
                     @mapping.map_sorted do |field|
                       if field.property == :id
                         xml[field.namespace.to_s]

--- a/spec/support/shared_examples/metadata_builder.rb
+++ b/spec/support/shared_examples/metadata_builder.rb
@@ -45,6 +45,18 @@ shared_examples 'a MetadataBuilder' do
         .to include('datatype=')
     end
 
+    context 'with collections' do
+      let(:collections) { create_list(:collection, 3) }
+
+      before { object.member_of_collections = collections }
+
+      it 'adds collections' do
+        expect { builder.add(object) }
+          .to change { builder.build }
+          .to include(*collections.map(&:id))
+      end
+    end
+
     context 'with uris' do
       before do
         object.replaces = objects


### PR DESCRIPTION
When an item is in a collection, the collection ids need to be exported in the XML format for round tripping. `tufts:memberOf` nodes are now added for each collection id that the item belongs to at export time.

Attached to #765.