### PR TITLE
Add a creator to batches created through the `BatchController`

### DIFF
--- a/app/controllers/hyrax/batches_controller.rb
+++ b/app/controllers/hyrax/batches_controller.rb
@@ -11,6 +11,7 @@ module Hyrax
       params['batch']['ids'] ||= params[:batch_document_ids]
 
       batch           = Batch.new(params.require(:batch).permit(ids: []))
+      batch.creator   = current_user if current_user
       batch.batchable = BatchTask.new(batchable_params)
       batch.save
 

--- a/spec/controllers/hyrax/batches_controller_spec.rb
+++ b/spec/controllers/hyrax/batches_controller_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe Hyrax::BatchesController, type: :controller do
         expect { post :create, params: params }.to change { Batch.count }.by(1)
       end
 
+      it 'assigns the current user to the batch' do
+        post :create, params: params
+        expect(Batch.last.user).to be_a User
+      end
+
       it 'enqueues jobs' do
         ActiveJob::Base.queue_adapter = :test
 


### PR DESCRIPTION
Generic batches previously were created with "No Creator"; i.e. `batch.creator #=> nil`. If there is a `current_user` (there always should be), we now create the batch with that user as creator.

Closes #878 