### PR TITLE
Validate metadata import file

### DIFF
--- a/app/controllers/hyrax/metadata_imports_controller.rb
+++ b/app/controllers/hyrax/metadata_imports_controller.rb
@@ -13,7 +13,7 @@ class Hyrax::MetadataImportsController < ApplicationController
       redirect_to main_app.batches_path(import.batch)
     else
       messages = import.errors.messages[:base].join("\n")
-      flash.alert = " Errors were found in #{@import.metadata_file.filename}:" \
+      flash.alert = " Errors were found in #{import.metadata_file.filename}:" \
                     "\n#{messages}"
       redirect_to main_app.new_metadata_import_path
     end

--- a/spec/features/metadata_import_spec.rb
+++ b/spec/features/metadata_import_spec.rb
@@ -2,28 +2,73 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.feature 'Import Metadata', :clean, js: true, batch: true do
-  let(:file)     { file_fixture('mira_export.xml') }
   let!(:objects) { FactoryGirl.create_list(:pdf, 2) }
   let(:object)   { objects.first }
   let(:other)    { objects[1] }
+  let(:user) { FactoryGirl.create(:admin) }
 
   before { ActiveJob::Base.queue_adapter = :test }
 
   context 'as admin' do
-    let(:user) { FactoryGirl.create(:admin) }
-
     before { login_as user }
 
-    scenario 'import metadata from file' do
-      visit '/metadata_imports/new'
+    context 'happy path' do
+      let(:file) { file_fixture('mira_export.xml') }
+      scenario 'import metadata from file' do
+        visit '/metadata_imports/new'
+        attach_file 'metadata_file', file
+        expect { click_button 'Next' }
+          .to enqueue_job(MetadataImportJob)
+          .exactly(5).times
+        expect(page).to have_content 'Batch'
+      end
+    end
 
-      attach_file 'metadata_file', file
+    context 'when file is malformed' do
+      let(:file) { file_fixture('malformed_files/metadata_update/metadata_stray_element.xml') }
+      scenario 'inform the user of malformed xml errors' do
+        visit '/metadata_imports/new'
+        attach_file 'metadata_file', file
+        click_button 'Next'
+        expect(page).to have_content 'Error'
+        expect(page).to have_content 'Malformed XML'
+      end
+    end
 
-      expect { click_button 'Next' }
-        .to enqueue_job(MetadataImportJob)
-        .exactly(5).times
+    context 'when file is missing required fields' do
+      let(:file) { file_fixture('malformed_files/metadata_update/metadata_missing_required_fields.xml') }
+      scenario 'inform the user of missing fields' do
+        visit '/metadata_imports/new'
+        attach_file 'metadata_file', file
+        click_button 'Next'
+        expect(page).to have_content 'Error'
+        expect(page).to have_content 'Missing required field: mst3k is missing dc:title'
+        expect(page).to have_content 'Missing required field: mst3k is missing tufts:displays_in'
+        expect(page).to have_content 'Missing required field: mst3k is missing model:hasModel'
+        expect(page).not_to have_content 'A file was missing'
+      end
+    end
 
-      expect(page).to have_content 'Batch'
+    context 'when file specifies nonexistent collection ids' do
+      let(:file) { file_fixture('malformed_files/metadata_update/metadata_nonexistent_collection.xml') }
+      scenario 'inform the user that the specified collection does not exist' do
+        visit '/metadata_imports/new'
+        attach_file 'metadata_file', file
+        click_button 'Next'
+        expect(page).to have_content 'Error'
+        expect(page).to have_content 'Cannot find collection with id fake for mst3k'
+      end
+    end
+
+    context 'when file has more than one id for a record' do
+      let(:file) { file_fixture('malformed_files/metadata_update/metadata_multiple_ids.xml') }
+      scenario 'inform the user that only one id per record is permitted' do
+        visit '/metadata_imports/new'
+        attach_file 'metadata_file', file
+        click_button 'Next'
+        expect(page).to have_content 'Error'
+        expect(page).to have_content 'Only one id field can be specified per metadata import record'
+      end
     end
   end
 end

