### PR TITLE
Automatically add self deposit items to associated collections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,7 @@ RSpec/MultipleExpectations:
   - 'spec/controllers/hyrax/audios_controller_spec.rb'
   - 'spec/features/**/*'
   - 'spec/jobs/**/*'
+  - 'spec/lib/tufts/contribute_collections_spec.rb'
   - 'spec/lib/tufts/workflow_setup_spec.rb'
   - 'spec/services/**/*'
 Style/FileName:

--- a/README.md
+++ b/README.md
@@ -90,3 +90,8 @@ Notifications are defined in `app/services/hyrax/workflow`. There are three kind
 2. **MiraNotification** -- These are single-item notifications which are not triggered by a SipityWorkflow event. These are primarily used for notification of single-item deposits, either via the `/contribute` form or the `Create New Work` form on the admin dashboard.
 
 3. **MiraBatchNotification** -- These are batch notifications. They inherit some behavior from the `MiraNotification` class, but operate at a batch level instead of at an individual level. Examples include batch xml import, batch metadata update, batch publish, batch unpublish, and batch template application.
+
+### Contribute Collections
+The `/contribute` forms deposit works into specific collections. In order to ensure that the expected collections exist, they are 
+created at application deploy time and (if necessary) at deposit time via the `Tufts::ContributeCollections` class. To change the names or
+identifiers of these Collection objects, edit the `app/lib/tufts/contribute_collections.rb` file. To create the collections explicitly, run `rake tufts:create_contribute_collections`.

--- a/app/lib/tufts/contribute_collections.rb
+++ b/app/lib/tufts/contribute_collections.rb
@@ -1,0 +1,120 @@
+module Tufts
+  # Create and maintain the Collection objects required by the Contribute controller
+  class ContributeCollections
+    attr_reader :seed_data
+
+    def initialize
+      @seed_data = make_seed_data_hash
+    end
+
+    def make_seed_data_hash
+      seed_hash = {}
+      SEED_DATA.each do |c|
+        id = convert_id(c[:identifier])
+        seed_hash[id] = c
+      end
+      seed_hash
+    end
+
+    def self.create
+      Tufts::ContributeCollections.new.create
+    end
+
+    # Convert a legacy Tufts identifier into a predictable and valid Fedora identifier
+    # @param [String] id
+    # @return [String]
+    def convert_id(id)
+      newid = id.downcase
+      newid.slice!('tufts:')
+      newid.tr!('.', '_')
+    end
+
+    def create
+      @seed_data.keys.each do |collection_id|
+        find_or_create_collection(collection_id)
+      end
+    end
+
+    # Given a collection id, find or create the collection.
+    # If the collection has been deleted, eradicate it so the id can be
+    # re-used, and re-create the collection object.
+    # @param [String] collection_id
+    # @return [Collection]
+    def find_or_create_collection(collection_id)
+      Collection.find(collection_id)
+    rescue ActiveFedora::ObjectNotFoundError
+      create_collection(collection_id)
+    rescue Ldp::Gone
+      Collection.eradicate(collection_id)
+      create_collection(collection_id)
+    end
+
+    # @param [String] collection_id
+    # @return [Collection]
+    def create_collection(collection_id)
+      collection = Collection.new(id: collection_id)
+      collection_hash = @seed_data[collection_id]
+      collection.title = Array(collection_hash[:title])
+      collection.identifier = Array(collection_hash[:identifier])
+      collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      collection.save
+      collection
+    end
+
+    # Convenience method for use by the contribute controller
+    # @param [Class] work_type
+    # @return [Collection]
+    # @example
+    #  Tufts::ContributeCollections.collection_for_work_type(FacultyScholarship)
+    def self.collection_for_work_type(work_type)
+      Tufts::ContributeCollections.new.collection_for_work_type(work_type)
+    end
+
+    # For a given work type, determine which Collection contributions should go into.
+    # If that collection object doesn't exist for some reason, create it.
+    # @param [Class] work_type
+    # @return [Collection]
+    def collection_for_work_type(work_type)
+      collection_id = @seed_data.select { |_key, hash| hash[:work_types].include? work_type }.keys.first
+      Collection.find(collection_id)
+    rescue ActiveFedora::ObjectNotFoundError
+      create_collection(collection_id)
+    rescue Ldp::Gone
+      Collection.eradicate(collection_id)
+      create_collection(collection_id)
+    end
+
+    SEED_DATA = [
+      {
+        title: "Tufts Published Scholarship, 1987-2014",
+        identifier: "tufts:UA069.001.DO.PB",
+        work_types: [GenericDeposit, GenericTischDeposit, GisPoster, UndergradSummerScholar, FacultyScholarship]
+      },
+      {
+        title: "Fletcher School Records, 1923 -- 2016",
+        identifier: "tufts:UA069.001.DO.UA015",
+        work_types: [CapstoneProject]
+      },
+      {
+        title: "Cummings School of Veterinary Medicine records, 1969-2012",
+        identifier: "tufts:UA069.001.DO.UA041",
+        work_types: [CummingsThesis]
+      },
+      {
+        title: "Undergraduate honors theses, 1929-2015",
+        identifier: "tufts:UA069.001.DO.UA005",
+        work_types: [HonorsThesis]
+      },
+      {
+        title: "Public Health and Professional Degree Programs Records, 1990 -- 2011",
+        identifier: "tufts:UA069.001.DO.UA187",
+        work_types: [PublicHealth]
+      },
+      {
+        title: "Department of Education records, 2007-02-01-2014",
+        identifier: "tufts:UA069.001.DO.UA071",
+        work_types: [QualifyingPaper]
+      }
+    ].freeze
+  end
+end

