### PR TITLE
Ensure workflow is setup for `XmlImport` specs

### DIFF
--- a/spec/models/xml_import_spec.rb
+++ b/spec/models/xml_import_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe XmlImport, :batch, type: :model do
+RSpec.describe XmlImport, :batch, :workflow, type: :model do
   subject(:import) { FactoryGirl.build(:xml_import) }
 
   before do


### PR DESCRIPTION
Test order could cause workflow to have been torn down for these tests, causing occasional failures.

Fixes #871.