--- a/spec/fixtures/files/malformed_files/metadata_update/metadata_missing_required_fields.xml
+++ b/spec/fixtures/files/malformed_files/metadata_update/metadata_missing_required_fields.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH
+  xmlns="http://www.openarchives.org/OAI/2.0/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:model="info:fedora/fedora-system:def/model#"
+  xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#"
+  xmlns:iana="http://www.iana.org/assignments/relation/"
+  xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#"
+  xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#"
+  xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/"
+  xmlns:bibframe="http://bibframe.org/vocab/"
+  xmlns:dc11="http://purl.org/dc/elements/1.1/"
+  xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#"
+  xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+  xmlns:mads="http://www.loc.gov/mads/rdf/v1#"
+  xmlns:tufts="http://dl.tufts.edu/terms#"
+  xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:id>mst3k</tufts:id>
+         <tufts:visibility></tufts:visibility>
+         <model:hasModel></model:hasModel>
+         <dc:title></dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/fixtures/files/malformed_files/metadata_update/metadata_multiple_ids.xml
+++ b/spec/fixtures/files/malformed_files/metadata_update/metadata_multiple_ids.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH
+  xmlns="http://www.openarchives.org/OAI/2.0/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:model="info:fedora/fedora-system:def/model#"
+  xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#"
+  xmlns:iana="http://www.iana.org/assignments/relation/"
+  xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#"
+  xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#"
+  xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/"
+  xmlns:bibframe="http://bibframe.org/vocab/"
+  xmlns:dc11="http://purl.org/dc/elements/1.1/"
+  xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#"
+  xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+  xmlns:mads="http://www.loc.gov/mads/rdf/v1#"
+  xmlns:tufts="http://dl.tufts.edu/terms#"
+  xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import>
+         <tufts:id>mst3k</tufts:id>
+         <tufts:id>abc123</tufts:id>
+         <tufts:visibility>open</tufts:visibility>
+         <model:hasModel>Pdf</model:hasModel>
+         <tufts:displays_in>dl</tufts:displays_in>
+         <dc:title>An Illegal Item With Muliple Ids</dc:title>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/fixtures/files/malformed_files/metadata_update/metadata_nonexistent_collection.xml
+++ b/spec/fixtures/files/malformed_files/metadata_update/metadata_nonexistent_collection.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH
+  xmlns="http://www.openarchives.org/OAI/2.0/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:model="info:fedora/fedora-system:def/model#"
+  xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#"
+  xmlns:iana="http://www.iana.org/assignments/relation/"
+  xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#"
+  xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#"
+  xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/"
+  xmlns:bibframe="http://bibframe.org/vocab/"
+  xmlns:dc11="http://purl.org/dc/elements/1.1/"
+  xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#"
+  xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+  xmlns:mads="http://www.loc.gov/mads/rdf/v1#"
+  xmlns:tufts="http://dl.tufts.edu/terms#"
+  xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import>
+          <tufts:id>mst3k</tufts:id>
+          <tufts:visibility>open</tufts:visibility>
+          <model:hasModel>Pdf</model:hasModel>
+          <dc:title>The Project Gutenberg EBook of Sonnets from the Portuguese by Browning</dc:title>
+          <tufts:displays_in>dl</tufts:displays_in>
+          <tufts:memberOf>fake</tufts:memberOf>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/fixtures/files/malformed_files/metadata_update/metadata_stray_element.xml
+++ b/spec/fixtures/files/malformed_files/metadata_update/metadata_stray_element.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH
+  xmlns="http://www.openarchives.org/OAI/2.0/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:model="info:fedora/fedora-system:def/model#"
+  xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#"
+  xmlns:iana="http://www.iana.org/assignments/relation/"
+  xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#"
+  xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#"
+  xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/"
+  xmlns:bibframe="http://bibframe.org/vocab/"
+  xmlns:dc11="http://purl.org/dc/elements/1.1/"
+  xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#"
+  xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+  xmlns:mads="http://www.loc.gov/mads/rdf/v1#"
+  xmlns:tufts="http://dl.tufts.edu/terms#"
+  xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import>
+         <tufts:id>mst3k</tufts:id>
+         <tufts:visibility>open</tufts:visibility>
+         <model:hasModel>Pdf</model:hasModel>
+         <dc:title>The Project Gutenberg EBook of Sonnets from the Portuguese
+by Browning</dc:title><model:hasModel>
+         <dc11:description>
+           This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net</dc11:description>
+         <dc:abstract>
+           I thought once how Theocritus had sung
+Of the sweet years, the dear and wished-for years,
+Who each one in a gracious hand appears
+To bear a gift for mortals, old or young:</dc:abstract>
+         <dc11:creator>Browning, Elizabeth Barrett</dc11:creator>
+         <dc:publisher>Caradoc Press</dc:publisher>
+         <dc:created>09/14/2002</dc:created>
+         <dc:available>02/26/2017</dc:available>
+         <dc:type>http://purl.org/dc/dcmitype/Text</dc:type>
+         <dc:format>application/pdf</dc:format>
+         <mads:PersonalName>Browning, Elizabeth</mads:PersonalName>
+         <mads:CorporateName>PROJECT GUTENBERG</mads:CorporateName>
+         <dc:subject>Poetry</dc:subject>
+         <dc:subject>Portuguese</dc:subject>
+         <dc:subject>Sonnets</dc:subject>
+         <dc:subject>Project Gutenberg</dc:subject>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/models/metadata_import_spec.rb
+++ b/spec/models/metadata_import_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe MetadataImport, type: :model do
         end
       end
     end
+    # rubocop:enable RSpec/InstanceVariable
 
     before { batchable.parser = parser }
   end


### PR DESCRIPTION
1. Use the same validation as for xml import
2. Check for well formed XML file
3. Check for required fields
4. Parameterize validate! method so we can skip
filename check
5. Reload parser each time instead of loading
it from cache, because otherwise the
CarrierWaveSanitizedFile gets destroyed before
being processed
6. Ensure each metadata import record has
one and only one id

Fixes #738 
Fixes #762 