--- a/app/models/forms/contribution.rb
+++ b/app/models/forms/contribution.rb
@@ -40,6 +40,7 @@ class Contribution
       internal_note: note
     )
     copy_attributes
+    add_to_collection
     user = User.find_by(email: @depositor)
     current_ability = ::Ability.new(user)
     uploaded_file = Hyrax::UploadedFile.create(user: user, file: @attachment)
@@ -47,6 +48,10 @@ class Contribution
     env = Hyrax::Actors::Environment.new(@tufts_pdf, current_ability, attributes)
     Hyrax::CurationConcern.actor.create(env)
     @tufts_pdf
+  end
+
+  def add_to_collection
+    @tufts_pdf.member_of_collections = Array(Tufts::ContributeCollections.collection_for_work_type(self.class))
   end
 
   def initialize(data = {})

--- a/app/models/forms/generic_tisch_deposit.rb
+++ b/app/models/forms/generic_tisch_deposit.rb
@@ -19,6 +19,7 @@ class GenericTischDeposit < Contribution
       internal_note: note
     )
     copy_attributes
+    add_to_collection
     user = User.find_by(email: @depositor)
     current_ability = ::Ability.new(user)
     uploaded_file = Hyrax::UploadedFile.create(user: user, file: @attachment)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -52,6 +52,17 @@ task :load_workflows do
 end
 after 'deploy:restart', 'load_workflows'
 
+# Ensure contribution collections are created whenever we deploy. Otherwise the
+# /contribute deposits won't have the right collections to go into
+task :create_contribute_collections do
+  on roles(:app) do
+    within release_path do
+      execute :bundle, 'exec rake tufts:create_contribute_collections RAILS_ENV=production'
+    end
+  end
+end
+after 'deploy:restart', 'create_contribute_collections'
+
 # Passenger is not consistently restarting, but the problem seems to
 # be fixed by making it restart twice.
 task :reenable_deploy_restart do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,7 @@ puts
 # and load the mira_publication_workflow
 require 'tufts/workflow_setup'
 Tufts::WorkflowSetup.setup
+Tufts::ContributeCollections.create
 
 # DepositType.create!(display_name: 'Initial Seed', deposit_view: 'generic_deposit', license_name: 'N/A')
 importer = DepositTypeImporter.new('./config/deposit_type_seed.csv')

--- a/lib/tasks/create_contribute_collections.rake
+++ b/lib/tasks/create_contribute_collections.rake
@@ -1,0 +1,8 @@
+require 'rake'
+
+namespace :tufts do
+  desc "Create contribute collections"
+  task create_contribute_collections: :environment do
+    Tufts::ContributeCollections.create
+  end
+end

--- a/spec/features/contribute/faculty_scholarship_contribute_spec.rb
+++ b/spec/features/contribute/faculty_scholarship_contribute_spec.rb
@@ -55,6 +55,8 @@ RSpec.feature 'Create a Faculty Scholarship self contribution', :clean, js: true
       expect(page).to have_content(created_pdf.title.first)
       expect(page).to have_content(abstract)
       expect(page).to have_content(bibliographic_citation)
