### PR TITLE
Inherit behaviors from models codebase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'whenever', require: false
 
 gem 'blacklight_advanced_search'
 
-gem 'tufts-curation', github: 'curationexperts/epigaea_models', tag: 'v0.3.0'
+gem 'tufts-curation', github: 'curationexperts/epigaea_models', tag: 'v0.4.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/curationexperts/epigaea_models.git
-  revision: 9b0286a706e5ff091fe10ee28801de8eb737ba89
-  tag: v0.3.0
+  revision: b636553c840199764a62dbc3215707364082196c
+  tag: v0.4.0
   specs:
     tufts-curation (0.1.0)
       active-fedora (>= 11.5, <= 12.99)
       activesupport
-      hyrax (>= 2.0)
+      hyrax (~> 2.0.0)
 
 GIT
   remote: https://github.com/thoughtbot/shoulda-matchers.git

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -1,5 +1,4 @@
 class Audio < Tufts::Curation::Audio
-  include ::Hyrax::WorkBehavior
   include ::Tufts::Draftable
 
   self.indexer = Tufts::Curation::Indexer

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,4 +1,3 @@
 class Collection < Tufts::Curation::Collection
-  include ::Hyrax::CollectionBehavior
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
 end

--- a/app/models/ead.rb
+++ b/app/models/ead.rb
@@ -1,5 +1,4 @@
 class Ead < Tufts::Curation::Ead
-  include ::Hyrax::WorkBehavior
   include ::Tufts::Draftable
 
   self.indexer = Tufts::Curation::Indexer

--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -1,5 +1,4 @@
 class GenericObject < Tufts::Curation::GenericObject
-  include ::Hyrax::WorkBehavior
   include ::Tufts::Draftable
 
   self.indexer = Tufts::Curation::Indexer

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,4 @@
 class Image < Tufts::Curation::Image
-  include ::Hyrax::WorkBehavior
   include ::Tufts::Draftable
 
   self.indexer = Tufts::Curation::Indexer

--- a/app/models/pdf.rb
+++ b/app/models/pdf.rb
@@ -1,5 +1,4 @@
 class Pdf < Tufts::Curation::Pdf
-  include ::Hyrax::WorkBehavior
   include ::Tufts::Draftable
 
   self.indexer = Tufts::Curation::Indexer

--- a/app/models/rcr.rb
+++ b/app/models/rcr.rb
@@ -1,5 +1,4 @@
 class Rcr < Tufts::Curation::Rcr
-  include ::Hyrax::WorkBehavior
   include ::Tufts::Draftable
 
   self.indexer = Tufts::Curation::Indexer

--- a/app/models/tei.rb
+++ b/app/models/tei.rb
@@ -1,5 +1,4 @@
 class Tei < Tufts::Curation::Tei
-  include ::Hyrax::WorkBehavior
   include ::Tufts::Draftable
 
   self.indexer = Tufts::Curation::Indexer

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,5 +1,4 @@
 class Video < Tufts::Curation::Video
-  include ::Hyrax::WorkBehavior
   include ::Tufts::Draftable
 
   self.indexer = Tufts::Curation::Indexer

--- a/app/models/voting_record.rb
+++ b/app/models/voting_record.rb
@@ -1,5 +1,4 @@
 class VotingRecord < Tufts::Curation::TuftsModel
-  include ::Hyrax::WorkBehavior
   include ::Tufts::Draftable
 
   self.indexer = Tufts::Curation::Indexer


### PR DESCRIPTION
The models codebase now attempts to auto-include behaviors. This avoids the need to include them manually.