### PR TITLE
Fix for adding a work to a collection

### DIFF
--- a/app/services/tufts/metadata_service.rb
+++ b/app/services/tufts/metadata_service.rb
@@ -1,8 +1,10 @@
 module Tufts
-  class MetadataService < HydraEditor::FieldMetadataService
+  class MetadataService < Hyrax::FormMetadataService
     def self.multiple?(model_class, field)
       if [:title].include?(field.to_sym)
         false
+      elsif [:rights_statement].include?(field.to_sym)
+        true
       else
         super
       end

--- a/spec/features/add_work_to_collection_spec.rb
+++ b/spec/features/add_work_to_collection_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Add a work to a collection', :clean, js: true do
+  context 'as logged in admin user' do
+    let(:admin) { FactoryGirl.create(:admin) }
+    let(:work) { FactoryGirl.actor_create(:image, user: admin, displays_in: ['dl']) }
+    let(:collection) { FactoryGirl.create(:collection) }
+
+    before { login_as admin }
+
+    scenario do
+      collection
+      expect(work.member_of_collections).to be_empty
+      visit("/concern/images/#{work.id}/edit#relationships")
+      expect(page).to have_content("This Work in Collections")
+      find('select#image_member_of_collection_ids').select(collection.title.first)
+      find('input#with_files_submit').click
+      expect(page).to have_content collection.title.first
+      work.reload
+      expect(work.member_of_collections.first.id).to eq(collection.id)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #833 

This test was failing because when HydraEditor runs the
'build_permitted_params' method, the method call
'multiple?(:member_of_collection_ids)' was returning false when it
should return true. This caused that field to be stripped from
the params that are passed to the actor stack, so they never
reach CollectionsMembershipActor.

The problem is fixed by correcting the inheritance of
Tufts::MetadataService so that it inherits from Hyrax, which
in turn inherits from HydraEditor. Crucially,
Hyrax::FormMetadataService, the step in the inheritance
chain that was previously being skipped,  is the place
where :member_of_collection_ids gets defined as multiple.