+      expect(page).to have_content("In Collection")
+      expect(page).to have_content("Tufts Published Scholarship, 1987-2014")
       visit("/concern/pdfs/#{created_pdf.id}/edit")
       expect(find_by_id("pdf_description").value).to eq abstract
       expect(find_by_id("pdf_bibliographic_citation").value).to eq bibliographic_citation

--- a/spec/features/contribute/fletcher_school_capstone_contribute_spec.rb
+++ b/spec/features/contribute/fletcher_school_capstone_contribute_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       expect(created_pdf.admin_set.title.first).to eq "Default Admin Set"
       expect(created_pdf.active_workflow.name).to eq "mira_publication_workflow"
       expect(created_pdf.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      expect(created_pdf.member_of_collections.first.identifier.first).to eq("tufts:UA069.001.DO.UA015")
     end
   end
 end

--- a/spec/features/contribute/gis_expo_contribute_spec.rb
+++ b/spec/features/contribute/gis_expo_contribute_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature 'Contribute GIS Expo Student Winners', :clean, js: true do
       expect(created_pdf.active_workflow.name).to eq "mira_publication_workflow"
       expect(created_pdf.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
       expect(created_pdf.description).to include("Masters", "CEE 194A: Introduction to Remote Sensing")
+      expect(created_pdf.member_of_collections.first.identifier.first).to eq("tufts:UA069.001.DO.PB")
       logout
       login_as(admin)
       visit("/concern/pdfs/#{created_pdf.id}")

--- a/spec/features/contribute/undergrad_scholarship_contribute_spec.rb
+++ b/spec/features/contribute/undergrad_scholarship_contribute_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature 'Create a PDF', :clean, js: true do
       expect(created_pdf.active_workflow.name).to eq "mira_publication_workflow"
       expect(created_pdf.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
       expect(created_pdf.description.first[0...10]).to eq short_description[0...10]
+      expect(created_pdf.member_of_collections.first.identifier.first).to eq("tufts:UA069.001.DO.PB")
       # Check notifications for depositing user
       login_as depositing_user
       visit("/notifications?locale=en")

--- a/spec/lib/tufts/contribute_collections_spec.rb
+++ b/spec/lib/tufts/contribute_collections_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Tufts::ContributeCollections, :clean do
+  let(:cc) { described_class.new }
+
+  it "has a hash of all the collections to be made, with their ids and titles" do
+    expect(cc.seed_data).to be_instance_of(Hash)
+  end
+  it "converts a legacy identifier into a predictable valid fedora id" do
+    expect(cc.convert_id('tufts:UA069.001.DO.PB')).to eq("ua069_001_do_pb")
+  end
+
+  context "creating all the collections" do
+    before do
+      described_class.create
+    end
+    it "creates a collection object for each item in the seed array" do
+      expect(Collection.count).to eq(6)
+    end
+    it "populates title and legacy identifier" do
+      c = Collection.find("ua069_001_do_pb")
+      expect(c.title.first).to eq("Tufts Published Scholarship, 1987-2014")
+      expect(c.identifier.first).to eq("tufts:UA069.001.DO.PB")
+    end
+  end
+
+  context "putting contributed works into collections" do
+    before do
+      described_class.create
+    end
+    it "finds the right collection for a given work type" do
+      faculty_scholarship_collection = cc.collection_for_work_type(FacultyScholarship)
+      expect(faculty_scholarship_collection).to be_instance_of(Collection)
+      expect(faculty_scholarship_collection.id).to eq('ua069_001_do_pb')
+    end
+    it "recovers if one of the expected collections has been deleted" do
+      Collection.find('ua069_001_do_pb').delete
+      faculty_scholarship_collection = cc.collection_for_work_type(FacultyScholarship)
+      expect(faculty_scholarship_collection).to be_instance_of(Collection)
+      expect(faculty_scholarship_collection.id).to eq('ua069_001_do_pb')
+    end
+  end
+end


### PR DESCRIPTION
* Create the collections that are required for the contribute deposits
* If a collection gets deleted, eradicate it so the id can be used again and re-create the collection
* Make a rake task so this can be run easily from the command line
* Add it to capistrano to ensure they exist whenever we deploy
* Query for a work type and get the collection it should go into
* Queries at deposit time recover gracefully and re-create the missing Collection object if necessary
* Add contributions to the appropriate collection according to their class

Closes #802 