### PR TITLE
Ordered creators field.  Story #122

### DIFF
--- a/app/lib/tufts/vocab/tufts.rb
+++ b/app/lib/tufts/vocab/tufts.rb
@@ -27,6 +27,7 @@ module Tufts
       term :qr_note
       term :creator_department
       term :admin_set_member
+      term :ordered_creators
       term :ordered_descriptions
     end
   end

--- a/app/models/concerns/tufts/metadata/ordered_fields.rb
+++ b/app/models/concerns/tufts/metadata/ordered_fields.rb
@@ -2,9 +2,22 @@ module Tufts
   module Metadata
     module OrderedFields
       extend ActiveSupport::Concern
+
       included do
-        # A property to preserve the order of descriptions.  Don't set the value of this property directly.  It will be kept in sync by the setter method for the 'description' property.
+        # These properties are used to store the order for their corresponding (unordered) properties.
+        # Don't set the value of these properties directly.  The values will be kept in sync by the setter method for the corresponding property.
+        # For example, if you want to set the value for the 'description' property, you just use the setter as you normally would:
+        # work.description = ['Desc 1', 'Desc 2']
+        # and the corresponding 'ordered_descriptions'
+        # property will automatically get set.
+
+        # Stores the order for 'description' property
         property :ordered_descriptions, predicate: ::Tufts::Vocab::Tufts.ordered_descriptions, multiple: false do |index|
+          index.as :symbol
+        end
+
+        # Stores the order for 'creator' property
+        property :ordered_creators, predicate: ::Tufts::Vocab::Tufts.ordered_creators, multiple: false do |index|
           index.as :symbol
         end
 
@@ -29,6 +42,23 @@ module Tufts
             super
           else
             JSON.parse(ordered_descriptions)
+          end
+        end
+
+        # @param [Array] Ordered array of values
+        # Overrides setter method to preserve order in a second property.
+        def creator=(values)
+          self.ordered_creators = values.to_json
+          super
+        end
+
+        # @return [Array<String>]
+        # Overrides getter method to return the creators in the correct order.
+        def creator
+          if ordered_creators.blank?
+            super
+          else
+            JSON.parse(ordered_creators)
           end
         end
       end

--- a/spec/features/create_pdf_spec.rb
+++ b/spec/features/create_pdf_spec.rb
@@ -37,7 +37,13 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       fill_in 'Contributor', with: 'Contributor'
       fill_in 'Corporate Name', with: 'Corporate Name'
       fill_in 'Created By', with: 'Created By'
-      fill_in 'Creator', with: 'Creator'
+
+      fill_in 'Creator', with: 'Creator 1'
+      click_on 'Add another Creator'
+      within '.pdf_creator li:last-child' do
+        fill_in 'Creator', with: 'Creator 2'
+      end
+
       fill_in 'Creator Department', with: 'Creator Department'
       fill_in 'Date Accepted', with: 'Date Accepted'
       fill_in 'Date Available', with: 'Date Available'
@@ -111,7 +117,8 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       expect(page).to have_content 'Contributor'
       expect(page).to have_content 'Corporate Name'
       expect(page).to have_content 'Created By'
-      expect(page).to have_content 'Creator'
+      # Creators should be in the correct order
+      expect(page).to have_content 'Creator 1 Creator 2'
       expect(page).to have_content 'Creator Department'
       expect(page).to have_content 'Date Accepted'
       expect(page).to have_content 'Date Available'

--- a/spec/features/edit_pdf_spec.rb
+++ b/spec/features/edit_pdf_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature 'Edit a PDF', js: true do
     let(:pdf) do
       FactoryGirl.create(
         :pdf,
+        creator: ['creator A', 'creator B'],
         description: ['desc A', 'desc B', 'desc C']
       )
     end
@@ -17,14 +18,20 @@ RSpec.feature 'Edit a PDF', js: true do
       visit edit_hyrax_pdf_path(pdf.id)
 
       # Check existing values when the form loads:
-
       # The description fields should be in order
       # (plus one blank field)
       expect(all('textarea.pdf_description').map(&:value)).to eq ['desc A', 'desc B', 'desc C', '']
+      # The creators should be in order
+      expect(all('input.pdf_creator').map(&:value)).to eq ['creator A', 'creator B', '']
 
       # Edit the description fields:
       all('.pdf_description li').each_with_index do |field, i|
         field.fill_in name: 'pdf[description][]', with: "desc #{i}"
+      end
+
+      # Edit the creator fields:
+      all('.pdf_creator li').each_with_index do |field, i|
+        field.fill_in name: 'pdf[creator][]', with: "creator #{i}"
       end
 
       click_on 'Save'
@@ -32,6 +39,8 @@ RSpec.feature 'Edit a PDF', js: true do
       # Now we're on the show page for the PDF.
       # The descriptions should be in correct order.
       expect(page).to have_content 'desc 0 desc 1 desc 2 desc 3'
+      # Creators should be in correct order
+      expect(page).to have_content 'creator 0 creator 1 creator 2'
     end
   end
 end

--- a/spec/support/shared_examples/metadata_ordered_fields.rb
+++ b/spec/support/shared_examples/metadata_ordered_fields.rb
@@ -51,4 +51,38 @@ shared_examples 'a record with ordered fields' do
       end
     end
   end
+
+  describe 'ordered creators' do
+    let(:lancelot) { 'Sir Lancelot du Lac' }
+    let(:gawain) { 'Sir Gawain' }
+    let(:arthur) { 'King Arthur Pendragon' }
+    let(:expected_order) { [arthur, gawain, lancelot] }
+
+    context 'an unsaved record' do
+      before do
+        expect(work.persisted?).to eq false
+        work.creator = expected_order
+      end
+
+      it 'preserves the creator order' do
+        expect(work.creator).to eq expected_order
+      end
+
+      it 'indexes the ordered creators in solr' do
+        expect(work.to_solr['creator_tesim']).to eq expected_order
+      end
+    end
+
+    context 'saving a record' do
+      before do
+        work.creator = expected_order
+        work.save!
+        work.reload
+      end
+
+      it 'preserves the description order' do
+        expect(work.creator).to eq expected_order
+      end
+    end
+  end
 end


### PR DESCRIPTION
I added a new property called `ordered_creators` that stores the
creators in order, and overrode the getter and setter methods for the
`creator` property so they will use the new propery to preserve the
order.