### PR TITLE
Store handle as fully resolvable URL

### DIFF
--- a/app/lib/tufts/handle_dispatcher.rb
+++ b/app/lib/tufts/handle_dispatcher.rb
@@ -75,7 +75,7 @@ module Tufts
     # @return [AciveFedora::Base] the object
     def assign_for(object:, attribute: :identifier)
       record = registrar.register!(object: object)
-      object.public_send("#{attribute}=".to_sym, [record.handle])
+      object.public_send("#{attribute}=".to_sym, handle_values(record: record))
       object
     end
 
@@ -87,5 +87,15 @@ module Tufts
       assign_for(object: object, attribute: attribute).save!
       object
     end
+
+    private
+
+      ##
+      # @private
+      # @param [#handle] record
+      # @return [Array<String>]
+      def handle_values(record:)
+        ["http://hdl.handle.net/#{record.handle}"]
+      end
   end
 end

--- a/spec/lib/tufts/handle_dispatcher_spec.rb
+++ b/spec/lib/tufts/handle_dispatcher_spec.rb
@@ -4,6 +4,7 @@ describe Tufts::HandleDispatcher do
   subject(:dispatcher) { described_class.new(registrar: fake_registrar.new) }
   let(:object)         { build(:pdf) }
   let(:handle)         { 'hdl/tufts_1' }
+  let(:handle_url)     { "http://hdl.handle.net/#{handle}" }
 
   let(:fake_registrar) do
     Class.new do
@@ -24,12 +25,12 @@ describe Tufts::HandleDispatcher do
 
     it 'assigns to the identifier attribute by default' do
       dispatcher.public_send(method, object: object)
-      expect(object.identifier).to contain_exactly(handle)
+      expect(object.identifier).to contain_exactly(handle_url)
     end
 
     it 'assigns to specified attribute when requested' do
       dispatcher.public_send(method, object: object, attribute: :keyword)
-      expect(object.keyword).to contain_exactly(handle)
+      expect(object.keyword).to contain_exactly(handle_url)
     end
   end
 


### PR DESCRIPTION
We want to store and display a fully qualified HTTP URL for generated
handles. To do this, we add a private `HandleDispatcher#handle_values` to
generate the fully qualified name. The handle.net domain is hard coded.

Attached to #763.