### PR TITLE
Change search field labels

### DIFF
--- a/app/controllers/concerns/advanced_search_fields.rb
+++ b/app/controllers/concerns/advanced_search_fields.rb
@@ -11,11 +11,11 @@ module AdvancedSearchFields
       adv_search_attrs -= already_included_attrs
 
       adv_search_attrs.each do |attr|
-        field_name = Tufts::AdvancedSearchField.solr_suffix(attr.to_s.underscore)
-
+        field_name = attr.to_s.underscore
+        full_field_name = Tufts::AdvancedSearchField.solr_suffix(field_name)
         config.add_search_field(field_name) do |field|
           field.include_in_simple_select = false
-          field.solr_local_parameters = { qf: field_name }
+          field.solr_local_parameters = { qf: full_field_name }
           # using :format_attr for :format because :format refers to the response
           # format in rails controllers
           if attr == :format


### PR DESCRIPTION
This removes the `tesim` and other solr
suffixes from appearing in the search results.

Related to #915