### PR TITLE
Force fade-in on finished uploads

### DIFF
--- a/app/assets/javascripts/tufts/ensure_upload_fade_in.js
+++ b/app/assets/javascripts/tufts/ensure_upload_fade_in.js
@@ -1,3 +1,7 @@
 $('#fileupload').bind('fileuploadstop', function (e, data) {
-  $('.template-download').addClass('in')
+  $('.template-download').addClass('in');
+  $('.template-upload').addClass('in')
 })
+
+$('.template-download').addClass('in')
+$('.template-upload').addClass('in')

--- a/app/assets/javascripts/tufts/ensure_upload_fade_in.js
+++ b/app/assets/javascripts/tufts/ensure_upload_fade_in.js
@@ -1,7 +1,5 @@
-$('#fileupload').bind('fileuploadstop', function (e, data) {
-  $('.template-download').addClass('in');
-  $('.template-upload').addClass('in')
-})
-
-$('.template-download').addClass('in')
-$('.template-upload').addClass('in')
+Blacklight.onLoad(function() {
+  $('#fileupload').bind('fileuploadadd', function (e, data) {
+    $('.template-upload').addClass('in');
+  });
+});


### PR DESCRIPTION
Uploaded objects sometimes fail to fade in, especially on large folder
uploads. We tried to fix this previously in #804, but the class we need to fade
in is sometimes (maybe always?) called `template-upload` rather than
`template-download`, so the fix was incomplete. This may fix the various issues
with batch XML import.

See: #785, #804, #872, & #873.