### PR TITLE
Make sure fields get marked as dirty if they change. Story #122

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,9 +67,12 @@ RSpec/MultipleExpectations:
   - 'spec/lib/tufts/metadata_exporter_spec.rb'
   - 'spec/lib/tufts/workflow_setup_spec.rb'
   - 'spec/services/**/*'
+  - 'spec/support/shared_examples/metadata_ordered_fields.rb'
 RSpec/ScatteredSetup:
   Exclude:
     - 'spec/models/metadata_import_spec.rb'
+RSpec/MessageSpies:
+  Enabled: false
 Style/FileName:
   Exclude:
     - '**/Capfile'

--- a/app/models/concerns/tufts/metadata/ordered_fields.rb
+++ b/app/models/concerns/tufts/metadata/ordered_fields.rb
@@ -31,8 +31,8 @@ module Tufts
         # @param [Array] Ordered array of values
         # Overrides setter method to preserve order in a second property.
         def description=(values)
-          self.ordered_descriptions = values.to_json
           super
+          self.ordered_descriptions = values.to_json
         end
 
         # @return [Array<String>]
@@ -48,8 +48,8 @@ module Tufts
         # @param [Array] Ordered array of values
         # Overrides setter method to preserve order in a second property.
         def creator=(values)
-          self.ordered_creators = values.to_json
           super
+          self.ordered_creators = values.to_json
         end
 
         # @return [Array<String>]

--- a/spec/factories/pdf.rb
+++ b/spec/factories/pdf.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
 
   factory :populated_pdf, class: Pdf do
     Pdf.properties.each_value do |property|
-      next if [:create_date, :date_modified, :modified_date, :date_uploaded, :has_model, :head, :tail].include? property.term
+      next if [:create_date, :date_modified, :modified_date, :date_uploaded, :has_model, :head, :tail, :ordered_descriptions, :ordered_creators].include? property.term
       if property.term == :title
         send(property.term, [FFaker::Book.title])
       elsif property.try(:multiple?)

--- a/spec/lib/tufts/handle_registrar_spec.rb
+++ b/spec/lib/tufts/handle_registrar_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-# rubocop:disable RSpec/MessageSpies, Lint/HandleExceptions, RSpec/InstanceVariable
+# rubocop:disable Lint/HandleExceptions, RSpec/InstanceVariable
 describe Tufts::HandleRegistrar do
   subject(:service) do
     described_class.new(connection: stubbed_connection.new(record: record))

--- a/spec/support/shared_examples/metadata_ordered_fields.rb
+++ b/spec/support/shared_examples/metadata_ordered_fields.rb
@@ -50,6 +50,14 @@ shared_examples 'a record with ordered fields' do
         end
       end
     end
+
+    describe '#description=' do
+      it 'marks both "description" and "ordered_descriptions" fields as dirty so they will both be updated in fedora' do
+        expect(work).to receive(:attribute_will_change!).with(:description)
+        expect(work).to receive(:attribute_will_change!).with(:ordered_descriptions)
+        work.description = expected_order
+      end
+    end
   end
 
   describe 'ordered creators' do
@@ -82,6 +90,14 @@ shared_examples 'a record with ordered fields' do
 
       it 'preserves the description order' do
         expect(work.creator).to eq expected_order
+      end
+    end
+
+    describe '#creator=' do
+      it 'marks both "creator" and "ordered_creators" fields as dirty so they will both be updated in fedora' do
+        expect(work).to receive(:attribute_will_change!).with(:creator)
+        expect(work).to receive(:attribute_will_change!).with(:ordered_creators)
+        work.creator = expected_order
       end
     end
   end


### PR DESCRIPTION
I overrode the getter and setter methods for the ordered fields to keep
track of their order in secondary fields, but that caused a problem.
Even though those fields appeared to be correct in the UI, I noticed
that the `description` and `ordered_descriptions` fields were out of
sync in the fedora console.

The overrides to the getters and setters messed up the logic that
determines whether or not a field is marked dirty.

I wrote a spec to make sure that both the original field and its
secondary ordering field will be marked dirty if the field is updated,
and then moved the `super` call to the top of the setter method, which
solves the problem with the logic for dirtiness.