### PR TITLE
Use `tufts-curation` 1.0.0.rc2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'whenever', require: false
 
 gem 'blacklight_advanced_search'
 
-gem 'tufts-curation', github: 'curationexperts/epigaea_models', tag: 'v1.0.0.rc1'
+gem 'tufts-curation', github: 'curationexperts/tufts-curation', tag: 'v1.0.0.rc2'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/curationexperts/epigaea_models.git
-  revision: c4f3dd0686286220dee584b41f5d16376a7908df
-  tag: v1.0.0.rc1
+  remote: https://github.com/curationexperts/tufts-curation.git
+  revision: 6a2d399da6b4aefc3a027d9365105126b18529ca
+  tag: v1.0.0.rc2
   specs:
     tufts-curation (0.1.0)
       active-fedora (>= 11.5, <= 12.99)

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -1,9 +1,4 @@
 Hyrax.config do |config|
-  # AdminSet Predicate
-  # Set this before setting up models to ensure inverse member relations work
-  # correctly
-  config.admin_set_predicate = Tufts::Vocab::Tufts.admin_set_member
-
   Tufts::Curation.setup_models!(configuration: config) do |model|
     model.include(Tufts::Draftable)
   end


### PR DESCRIPTION
`Tufts::Curation.setup_models!` now sets up the admin set predicate with `Hyrax`, so we don't need to include that manually in the application.

Closes #212.