### PR TITLE
Update the date_modified field with the current timestamp upon metada…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,7 @@ Metrics/LineLength:
     - 'spec/controllers/tufts/draft_controller_spec.rb'
 Metrics/MethodLength:
    Exclude:
+    - 'app/lib/tufts/import_record.rb'
     - 'app/models/forms/contribution.rb'
     - 'app/models/forms/generic_tisch_deposit.rb'
     - 'lib/tasks/import_test_file.rake'

--- a/app/lib/tufts/import_record.rb
+++ b/app/lib/tufts/import_record.rb
@@ -136,12 +136,13 @@ module Tufts
     def fields
       return [].to_enum        unless metadata
       return enum_for(:fields) unless block_given?
-
       mapping.map do |field|
         case field.property
         when :title
           yield [:title, Array.wrap(title)]
-        when :id, :has_model, :date_uploaded, :modified_date, :head, :tail
+        when :date_modified
+          yield [:date_modified, Time.current]
+        when :id, :has_model, :date_uploaded, :create_date, :modified_date, :head, :tail
           next
         else
           values = values_for(field: field)

--- a/spec/factories/pdf.rb
+++ b/spec/factories/pdf.rb
@@ -23,14 +23,13 @@ FactoryGirl.define do
 
   factory :populated_pdf, class: Pdf do
     Pdf.properties.each_value do |property|
-      next if [:create_date, :modified_date, :has_model, :head, :tail].include? property.term
-
+      next if [:create_date, :date_modified, :modified_date, :date_uploaded, :has_model, :head, :tail].include? property.term
       if property.term == :title
         send(property.term, [FFaker::Book.title])
       elsif property.try(:multiple?)
-        send(property.term, (1..4).map { FFaker::BaconIpsum.phrase })
+        send(property.term, (1..4).map { FFaker::HipsterIpsum.phrase })
       else
-        send(property.term, FFaker::BaconIpsum.phrase)
+        send(property.term, FFaker::HipsterIpsum.phrase)
       end
     end
   end

--- a/spec/fixtures/files/metadata_import_date_testing.xml
+++ b/spec/fixtures/files/metadata_import_date_testing.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/">
+  <ListRecords>
+    <record>
+      <metadata>
+        <mira_import xmlns:model="info:fedora/fedora-system:def/model#" xmlns:dc="http://purl.org/dc/terms/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dc11="http://purl.org/dc/elements/1.1/" xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" xmlns:mads="http://www.loc.gov/mads/rdf/v1#" xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/" xmlns:tufts="http://dl.tufts.edu/terms#" xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+          <technicalmetadata>
+            <file>
+              <fits_version>0.8.6</fits_version>
+              <format_label>Portable Document Format</format_label>
+              <mime_type>application/pdf</mime_type>
+              <file_size>7945</file_size>
+              <file_name>pdf_sample0.pdf</file_name>
+              <original_checksum>fa7d7e650b2cec68f302b31ba28235d8</original_checksum>
+              <date_created>2000:06:29 10:21:08+11:00</date_created>
+              <well_formed>false</well_formed>
+              <valid>false</valid>
+              <file_title>This is a test PDF file</file_title>
+              <page_count>1</page_count>
+              <exif_version>9.13</exif_version>
+            </file>
+          </technicalmetadata>
+          <tufts:visibility>open</tufts:visibility>
+          <dc:dateSubmitted datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-12-27T20:01:59+00:00</dc:dateSubmitted>
+          <dc:modified datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-12-27T20:01:59+00:00</dc:modified>
+          <dc:title>Post Import Title</dc:title>
+          <model:hasModel>Pdf</model:hasModel>
+          <tufts:displays_in>dl</tufts:displays_in>
+          <tufts:id>date_testing_id</tufts:id>
+        </mira_import>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>


### PR DESCRIPTION
…ta import

* Use the correct name for this field (date_modified, not modified_date)
* Ignoring this date entirely leads to it being set to nil
* Instead, set it to the current date and time
* Ensure the modified date appears on the work show page

Fixes #628 