### PR TITLE
Search by batch

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,5 +31,6 @@
 //= require tufts/select_work_type
 //= require tufts/qr_status
 //= require tufts/ensure_upload_fade_in
+//= require tufts/batch_selection
 //= require tufts
 //= require app

--- a/app/assets/javascripts/tufts/batch_selection.js
+++ b/app/assets/javascripts/tufts/batch_selection.js
@@ -1,0 +1,12 @@
+var BatchSelection = {
+  changeSearchFieldOnBatchSelect: function() {
+    $('.batch-search-dropdown-js').on('click', function() {
+      $('#search_field').val('batch')
+    })
+  },
+  changeSearchFieldOnOtherSelect: function() {
+    $('.search-dropdown-js').on('click', function() {
+      $('#search_field').val('all_fields')
+    })
+  }
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -120,7 +120,7 @@ class CatalogController < ApplicationController
         retention_period_tesim rights_statement_tesim rights_holder_tesim
         rights_note_tesim source_tesim spatial_tesim admin_start_date_tesim
         steward_tesim subject_tesim table_of_contents_tesim temporal_tesim
-        legacy_pid_tesim resource_type_tesim tufts_is_part_of_tesim batch_tesim ),
+        legacy_pid_tesim resource_type_tesim tufts_is_part_of_tesim ),
         pf: title_name.to_s
       }
     end

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -17,21 +17,29 @@
         </button>
 
         <ul class="dropdown-menu pull-right">
-          <li>
+          <li class="search-dropdown-js">
             <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
               data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
           </li>
-          <li>
+          <li class="search-dropdown-js" >
             <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
               data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
           </li>
-          <li>
+          <li class="search-dropdown-js">
             <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
               data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
           </li>
-          <li>
+          <li class="search-dropdown-js">
             <%= link_to t("hyrax.search.form.option.my_shares.label_long"), "#",
               data: { "search-option" => hyrax.dashboard_shares_path, "search-label" => t("hyrax.search.form.option.my_shares.label_short") } %>
+          </li>
+          <li class="batch-search-dropdown-js">
+           <%= link_to t("hyrax.search.form.option.batch"), "#",
+             data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.batch") } %>
+            <script>
+             BatchSelection.changeSearchFieldOnBatchSelect()
+             BatchSelection.changeSearchFieldOnOtherSelect()
+            </script>
           </li>
       <% end %>
 

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,0 +1,42 @@
+<%= form_tag search_form_action, method: :get, id: "search-form-header", role: "search" do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <%= hidden_field_tag :search_field, 'all_fields' %>
+  <div class="input-group">
+
+    <label class="sr-only" for="search-field-header"><%= t("hyrax.search.form.q.label", application_name: application_name) %></label>
+    <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+
+    <div class="input-group-btn">
+      <button type="submit" class="btn btn-primary" id="search-submit-header">
+        <%= t('hyrax.search.button.html') %>
+      </button>
+      <% if current_user %>
+        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+          <span data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu pull-right">
+          <li>
+            <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
+              data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
+          </li>
+          <li>
+            <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
+              data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
+          </li>
+          <li>
+            <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
+              data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
+          </li>
+          <li>
+            <%= link_to t("hyrax.search.form.option.my_shares.label_long"), "#",
+              data: { "search-option" => hyrax.dashboard_shares_path, "search-label" => t("hyrax.search.form.option.my_shares.label_short") } %>
+          </li>
+      <% end %>
+
+        </ul>
+    </div><!-- /.input-group-btn -->
+
+  </div><!-- /.input-group -->
+<% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -188,6 +188,10 @@ en:
         note_html: ""
         text: "Private"
       restricted_title_attr: "Change the visibility of this resource"
+  search:
+    form:
+      option:
+        batch: "Batch"
   simple_form:
     labels:
       defaults:

--- a/spec/features/batch_spec.rb
+++ b/spec/features/batch_spec.rb
@@ -78,4 +78,12 @@ RSpec.feature 'Manage batches', :clean, js: true do
 
     expect(page).to have_content batch.creator
   end
+
+  scenario 'searching for a batch' do
+    visit '/'
+    find(:xpath, "//input[@id='search-field-header']").set batch.id
+    execute_script('$(".batch-search-dropdown-js").click()')
+    execute_script('$("#search-submit-header").click()')
+    expect(page).to have_content batch.creator
+  end
 end


### PR DESCRIPTION
This commit adds some JS that handles switching the
search field via that dropdown. There is now a batch
option that allows you to search via batch.

This is tested in the batch feature spec.

`batch_tesim` is also removed from the `All Fields` search.

Closes #877