### PR TITLE
Add :clean metadata to `XmlImport`

### DIFF
--- a/spec/models/xml_import_spec.rb
+++ b/spec/models/xml_import_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe XmlImport, :batch, :workflow, type: :model do
+RSpec.describe XmlImport, :batch, :clean, :workflow, type: :model do
   subject(:import) { FactoryGirl.build(:xml_import) }
 
   before do


### PR DESCRIPTION
These tests are still failing on occasion. The past fix in #914 fixed some
workflow related issues, but it seems like it's possible for other tests to
leave the database in a bad state.

These tests just need to run as clean as possible.