### PR TITLE
Fix typo in `all_fields` configuration

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -120,7 +120,7 @@ class CatalogController < ApplicationController
         retention_period_tesim rights_statement_tesim rights_holder_tesim
         rights_note_tesim source_tesim spatial_tesim admin_start_date_tesim
         steward_tesim subject_tesim table_of_contents_tesim temporal_tesim
-        legacy_pid_tesim resource_type_tesim tufts_is_part_of_tesim batch_tesim" ),
+        legacy_pid_tesim resource_type_tesim tufts_is_part_of_tesim batch_tesim ),
         pf: title_name.to_s
       }
     end


### PR DESCRIPTION
`batch_tesim` had a typo which prevented batch id search from working from the
top search bar. The errant `"` is removed here, fixing search for batch ids.