### PR TITLE
Fix issue where uploaded files are not faded in

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,5 +30,6 @@
 //= require almond
 //= require tufts/select_work_type
 //= require tufts/qr_status
+//= require tufts/ensure_upload_fade_in
 //= require tufts
 //= require app

--- a/app/assets/javascripts/tufts/ensure_upload_fade_in.js
+++ b/app/assets/javascripts/tufts/ensure_upload_fade_in.js
@@ -1,0 +1,3 @@
+$('#fileupload').bind('fileuploadstop', function (e, data) {
+  $('.template-download').addClass('in')
+})


### PR DESCRIPTION
If the files in a batch are not faded in they are not submitted
in the form. This uses the file uploaders stop event which is
triggered when files are done uploading and adds the `in` class
to all of the files that have been uploaded. This will ensure that
they are submitted in the form.

Related to #785