### PR TITLE
Added the inverse association for batchable models.

### DIFF
--- a/app/models/batch_task.rb
+++ b/app/models/batch_task.rb
@@ -11,7 +11,7 @@ class BatchTask < ApplicationRecord
   #   @return [Batch]
   # @!attribute batch_type [rw]
   #   @return [String]
-  has_one :batch, as: :batchable
+  has_one :batch, as: :batchable, inverse_of: :batchable
 
   BATCH_TYPES = {
     publish: PublishJob,

--- a/app/models/metadata_export.rb
+++ b/app/models/metadata_export.rb
@@ -8,7 +8,7 @@ class MetadataExport < ApplicationRecord
   #   @return [String]
   # @!attribute batch [rw]
   #   @return [Batch]
-  has_one :batch, as: :batchable
+  has_one :batch, as: :batchable, inverse_of: :batchable
 
   TYPE_STRING = 'Export'.freeze
 

--- a/app/models/metadata_import.rb
+++ b/app/models/metadata_import.rb
@@ -15,7 +15,7 @@ class MetadataImport < ApplicationRecord
   ##
   # @!attribute batch [rw]
   #   @return [Batch]
-  has_one :batch, as: :batchable
+  has_one :batch, as: :batchable, inverse_of: :batchable
 
   TYPE_STRING = 'Metadata Import'.freeze
 

--- a/app/models/template_update.rb
+++ b/app/models/template_update.rb
@@ -16,7 +16,7 @@ class TemplateUpdate < ApplicationRecord
   #   @return [Array<String>]
   # @!attribute template_name [rw]
   #   @return [String]
-  has_one :batch, as: :batchable
+  has_one :batch, as: :batchable, inverse_of: :batchable
 
   serialize :ids, Array
 

--- a/spec/services/tufts/import_service_spec.rb
+++ b/spec/services/tufts/import_service_spec.rb
@@ -27,7 +27,6 @@ describe Tufts::ImportService, :workflow, :clean do
 
   describe '#import_object!' do
     it 'imports the object' do
-      optional 'sometimes fails on travis' if ENV['TRAVIS']
       expect(service.import_object!).to be_persisted
     end
 


### PR DESCRIPTION
This inverse association was needed in a previous commit for the
XmlImport model, so I'm just making the same change to the other models
that use that polymorphic relationship with the Batch model.

I suspect that this will fix the problem with intermittent failing specs
described in stories #752 and #337, but I can't confirm it since I can't
reproduce those failures locally.