### PR TITLE
Use typed SolrDocument suffixes for`date_modified` and `date_uploaded`

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -26,7 +26,11 @@ class SolrDocument
 
   Tufts::Terms.shared_terms.each do |term|
     define_method(term) do
-      self[Solrizer.solr_name(term.to_s)]
+      if [:date_uploaded, :date_modified].include?(term)
+        self[term.to_s + '_dtsi']
+      else
+        self[Solrizer.solr_name(term.to_s)]
+      end
     end
   end
 

--- a/spec/features/publication_workflow_spec.rb
+++ b/spec/features/publication_workflow_spec.rb
@@ -48,6 +48,7 @@ RSpec.feature 'deposit and publication', :clean, :workflow do
       # Check it appears as waiting for review in the admin dashboard
       visit("/admin/workflows#under-review")
       expect(page).to have_content work.title.first
+      expect(page).to have_content work.date_modified.strftime('%Y-%m-%d')
 
       # The admin user approves the work, changing its status to "published"
       Tufts::WorkflowStatus.publish(work: work, current_user: publishing_user, comment: "Published in publication_workflow_spec.rb")


### PR DESCRIPTION
These date fields are indexed as typed, and need typed token suffixes for access
from a serialized solr document. This points to the need for a larger refactor
of `Tufts::Terms`, to include the index types. For now, we are hard-coding.

Fixes #883.