### PR TITLE
Add Purge functionality and remove Review buttons

### DIFF
--- a/app/jobs/purge_job.rb
+++ b/app/jobs/purge_job.rb
@@ -1,0 +1,9 @@
+##
+# A job to purge works in a batch
+class PurgeJob < BatchableJob
+  def perform(id)
+    work = ActiveFedora::Base.find(id)
+    work.delete_draft
+    work.destroy
+  end
+end

--- a/app/models/batch_task.rb
+++ b/app/models/batch_task.rb
@@ -16,7 +16,8 @@ class BatchTask < ApplicationRecord
   BATCH_TYPES = {
     publish: PublishJob,
     unpublish: UnpublishJob,
-    revert: RevertJob
+    revert: RevertJob,
+    purge: PurgeJob
   }.freeze
 
   validates :batch_type,

--- a/app/views/hyrax/batches/_batch_items.html.erb
+++ b/app/views/hyrax/batches/_batch_items.html.erb
@@ -4,7 +4,6 @@
         <th>Item ID</th>
         <th>Title</th>
         <th>Status</th>
-        <th>Review Status</th>
       </tr>
 
       <% batch.items.each do |item| %>
@@ -18,9 +17,6 @@
           </td>
           <td class="record_title"><%= item.title %></td>
           <td class="record_status"><%= item.status.capitalize %></td>
-          <td class="record_reviewed_status">
-            <%= check_box_tag :reviewed, :reviewed, item.reviewed?, type: :checkbox, disabled: true  %>
-          </td> 
         </tr>
       <% end %>
     </table>

--- a/app/views/hyrax/batches/_controls.html.erb
+++ b/app/views/hyrax/batches/_controls.html.erb
@@ -1,8 +1,5 @@
 <ul class="batch-controls">
   <li>
-    <%= button_to "Review Batches", main_app.batches_path, method: :post, params: { batch: { batchable_attributes: { batch_type: "Publish" } } }, class: "btn btn-primary", disabled: true %>
-  </li>
-  <li>
     <%= button_to "Publish Batches", main_app.batches_path, method: :post, params: { batch: { ids: @batch.object.ids, batchable_attributes: { batch_type: "Publish" } } }, class: "btn btn-primary" %>
   </li>
   <li>
@@ -11,7 +8,7 @@
   </li>
   </li>
   <li>
-    <%= button_to "Purge Batch", main_app.batches_path, method: :post, params: { batch: { batchable_attributes: { batch_type: "Publish" } } }, class: "btn btn-primary", disabled: true %>
+    <%= button_to "Purge Batches", main_app.batches_path, method: :post, params: { batch: { ids: @batch.object.ids, batchable_attributes: { batch_type: "Purge" } } }, class: "btn btn-primary" %>
   </li>
   <li>
     <%= button_to "Revert Drafts", main_app.batches_path, method: :post, params: { batch: { ids: @batch.object.ids, batchable_attributes: { batch_type: "Revert" } } }, class: "btn btn-primary" %>

--- a/spec/jobs/purge_job_spec.rb
+++ b/spec/jobs/purge_job_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe PurgeJob, :workflow, type: :job do
+  subject(:job) { described_class }
+  let(:pdf)     { FactoryGirl.create(:pdf) }
+
+  before { ActiveJob::Base.queue_adapter = :test }
+
+  describe '#perform_later' do
+    it 'enqueues the job' do
+      expect { job.perform_later(pdf.id) }
+        .to enqueue_job(described_class)
+        .with(pdf.id)
+        .on_queue('batch')
+    end
+  end
+
+  context "purging a work" do
+    let(:work) { FactoryGirl.actor_create(:pdf, user: depositing_user) }
+    let(:depositing_user) { FactoryGirl.create(:user) }
+
+    before do
+      Pdf.destroy_all
+    end
+    it 'removes the work that was created' do
+      work.title = ['test']
+      work.save
+      expect(Pdf.count).to eq(1)
+      PurgeJob.perform_now(work.id)
+      expect(Pdf.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a Purge job that removes works and enables
the button for it in a batch view.

This also removes the Review Status check-boxes and button from
the batch view as that functionality isn't part of the
current Tufts workflow.