### PR TITLE
Load uploader config as part of application initialization

### DIFF
--- a/app/assets/javascripts/hyrax/config.js.erb
+++ b/app/assets/javascripts/hyrax/config.js.erb
@@ -1,0 +1,3 @@
+Hyrax.config = {
+    uploader: <%= Hyrax.config.uploader.to_json %>
+}


### PR DESCRIPTION
The uploader configuration code in the Hyrax engine get run when
the engine is loaded, which is before the application-level initializers
run, so settings from the local application never get read.  Moving
the uploader configuration code to the local application ensures that
the javascript has access to the application-level settings instead of
the engine defaults.