### PR TITLE
Disable unused Hyrax features

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1,0 +1,8 @@
+proxy_deposit:
+  enabled: false
+transfer_works:
+  enabled: false
+show_deposit_agreement:
+  enabled: false
+active_deposit_agreement_acceptance:
+  enabled: false


### PR DESCRIPTION
Closes #843

Add configuration file to disable features that do not map to
MIRA 3.0 functionality.  For the inital 4.0 release, these features
are out-of-scope, and, therefore largely untested which may result
in unexpected behaviors.

These festures should be individually enabled in future releases and
tested thoroughly to ensure they meet user requirements.