### PR TITLE
Handle self-deposit embargoes correctly

### DIFF
--- a/app/models/forms/contribution.rb
+++ b/app/models/forms/contribution.rb
@@ -11,9 +11,9 @@ class Contribution
 
   class_attribute :ignore_attributes, :attributes
 
-  self.ignore_attributes = [:attachment]
+  self.ignore_attributes = [:attachment, :embargo]
 
-  self.attributes = [:title, :description, :creator, :contributor, :bibliographic_citation, :subject, :attachment, :tufts_license, :embargo_note]
+  self.attributes = [:title, :description, :creator, :contributor, :bibliographic_citation, :subject, :attachment, :tufts_license, :embargo]
 
   SELFDEP = 'selfdep'.freeze
 
@@ -106,7 +106,7 @@ protected
 
   def insert_embargo_date
     return unless @tufts_pdf
-    @tufts_pdf.embargo_note = (Time.zone.now + embargo_note.to_i.months).iso8601 unless (embargo_note || '0').eql? '0'
+    @tufts_pdf.embargo_note = (Time.zone.now + embargo.to_i.months).iso8601 unless (embargo || '0').eql? '0'
   end
 
   def attachment_has_valid_content_type

--- a/app/models/forms/gis_poster.rb
+++ b/app/models/forms/gis_poster.rb
@@ -2,7 +2,7 @@ class GisPoster < GenericTischDeposit
   self.attributes = [:title, :degrees, :schools, :departments, :courses, :methodological_keywords, :geonames,
                      :term, :year, :topics, :geonames_placeholder,
                      :degree,
-                     :description, :creator, :contributor, :embargo_note,
+                     :description, :creator, :contributor,
                      :bibliographic_citation, :subject, :corpname, :attachment, :license]
   # def copy_attributes
   #  super

--- a/app/views/contribute/deposit_view/_capstone_project.html.erb
+++ b/app/views/contribute/deposit_view/_capstone_project.html.erb
@@ -12,6 +12,6 @@
 
 <%= f.select :degree, options_for_select(fletcher_degrees), {prompt: 'Please select a degree', label: 'Degree'}, {required: true} %>
 
-<%= f.select :embargo_note, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
+<%= f.select :embargo, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
 
 <%= f.text_area :description, label: 'Short Description', rows: 5, class: 'col-sm-8'  %>

--- a/app/views/contribute/deposit_view/_cummings_thesis.html.erb
+++ b/app/views/contribute/deposit_view/_cummings_thesis.html.erb
@@ -10,6 +10,6 @@
   <%= react_component('ContributeOtherAuthors', {contributor: []}, {camelize_props: true}) %>
 <% end %>
 
-<%= f.select :embargo_note, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
+<%= f.select :embargo, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
 
 <%= f.text_area :description, label: 'Short Description', rows: 5, class: 'col-sm-8'  %>

--- a/app/views/contribute/deposit_view/_faculty_scholarship.html.erb
+++ b/app/views/contribute/deposit_view/_faculty_scholarship.html.erb
@@ -12,6 +12,6 @@
 <%= react_component('ContributeOtherAuthors', {contributor: []}, {camelize_props: true}) %>
 <% end %>
 
-<%= f.select :embargo_note, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
+<%= f.select :embargo, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
 
 <%= f.text_area :description, label: 'Short Description', rows: 5, class: 'col-sm-8', required: true %>

--- a/app/views/contribute/deposit_view/_generic_deposit.html.erb
+++ b/app/views/contribute/deposit_view/_generic_deposit.html.erb
@@ -10,6 +10,6 @@
   <%= react_component('ContributeOtherAuthors', {contributor: []}, {camelize_props: true}) %>
 <% end %>
 
-<%= f.select :embargo_note, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
+<%= f.select :embargo, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
 
 <%= f.text_area :description, label: 'Short Description', rows: 5, class: 'col-sm-8'  %>

--- a/app/views/contribute/deposit_view/_honors_thesis.html.erb
+++ b/app/views/contribute/deposit_view/_honors_thesis.html.erb
@@ -16,6 +16,6 @@
   Tufts.autocomplete()
 </script>
 
-<%= f.select :embargo_note, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
+<%= f.select :embargo, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
 
 <%= f.text_area :description, label: 'Short Description', rows: 5, class: 'col-sm-8', required: true  %>

--- a/app/views/contribute/deposit_view/_public_health.html.erb
+++ b/app/views/contribute/deposit_view/_public_health.html.erb
@@ -12,6 +12,6 @@
 
 <%= f.select :degree, options_for_select(public_health_degrees), {prompt: 'Please select a degree', label: 'Degree'}, {required: true} %>
 
-<%= f.select :embargo_note, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
+<%= f.select :embargo, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
 
 <%= f.text_area :description, label: 'Short Description', rows: 5, class: 'col-sm-8'  %>

--- a/app/views/contribute/deposit_view/_qualifying_paper.html.erb
+++ b/app/views/contribute/deposit_view/_qualifying_paper.html.erb
@@ -10,6 +10,6 @@
   <%= react_component('ContributeOtherAuthors', {contributor: []}, {camelize_props: true}) %>
 <% end %>
 
-<%= f.select :embargo_note, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
+<%= f.select :embargo, standard_embargos,  label: 'Embargo', help: 'An embargo will restrict all access to your work until the selected time has passed'  %>
 
 <%= f.text_area :description, label: 'Short Description', rows: 5, class: 'col-sm-8', required: true  %>


### PR DESCRIPTION
Self deposit items can be submitted with an optional embargo.  When
no embargo (value '0') is selected, the :embargo_note attribute should
be left empty; otherwise, the embargo note should contain the embargo
release date

closes #888