### PR TITLE
Update `loofah` and `sanitize`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'react-rails'
 gem 'redis-activesupport', '~> 5.0.4'
 gem 'redis-rails' # Will install several other redis-* gems
 gem 'rsolr', '>= 1.0'
-gem 'sanitize'
+gem 'sanitize', '~> 4.6', '>= 4.6.3'
 gem 'sidekiq'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
-    crass (1.0.2)
+    crass (1.0.3)
     daemons (1.2.5)
     database_cleaner (1.6.1)
     declarative (0.0.10)
@@ -511,7 +511,8 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.0.3)
+    loofah (2.2.1)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
@@ -540,7 +541,7 @@ GEM
     noid (0.9.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    nokogumbo (1.4.13)
+    nokogumbo (1.5.0)
       nokogiri
     oauth (0.5.3)
     oauth2 (1.4.0)
@@ -745,10 +746,10 @@ GEM
       oauth2
     ruby-progressbar (1.8.1)
     rubyzip (1.2.1)
-    sanitize (4.5.0)
+    sanitize (4.6.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
-      nokogumbo (~> 1.4.1)
+      nokogumbo (~> 1.4)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -919,7 +920,7 @@ DEPENDENCIES
   redis-rails
   rsolr (>= 1.0)
   rspec-rails
-  sanitize
+  sanitize (~> 4.6, >= 4.6.3)
   sass-rails (~> 5.0)
   selenium-webdriver
   shoulda-matchers!


### PR DESCRIPTION
Addresses CVE-2018-8048 and CVE-2018-3740.