### PR TITLE
Index batch ids for objects

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -120,7 +120,7 @@ class CatalogController < ApplicationController
         retention_period_tesim rights_statement_tesim rights_holder_tesim
         rights_note_tesim source_tesim spatial_tesim admin_start_date_tesim
         steward_tesim subject_tesim table_of_contents_tesim temporal_tesim
-        legacy_pid_tesim resource_type_tesim tufts_is_part_of_tesim" ),
+        legacy_pid_tesim resource_type_tesim tufts_is_part_of_tesim batch_tesim" ),
         pf: title_name.to_s
       }
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -152,6 +152,14 @@ class CatalogController < ApplicationController
       }
     end
 
+    config.add_search_field('batch') do |field|
+      solr_name = solr_name('batch', :stored_searchable)
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
     config.add_search_field('title') do |field|
       solr_name = solr_name("title", :stored_searchable)
       field.solr_local_parameters = {

--- a/app/indexers/mira_indexer.rb
+++ b/app/indexers/mira_indexer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+##
+# Extends `Tufts::Curation::Indexer` to index batches.
+class MiraIndexer < Tufts::Curation::Indexer
+  def generate_solr_document
+    super.tap do |solr_doc|
+      # Batches store ids as a serialized array. To retrieve them, we query
+      # "ids LIKE...". To avoid potential substring collisions (this shouldn't
+      # happen in normal operation), we follow up by filtering the results with
+      # `#select`, before mapping to batch ids.
+      batches = Batch.where("ids LIKE '%#{object.id}%'")
+                     .select { |batch| batch.ids.include?(object.id) }
+                     .map(&:id)
+
+      unless batches.empty?
+        batch_key = Solrizer.solr_name('batch', :stored_searchable)
+        solr_doc[batch_key] = batches
+      end
+    end
+  end
+end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -1,6 +1,7 @@
 Hyrax.config do |config|
   Tufts::Curation.setup_models!(configuration: config) do |model|
     model.include(Tufts::Draftable)
+    model.indexer = MiraIndexer
   end
 
   # Register roles that are expected by your implementation.

--- a/spec/models/pdf_spec.rb
+++ b/spec/models/pdf_spec.rb
@@ -13,4 +13,12 @@ RSpec.describe Pdf do
   end
 
   it { expect(described_class.human_readable_type).to eq 'PDF' }
+
+  context 'when it is in a batch' do
+    let!(:batch) { FactoryGirl.create(:batch, ids: [work.id]) }
+
+    it 'indexes the batches' do
+      expect(work.to_solr['batch_tesim']).to contain_exactly(batch.id)
+    end
+  end
 end


### PR DESCRIPTION
Batch membership is tracked as a serialized array of ids on each `Batch` (`Batch#ids`). This adds reverse lookup of batch ids for objects and indexing as `batch_tesim`.

Connected to #877.