### PR TITLE
Don't list all filenames when uploading large numbers of files

### DIFF
--- a/app/controllers/hyrax/xml_imports_controller.rb
+++ b/app/controllers/hyrax/xml_imports_controller.rb
@@ -103,6 +103,8 @@ module Hyrax
       # @private
       # @return [String]
       def added_notice(added, filenames)
+        return "Added #{added.count} files." if added.count > 10
+
         "Added files: #{added.map { |id| filenames[id] }.join(', ')}"
       end
 
@@ -110,6 +112,8 @@ module Hyrax
       # @private
       # @return [String]
       def unmatched_notice(unmatched, filenames)
+        return "#{unmatched.count} files did not match." if unmatched.count > 10
+
         'Files did not match: ' \
         "#{unmatched.map { |id| filenames[id] }.join(', ')};\n"
       end


### PR DESCRIPTION
Rather than flashing a large number of uploaded filenames to the user, simply
display the number of uploaded files.

Fixes #895.