### PR TITLE
Filter Review Submissions to only include self-deposit items 

### DIFF
--- a/app/controllers/hyrax/admin/workflows_controller.rb
+++ b/app/controllers/hyrax/admin/workflows_controller.rb
@@ -1,0 +1,27 @@
+module Hyrax
+  # Presents a list of works in workflow
+  class Admin::WorkflowsController < ApplicationController
+    before_action :ensure_authorized!
+    layout 'dashboard'
+    class_attribute :deposited_workflow_state_name
+
+    # Works that are in this workflow state (see workflow json template) are excluded from the
+    # status list and display in the "Published" tab
+    self.deposited_workflow_state_name = 'deposited'
+
+    def index
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.tasks'), '#'
+      add_breadcrumb t(:'hyrax.admin.sidebar.workflow_review'), request.path
+      @status_list = Hyrax::Workflow::StatusListService.new(self, "-workflow_state_name_ssim:#{deposited_workflow_state_name}")
+      @published_list = Hyrax::Workflow::StatusListService.new(self, "workflow_state_name_ssim:#{deposited_workflow_state_name}")
+    end
+
+    private
+
+      def ensure_authorized!
+        authorize! :review, :submissions
+      end
+  end
+end

--- a/app/controllers/hyrax/admin/workflows_controller.rb
+++ b/app/controllers/hyrax/admin/workflows_controller.rb
@@ -14,7 +14,7 @@ module Hyrax
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.admin.sidebar.tasks'), '#'
       add_breadcrumb t(:'hyrax.admin.sidebar.workflow_review'), request.path
-      @status_list = Hyrax::Workflow::StatusListService.new(self, "-workflow_state_name_ssim:#{deposited_workflow_state_name}")
+      @status_list = Hyrax::Workflow::StatusListService.new(self, "-workflow_state_name_ssim:#{deposited_workflow_state_name} AND createdby_tesim:#{Contribution::SELFDEP}")
       @published_list = Hyrax::Workflow::StatusListService.new(self, "workflow_state_name_ssim:#{deposited_workflow_state_name}")
     end
 

--- a/app/controllers/hyrax/admin/workflows_controller.rb
+++ b/app/controllers/hyrax/admin/workflows_controller.rb
@@ -15,7 +15,7 @@ module Hyrax
       add_breadcrumb t(:'hyrax.admin.sidebar.tasks'), '#'
       add_breadcrumb t(:'hyrax.admin.sidebar.workflow_review'), request.path
       @status_list = Hyrax::Workflow::StatusListService.new(self, "-workflow_state_name_ssim:#{deposited_workflow_state_name} AND createdby_tesim:#{Contribution::SELFDEP}")
-      @published_list = Hyrax::Workflow::StatusListService.new(self, "workflow_state_name_ssim:#{deposited_workflow_state_name}")
+      @published_list = Hyrax::Workflow::StatusListService.new(self, "workflow_state_name_ssim:#{deposited_workflow_state_name} AND createdby_tesim:#{Contribution::SELFDEP}")
     end
 
     private

--- a/spec/features/publication_workflow_spec.rb
+++ b/spec/features/publication_workflow_spec.rb
@@ -74,8 +74,9 @@ RSpec.feature 'deposit and publication', :clean, :workflow do
       # The admin user approves the batch work, changing its status to "published"
       Tufts::WorkflowStatus.publish(work: batch_work, current_user: publishing_user, comment: "Published in publication_workflow_spec.rb")
 
+      # Does not list non-selfdeposit items as published
       visit("/admin/workflows#published")
-      expect(page).to have_content batch_work.title.first
+      expect(page).not_to have_content batch_work.title.first
 
       # The admin user comments on the work
       subject = Hyrax::WorkflowActionInfo.new(work, publishing_user)


### PR DESCRIPTION
0469f44 overwrites the status list to only include self-deposit items when reviewing submissions. The "published" list still contains all items.

ad433d4 adds the same filter to the "published" list.

To accomplish this, we overwrite `Hyrax::Admin::WorkflowController`. That module is copied in wholesale in a separate commit, before making the necessary changes.

Closes #882, #887.