### PR TITLE
Completed a pending spec for editing a template.

### DIFF
--- a/spec/controllers/hyrax/templates_controller_spec.rb
+++ b/spec/controllers/hyrax/templates_controller_spec.rb
@@ -59,8 +59,6 @@ RSpec.describe Hyrax::TemplatesController, :clean, type: :controller do
 
         expect(assigns(:form)).to be_a Hyrax::TemplateForm
       end
-
-      it 'renders existing data'
     end
 
     describe 'GET #new' do

--- a/spec/features/template_spec.rb
+++ b/spec/features/template_spec.rb
@@ -71,6 +71,10 @@ RSpec.feature 'Apply a Template', :clean, js: true do
 
       expect(Tufts::Template.for(name: template.name).changeset)
         .not_to be_empty
+
+      # Reload the form: the values I previously entered should be there
+      click_link 'Edit', id: "edit-#{template.name}"
+      expect(find_field('Title').value).to eq 'Moomin Title'
     end
 
     scenario 'edit a template name' do


### PR DESCRIPTION
There was a pending spec for the templates controller to check that the
previously-entered values appear on the template's edit form.  That spec
would have been hard to test in a controller spec because I would have
to reach down too many levels.  (e.g. in order to test the `title`, it
would be something like
`assigns(:form).template.changeset.object.title`.)

So, I decided to test it in a feature spec instead.  I added a test to
check that the `title` field in the template appears correctly on the
form when you edit an existing template.