### PR TITLE
Save degree and course name to `description` for GIS Poster deposits

### DIFF
--- a/app/models/forms/gis_poster.rb
+++ b/app/models/forms/gis_poster.rb
@@ -12,7 +12,8 @@ class GisPoster < GenericTischDeposit
   def copy_attributes
     self.class.attributes
     @tufts_pdf.title = [title]
-    @tufts_pdf.abstract = abstract
+    @tufts_pdf.description = description
+    @tufts_pdf.abstract = nil
     @tufts_pdf.creator = [(send(:creator) unless send(:creator).nil?)]
     @tufts_pdf.tufts_license = license_data(@tufts_pdf)
     @tufts_pdf.corporate_name = corpname
@@ -42,7 +43,7 @@ class GisPoster < GenericTischDeposit
       end
     end
 
-    def abstract
+    def description
       (send(:degrees).nil? ? [] : Array(send(:degrees))) + (send(:courses).nil? ? [] : Array(send(:courses)))
     end
 

--- a/spec/features/contribute/gis_expo_contribute_spec.rb
+++ b/spec/features/contribute/gis_expo_contribute_spec.rb
@@ -44,7 +44,8 @@ RSpec.feature 'GIS Expo Student Winners', :clean, js: true do
       expect(created_pdf.admin_set.title.first).to eq "Default Admin Set"
       expect(created_pdf.active_workflow.name).to eq "mira_publication_workflow"
       expect(created_pdf.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-      expect(created_pdf.abstract).to include("Masters", "CEE 194A: Introduction to Remote Sensing")
+      expect(created_pdf.description).to include("Masters", "CEE 194A: Introduction to Remote Sensing")
+      expect(created_pdf.abstract).to be_empty
       expect(created_pdf.member_of_collections.first.identifier.first).to eq("tufts:UA069.001.DO.PB")
       logout
 


### PR DESCRIPTION
This completes the refactor requested in #357 and fixes the specific
issue described in #917. I.E. store the user entered text as `abstract`
and store any system generated text to `description`.