### PR TITLE
Deleted a non-functional pending spec

### DIFF
--- a/spec/controllers/hyrax/template_updates_controller_spec.rb
+++ b/spec/controllers/hyrax/template_updates_controller_spec.rb
@@ -45,11 +45,6 @@ RSpec.describe Hyrax::TemplateUpdatesController, type: :controller do
           .to enqueue_job(TemplateUpdateJob)
           .exactly(:twice)
       end
-
-      xit 'redirects to show' do
-        post :create, params: { template_update: update.attributes }
-        expect(response).to redirect_to :show
-      end
     end
   end
 end


### PR DESCRIPTION
This spec can't work.  After a template update, there is no 'show' page
to redirect to.  The template update works on a batch of objects.