### PR TITLE
Fixed a pending spec

### DIFF
--- a/spec/controllers/deposit_types_controller_spec.rb
+++ b/spec/controllers/deposit_types_controller_spec.rb
@@ -184,13 +184,12 @@ describe DepositTypesController do
 
     describe 'update with bad inputs' do
       it 'renders the form' do
-        pending 'not sure why this is failing'
+        expect(dt.display_name).to eq('DT')
+
         # Make it fail to validate:
         allow_any_instance_of(DepositType)
           .to receive(:valid?)
           .and_return(false)
-
-        expect(dt.display_name).to eq('DT')
 
         put :update, params: {
           id:           dt.id,


### PR DESCRIPTION
It was failing with a validation error because of the timing of the test
setup.  The spec was set up with a stub to simulate a validation error,
but because of the lazy instantiation of the let(:dt), that validation
stub interfered with FactoryGirl's initial creation of the record.

I moved the test for the old name ahead of the validation stub so that
FactoryGirl can create the record before the stub gets set.