### PR TITLE
Fix specs that fail intermittently

### DIFF
--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -1,19 +1,22 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe 'batch', :batch, type: :feature, js: true do
+RSpec.describe 'batch', :batch, :clean, type: :feature, js: true do
   let(:current_user) { create(:admin) }
-  let(:work_first) { create(:pdf) }
-  let(:work_second) { create(:pdf) }
+  let!(:work_first) { create(:pdf) }
+  let!(:work_second) { create(:pdf) }
 
   before do
     login_as current_user
     visit '/dashboard/works'
+
+    # Make sure the tests are set up correctly.
+    # Only our 2 works should be displayed in the table.
+    expect(page).to have_selector("#documents table tbody tr", count: 2)
   end
 
   describe 'publishing' do
     it 'sends the user to the batch status page like on the catalog' do
-      optional "Sometimes fails on travis" if ENV['TRAVIS']
       check 'check_all'
       expect(page).to have_selector('.tufts-buttons')
       click_on 'Publish'
@@ -23,7 +26,6 @@ RSpec.describe 'batch', :batch, type: :feature, js: true do
 
   describe 'unpublishing' do
     it 'sends the user to the batch status page like on the catalog' do
-      optional "Sometimes fails on travis" if ENV['TRAVIS']
       check 'check_all'
       expect(page).to have_selector('.tufts-buttons')
       click_on 'Unpublish'
@@ -33,7 +35,6 @@ RSpec.describe 'batch', :batch, type: :feature, js: true do
 
   describe 'exporting metadata' do
     it 'sends the user to the batch status page like on the catalog' do
-      optional "Sometimes fails on travis" if ENV['TRAVIS']
       check 'check_all'
       expect(page).to have_selector('.tufts-buttons')
       click_on 'Export Metadata'
@@ -43,7 +44,6 @@ RSpec.describe 'batch', :batch, type: :feature, js: true do
 
   describe 'applying template' do
     it 'sends the user to the batch status page like on the catalog' do
-      optional "Sometimes fails on travis" if ENV['TRAVIS']
       check 'check_all'
       expect(page).to have_selector('.tufts-buttons')
       click_on 'Apply Template'

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -3,10 +3,13 @@ require 'rails_helper'
 
 RSpec.describe 'batch', :batch, :clean, type: :feature, js: true do
   let(:current_user) { create(:admin) }
-  let!(:work_first) { create(:pdf) }
-  let!(:work_second) { create(:pdf) }
+  let(:work_first) { create(:pdf) }
+  let(:work_second) { create(:pdf) }
 
   before do
+    work_first
+    work_second
+
     login_as current_user
     visit '/dashboard/works'
 


### PR DESCRIPTION
These specs were marked for intermittent failure on Travis.  I suspect
the problem was the test setup, not a problem with the code.

If you load the `dashboard/works` page with no works in your repo, you
can still click the `check_all` button, but the batch buttons won't
appear on the page.  A situation like that would definitely cause these
specs to fail.

I changed the test setup to clean up old records, then create the 2
expected records.  I added a test to make sure we see exactly those 2
records in the table before we run any of the specs.