### PR TITLE
Increase the number of files that can be uploaded at once

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -35,7 +35,7 @@ Hyrax.config do |config|
   # Options to control the file uploader
   config.uploader = {
     limitConcurrentUploads: 6,
-    maxNumberOfFiles: 100,
+    maxNumberOfFiles: 600,
     maxFileSize: 6.gigabytes
   }
 


### PR DESCRIPTION
Tufts often uploads large numbers of files in a single batch operation
and requested that we increase the max file limit from 100-->600

closes #900 