### PR TITLE
Fix results for Date Created

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -186,7 +186,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('date_created') do |field|
-      solr_name = solr_name("created", :stored_searchable)
+      solr_name = solr_name("date_created", :stored_searchable)
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name

--- a/spec/factories/pdf.rb
+++ b/spec/factories/pdf.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     displays_in ['nowhere']
     rights_statement ['http://bostonhistory.org/photorequest.html']
+    date_created ['1500']
     transient do
       user nil
     end

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -15,5 +15,12 @@ RSpec.feature 'perform an advanced search', :clean do
     click_on 'Search'
     expect(page).to have_content(pdf.title[0])
     expect(page).not_to have_content(another_pdf.title[0])
+
+    visit '/advanced'
+    expect(page).to have_content('More Search Options')
+    fill_in 'Date Created', with: pdf.date_created[0]
+    click_on 'Search'
+    expect(page).to have_content(pdf.title[0])
+    expect(page).not_to have_content(another_pdf.title[0])
   end
 end


### PR DESCRIPTION
This fixes an issue of the advanced search form, where
an incorrect solr field for 'Date Created' is used in the
query generated by the form.

This updates the pdf factory with a `date_created` attribute
and changes the the advanced search feature spec to check
that the correct results are returned for a date query.

Related to #915