### PR TITLE
Handle collections on MetadataImport

### DIFF
--- a/app/controllers/hyrax/metadata_imports_controller.rb
+++ b/app/controllers/hyrax/metadata_imports_controller.rb
@@ -10,7 +10,7 @@ class Hyrax::MetadataImportsController < ApplicationController
                                          creator:   current_user,
                                          ids:       import.ids.to_a))
       import.batch.enqueue!
-      redirect_to main_app.batches_path(import.batch)
+      redirect_to main_app.batch_path(import.batch)
     else
       messages = import.errors.messages[:base].join("\n")
       flash.alert = " Errors were found in #{import.metadata_file.filename}:" \

--- a/app/lib/tufts/import_record.rb
+++ b/app/lib/tufts/import_record.rb
@@ -119,14 +119,17 @@ module Tufts
         attrs[field.first] = field.last
       end
 
-      return object_class.new(visibility: visibility, **attributes) unless id
+      attributes[:visibility] = visibility
+      attributes[:member_of_collections] = ActiveFedora::Base.find(collections)
+
+      return object_class.new(**attributes) unless id
 
       begin
         object = object_class.find(id)
         object.assign_attributes(attributes)
         object
       rescue ActiveFedora::ObjectNotFoundError
-        object_class.new(id: id, visibility: visibility, **attributes)
+        object_class.new(id: id, **attributes)
       end
     end
 

--- a/app/services/tufts/import_service.rb
+++ b/app/services/tufts/import_service.rb
@@ -75,7 +75,6 @@ module Tufts
       # @return [HashWithIndifferentAccess]
       def attributes
         { uploaded_files:           file_ids,
-          member_of_collection_ids: record.collections,
           thumbnail:                record.thumbnail,
           transcript:               record.transcript,
           representative:           record.representative }.with_indifferent_access

--- a/spec/fixtures/files/mira_export_with_collections.xml
+++ b/spec/fixtures/files/mira_export_with_collections.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import xmlns:model="info:fedora/fedora-system:def/model#" xmlns:fcrepo4="http://fedora.info/definitions/v4/repository#" xmlns:iana="http://www.iana.org/assignments/relation/" xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/" xmlns:dc="http://purl.org/dc/terms/" xmlns:fedoraresourcestatus="http://fedora.info/definitions/1/0/access/ObjState#" xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#" xmlns:opaquehydra="http://opaquenamespace.org/ns/hydra/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dc11="http://purl.org/dc/elements/1.1/" xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" xmlns:mads="http://www.loc.gov/mads/rdf/v1#" xmlns:tufts="http://dl.tufts.edu/terms#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+          <tufts:id>test_pdf_with_collections</tufts:id>
+          <model:hasModel>Pdf</model:hasModel>
+          <tufts:memberOf>collection_1</tufts:memberOf>
+          <tufts:memberOf>collection_2</tufts:memberOf>
+          <tufts:memberOf>collection_3</tufts:memberOf>
+          <dc:title>I Married a Electric Ninjas</dc:title>
+          <tufts:displays_in>dl</tufts:displays_in>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/spec/lib/tufts/import_record_spec.rb
+++ b/spec/lib/tufts/import_record_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Tufts::ImportRecord do
-  subject(:record) { described_class.new }
-  let(:id)         { 'IMPORT_RECORD_FAKE_ID' }
-  let(:title)      { "President Jean Mayer speaking\n          at commencement, 1987" }
+  subject(:record)   { described_class.new }
+  let(:id)           { 'IMPORT_RECORD_FAKE_ID' }
+  let(:title)        { "President Jean Mayer speaking\n          at commencement, 1987" }
+  let!(:collections) { record.collections.map { |id| create(:collection, id: id) } }
 
   shared_context 'with metadata' do
     subject(:record) { described_class.new(metadata: node) }
@@ -49,12 +50,17 @@ RSpec.describe Tufts::ImportRecord do
     context 'with metadata' do
       include_context 'with metadata'
 
+      let(:expected_attributes) do
+        { title:                 [title],
+          creator:               ['Unknown'],
+          personal_name:         ['Mayer, Jean'],
+          corporate_name:        ['Office of the President'],
+          visibility:            'open',
+          member_of_collections: collections }
+      end
+
       it 'assigns metadata' do
-        expect(record.build_object)
-          .to have_attributes(title:          [title],
-                              creator:        ['Unknown'],
-                              personal_name:  ['Mayer, Jean'],
-                              corporate_name: ['Office of the President'])
+        expect(record.build_object).to have_attributes(**expected_attributes)
       end
     end
   end

--- a/spec/search_builders/hyrax/admin_admin_set_member_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/admin_admin_set_member_search_builder_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Hyrax::AdminAdminSetMemberSearchBuilder do
   let(:context) do
-    # rubocop:disable Rspec/VerifiedDoubles
+    # rubocop:disable RSpec/VerifiedDoubles
     double(
       blacklight_config: CatalogController.blacklight_config,
       current_ability: ability
     )
-    # rubocop:enable Rspec/VerifiedDoubles
+    # rubocop:enable RSpec/VerifiedDoubles
   end
   let(:user_groups) { [] }
   let(:ability) do


### PR DESCRIPTION
When importing metadata, ensure that items belong exactly to the collections
specified in the import file.

Handling is added to `ImportRecord#build_object`. This is unit tested, and a
feature spec is added to check that an object changes its membership on import
when the job is run through the UI.

Closes #675.