### PR TITLE
Add the correct solr suffix for modified and uploaded fields

### DIFF
--- a/app/controllers/concerns/advanced_search_fields.rb
+++ b/app/controllers/concerns/advanced_search_fields.rb
@@ -11,10 +11,11 @@ module AdvancedSearchFields
       adv_search_attrs -= already_included_attrs
 
       adv_search_attrs.each do |attr|
-        field_name = attr.to_s.underscore
+        field_name = Tufts::AdvancedSearchField.solr_suffix(attr.to_s.underscore)
+
         config.add_search_field(field_name) do |field|
           field.include_in_simple_select = false
-          field.solr_local_parameters = { qf: field_name + '_tesim' }
+          field.solr_local_parameters = { qf: field_name }
           # using :format_attr for :format because :format refers to the response
           # format in rails controllers
           if attr == :format

--- a/app/lib/tufts/advanced_search_field.rb
+++ b/app/lib/tufts/advanced_search_field.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+###
+# This class returns the Solr field name with the correct suffix. Not
+# all fields in advanced search have a _tesim suffix.
+module Tufts
+  class AdvancedSearchField
+    DTSI_FIELDS = ['date_modified', 'date_uploaded'].freeze
+
+    # @param [String]
+    # @return [String]
+    def self.solr_suffix(field_name)
+      if DTSI_FIELDS.include?(field_name)
+        field_name + '_dtsi'
+      else
+        field_name + '_tesim'
+      end
+    end
+  end
+end

--- a/spec/lib/tufts/advanced_search_field_spec.rb
+++ b/spec/lib/tufts/advanced_search_field_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tufts::AdvancedSearchField do
+  let(:advanced_search_field) { described_class }
+  it 'returns _dtsi suffix for date_modified' do
+    expect(advanced_search_field.solr_suffix('date_modified')).to eq('date_modified_dtsi')
+  end
+
+  it 'returns _dtsi suffix for date_uploaded ' do
+    expect(advanced_search_field.solr_suffix('date_uploaded')).to eq('date_uploaded_dtsi')
+  end
+
+  it 'returns _tesim for other fields' do
+    expect(advanced_search_field.solr_suffix('title')).to eq('title_tesim')
+  end
+end


### PR DESCRIPTION
These fields are `_dtsi` and not `_ssim`. This commit
introduces a small class that will return the correct suffix
for a given field that is used by the advanced search form.
If the suffix isn't corrrect, then the solr query is wrong
and won't return results.

Closes #915