### PR TITLE
Whitespace deposit

### DIFF
--- a/app/controllers/contribute_controller.rb
+++ b/app/controllers/contribute_controller.rb
@@ -1,5 +1,6 @@
 class ContributeController < ApplicationController
   include GisHelper
+  include Tufts::Normalizer
 
   before_action :load_deposit_type, only: [:new, :create]
 
@@ -31,24 +32,11 @@ class ContributeController < ApplicationController
     end
   end
 
-  # Go through the params hash and normalize whitespace before handing it off to
-  # object creation
-  # @param [ActionController::Parameters] params
-  def normalize_whitespace(params)
-    # For keep_newline_fields, keep single newlines, compress 2+ newlines to 2,
-    # and otherwise strip whitespace as usual
-    keep_newline_fields = ['description', 'abstract']
-    params["contribution"].keys.each do |key|
-      next unless params["contribution"][key].class == String
-      params["contribution"][key] = if keep_newline_fields.include?(key)
-                                      params["contribution"][key].gsub(/[ \t]+?[\n]{2,}[ \t]+?/, "\n\n").gsub(/[ \t]+/, " ").strip
-                                    else
-                                      params["contribution"][key].gsub(/\s+/, " ").strip
-                                    end
-    end
-  end
-
 protected
+
+  def hash_key_for_curation_concern
+    'contribution'
+  end
 
   def load_deposit_type
     @deposit_type = DepositType.where(id: params[:deposit_type]).first

--- a/app/lib/tufts/normalizer.rb
+++ b/app/lib/tufts/normalizer.rb
@@ -1,14 +1,13 @@
 module Tufts
   module Normalizer
     def strip_whitespace(param_value)
-      return nil if param_value.empty?
+      return nil if param_value.respond_to?(:empty?) && param_value.empty?
 
       normalizer.strip_whitespace(param_value)
     end
 
     def strip_whitespace_keep_newlines(param_value)
-      return nil if param_value.empty?
-
+      return nil if param_value.respond_to?(:empty?) && param_value.empty?
       normalizer.strip_whitespace(param_value, keep_newlines: true)
     end
 

--- a/app/lib/tufts/normalizer.rb
+++ b/app/lib/tufts/normalizer.rb
@@ -2,25 +2,14 @@ module Tufts
   module Normalizer
     def strip_whitespace(param_value)
       return nil if param_value.empty?
-      return strip_whitespace_transformation(param_value) if param_value.class == String
-      return param_value.map { |m| strip_whitespace_transformation(m) } if param_value.class == Array
-      param_value
+
+      normalizer.strip_whitespace(param_value)
     end
 
     def strip_whitespace_keep_newlines(param_value)
       return nil if param_value.empty?
-      return strip_whitespace_keep_newlines_transformation(param_value) if param_value.class == String
-      return param_value.map { |m| strip_whitespace_keep_newlines_transformation(m) } if param_value.class == Array
-      param_value
-    end
 
-    def strip_whitespace_keep_newlines_transformation(string)
-      return nil if string.empty?
-      string.delete("\r").gsub(/[\n]{2,}/, "\n\n").gsub(/[ \t]+/, " ").strip
-    end
-
-    def strip_whitespace_transformation(string)
-      string.gsub(/\s+/, " ").strip
+      normalizer.strip_whitespace(param_value, keep_newlines: true)
     end
 
     def normalize_import_field(field, values)
@@ -46,6 +35,12 @@ module Tufts
                                                        strip_whitespace(params[hash_key_for_curation_concern][key])
                                                      end
       end
+    end
+
+    ##
+    # @api private
+    def normalizer
+      @normalizer ||= WhitespaceNormalizer.new
     end
   end
 end

--- a/app/lib/tufts/whitespace_normalizer.rb
+++ b/app/lib/tufts/whitespace_normalizer.rb
@@ -1,0 +1,32 @@
+module Tufts
+  ##
+  # Normalize whitespace for string input
+  class WhitespaceNormalizer
+    ##
+    # @param [Enumerable<#to_str>, #to_str] value
+    #
+    # @return [String, nil]
+    def strip_whitespace(value, keep_newlines: false)
+      if value.respond_to?(:to_str)
+        strip_string(value.to_str, keep_newlines: keep_newlines)
+      elsif value.is_a?(Enumerable)
+        value
+          .map { |str| strip_string(str.to_str, keep_newlines: keep_newlines) }
+          .compact
+      else
+        value
+      end
+    end
+
+    def strip_string(string, keep_newlines: false)
+      stripped =
+        if keep_newlines
+          string.delete("\r").gsub(/[\n]{2,}/, "\n\n").gsub(/[ \t]+/, " ").strip
+        else
+          string.gsub(/\s+/, " ").strip
+        end
+
+      stripped.empty? ? nil : stripped
+    end
+  end
+end

--- a/app/lib/tufts/whitespace_normalizer.rb
+++ b/app/lib/tufts/whitespace_normalizer.rb
@@ -11,7 +11,7 @@ module Tufts
         strip_string(value.to_str, keep_newlines: keep_newlines)
       elsif value.is_a?(Enumerable)
         value
-          .map { |str| strip_string(str.to_str, keep_newlines: keep_newlines) }
+          .map { |v| v.respond_to?(:to_str) ? strip_string(v.to_str, keep_newlines: keep_newlines) : v }
           .compact
       else
         value

--- a/spec/controllers/contribute_controller_spec.rb
+++ b/spec/controllers/contribute_controller_spec.rb
@@ -178,8 +178,8 @@ describe ContributeController do
       described_class.new.normalize_whitespace(params)
       expect(params["contribution"]["title"]).to eq "Space non normalized title"
       expect(params["contribution"]["creator"]).to eq "Name with Spaces"
-      expect(params["contribution"]["description"]).to eq "A short description \n with wonky spaces\n\nBut keep two newlines between paragraphs."
-      expect(params["contribution"]["abstract"]).to eq "A short description \n with wonky spaces\n\nBut keep two newlines between paragraphs."
+      expect(params["contribution"]["description"]).to eq "A short description \n with wonky spaces\n\n But keep two newlines between paragraphs."
+      expect(params["contribution"]["abstract"]).to eq "A short description \n with wonky spaces\n\n But keep two newlines between paragraphs."
     end
   end
 end

--- a/spec/controllers/hyrax/audios_controller_spec.rb
+++ b/spec/controllers/hyrax/audios_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::AudiosController do
           "accrual_policy" => "",
           "creator" => " Name   with  Spaces ",
           "bibliographic_citation" => [" bibliographic   citation   with     spaces    "],
-          "rights_holder" => ["blah     spaces   "],
+          "rights_holder" => ["blah     \nspaces   "],
           "publisher" => ["Publisher  "],
           "description" => [" A short   description \n   with  wonky spaces.\r\n\r\n\r\nBut keep two newlines between paragraphs. "],
           "abstract" => [" A short   description \n   with  wonky spaces.\r\n\r\n\r\nBut keep two newlines between paragraphs. "]

--- a/spec/features/create_generic_object_spec.rb
+++ b/spec/features/create_generic_object_spec.rb
@@ -25,18 +25,18 @@ RSpec.feature 'Create a GenericObject', :clean, js: true do
       expect(page).to have_no_content('Location')
       # Fill out the form with everything
       within('.generic_object_title') do
-        fill_in "Title", with: "Example \nTitle   "
+        fill_in "Title", with: "Title \n with \t condensed   spaces  "
       end
       find(:xpath, '//option[contains(text(), "nowhere")]').select_option
-      fill_in 'Abstract', with: 'Abstract'
+      fill_in 'Abstract', with: " A short   description    with  \t wonky spaces   "
       fill_in 'Accrual Policy', with: 'Accrual Policy'
       fill_in 'Alternate Title', with: 'Alternate Title'
       fill_in 'Audience', with: 'Audience'
-      fill_in 'Bibliographic Citation', with: 'Bibliographic Citation'
+      fill_in 'Bibliographic Citation', with: " bibliographic   citation  \n with     spaces    "
       fill_in 'Contributor', with: 'Contributor'
       fill_in 'Corporate Name', with: 'Corporate Name'
       fill_in 'Created By', with: 'Created By'
-      fill_in 'Creator', with: 'Creator'
+      fill_in 'Creator', with: '     Name   with   Spaces   '
       fill_in 'Creator Department', with: 'Creator Department'
       fill_in 'Date Accepted', with: 'Date Accepted'
       fill_in 'Date Available', with: 'Date Available'
@@ -92,17 +92,17 @@ RSpec.feature 'Create a GenericObject', :clean, js: true do
       sleep(1)
       find('#with_files_submit').click
 
-      expect(page).to have_content 'Example Title'
+      expect(page).to have_content 'Title with condensed spaces'
       expect(page).to have_content 'nowhere'
-      expect(page).to have_content 'Abstract'
+      expect(page).to have_content 'A short description with wonky spaces'
       expect(page).to have_content 'Accrual Policy'
       expect(page).to have_content 'Alternate Title'
       expect(page).to have_content 'Audience'
-      expect(page).to have_content 'Bibliographic Citation'
+      expect(page).to have_content 'bibliographic citation with spaces'
       expect(page).to have_content 'Contributor'
       expect(page).to have_content 'Corporate Name'
       expect(page).to have_content 'Created By'
-      expect(page).to have_content 'Creator'
+      expect(page).to have_content 'Name with Spaces'
       expect(page).to have_content 'Creator Department'
       expect(page).to have_content 'Date Accepted'
       expect(page).to have_content 'Date Available'

--- a/spec/lib/tufts/normalizer_spec.rb
+++ b/spec/lib/tufts/normalizer_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe Tufts::Normalizer do
       it 'raises an error for non string values' do
         values = [Object.new]
 
-        expect { controller.strip_whitespace(values) }
-          .to raise_error NoMethodError
+        expect(controller.strip_whitespace(values))
+          .to contain_exactly(*values)
       end
     end
   end
@@ -121,8 +121,8 @@ RSpec.describe Tufts::Normalizer do
       it 'raises an error for non string values' do
         values = [Object.new]
 
-        expect { controller.strip_whitespace_keep_newlines(values) }
-          .to raise_error NoMethodError
+        expect(controller.strip_whitespace_keep_newlines(values))
+          .to contain_exactly(*values)
       end
     end
   end

--- a/spec/lib/tufts/normalizer_spec.rb
+++ b/spec/lib/tufts/normalizer_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# these tests are descriptive; deprecate this module eventually
+RSpec.describe Tufts::Normalizer do
+  subject(:controller) { klass.new }
+  let(:klass)          { Class.new { include Tufts::Normalizer } }
+
+  describe '.normalize_whitespace' do
+    let(:klass) do
+      Class.new do
+        include Tufts::Normalizer
+
+        def hash_key_for_curation_concern
+          :concern
+        end
+      end
+    end
+
+    let(:params) do
+      { concern:
+        { 'string'           => "moomin   \n\t   ",
+          'array_of_strings' => ['moomin', "moomin\t ", "moomin   \n\t   "],
+          'description'      => "moomin  \n\t   papa",
+          'abstract'         => ['moomin', "moomin\t ", "moomin  \n\t   papa"] } }
+    end
+
+    it 'edits the params with whitespace normalization' do
+      expect { controller.normalize_whitespace(params) }
+        .to change { params[:concern] }
+        .to include('string'           => 'moomin', 'description' => "moomin \n papa",
+                    'array_of_strings' => ['moomin', "moomin", "moomin"],
+                    'abstract'         => ['moomin', "moomin", "moomin \n papa"])
+    end
+  end
+
+  describe '.strip_whitespace' do
+    context 'when the value is another type' do
+      let(:param_value) { :blah }
+
+      it 'returns the value unchanged' do
+        expect(controller.strip_whitespace(param_value)).to eq :blah
+      end
+    end
+
+    context 'when the value is a string' do
+      it 'returns nil for an empty string' do
+        expect(controller.strip_whitespace('')).to be_nil
+      end
+
+      it 'turns extended whitespace into a single space' do
+        expect(controller.strip_whitespace("moomi \n\t n  \n ")).to eq "moomi n"
+      end
+    end
+
+    context 'when the value an array' do
+      it 'returns nil for an empty array' do
+        expect(controller.strip_whitespace([])).to be_nil
+      end
+
+      it 'echos values when a simple string is the only member' do
+        expect(controller.strip_whitespace(['moomin']))
+          .to contain_exactly('moomin')
+      end
+
+      it 'turns extended whitespace into a single space mapped over array' do
+        values = ["moomi \n\t n  \n ", 'moomin', '   moomin']
+
+        expect(controller.strip_whitespace(values))
+          .to contain_exactly 'moomi n', 'moomin', 'moomin'
+      end
+
+      it 'raises an error for non string values' do
+        values = [Object.new]
+
+        expect { controller.strip_whitespace(values) }
+          .to raise_error NoMethodError
+      end
+    end
+  end
+
+  describe '.strip_whitespace_keep_newlines' do
+    context 'when the value is another type' do
+      let(:param_value) { :blah }
+
+      it 'returns the value unchanged' do
+        expect(controller.strip_whitespace_keep_newlines(param_value))
+          .to eq :blah
+      end
+    end
+
+    context 'when the value is a string' do
+      it 'returns nil for an empty string' do
+        expect(controller.strip_whitespace_keep_newlines('')).to be_nil
+      end
+
+      it 'turns extended whitespace into a single space' do
+        expect(controller.strip_whitespace_keep_newlines("moomi \n\t n  \n "))
+          .to eq "moomi \n n"
+      end
+    end
+
+    context 'when the value an array' do
+      it 'returns nil for an empty array' do
+        expect(controller.strip_whitespace_keep_newlines([])).to be_nil
+      end
+
+      it 'echos values when a simple string is the only member' do
+        expect(controller.strip_whitespace_keep_newlines(['moomin']))
+          .to contain_exactly('moomin')
+      end
+
+      it 'turns extended whitespace into a single space mapped over array' do
+        values = ["moomi \n\t n  \n ", 'moomin', '   moomin']
+
+        expect(controller.strip_whitespace_keep_newlines(values))
+          .to contain_exactly "moomi \n n", 'moomin', 'moomin'
+      end
+
+      it 'raises an error for non string values' do
+        values = [Object.new]
+
+        expect { controller.strip_whitespace_keep_newlines(values) }
+          .to raise_error NoMethodError
+      end
+    end
+  end
+end

--- a/spec/lib/tufts/whitespace_normalizer_spec.rb
+++ b/spec/lib/tufts/whitespace_normalizer_spec.rb
@@ -34,17 +34,17 @@ RSpec.describe Tufts::WhitespaceNormalizer do
 
     context 'when value is enumerable' do
       it 'maps normalization over the values' do
-        values = ["moomi \n\t n  \n ", 'moomin', '   moomin', '']
+        values = ["moomi \n\t n  \n ", 'moomin', '   moomin', '', nil, :moomin]
 
         expect(normalizer.strip_whitespace(values))
-          .to contain_exactly "moomi n", 'moomin', 'moomin'
+          .to contain_exactly "moomi n", 'moomin', 'moomin', :moomin
       end
 
       it 'retains keep_newlines' do
-        values = ["moomi \n\t n  \n ", 'moomin', '   moomin', '']
+        values = ["moomi \n\t n  \n ", 'moomin', '   moomin', '', nil, :moomin]
 
         expect(normalizer.strip_whitespace(values, keep_newlines: true))
-          .to contain_exactly "moomi \n n", 'moomin', 'moomin'
+          .to contain_exactly "moomi \n n", 'moomin', 'moomin', :moomin
       end
     end
   end

--- a/spec/lib/tufts/whitespace_normalizer_spec.rb
+++ b/spec/lib/tufts/whitespace_normalizer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Tufts::WhitespaceNormalizer do
 
     context 'when keeping newlines' do
       it 'collapses whitespace into a single whitespace keeping \n' do
-        string = "moomin   \n\r\n moomin  \n\t\r"
+        string = "moomin   \n\n\r\n \t moomin  \n\t\r"
 
         expect(normalizer.strip_whitespace(string, keep_newlines: true))
           .to eq "moomin \n\n moomin"

--- a/spec/lib/tufts/whitespace_normalizer_spec.rb
+++ b/spec/lib/tufts/whitespace_normalizer_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tufts::WhitespaceNormalizer do
+  subject(:normalizer) { described_class.new }
+
+  describe '#strip_whitespace' do
+    it 'returns non-string values unchanged' do
+      expect(normalizer.strip_whitespace(:blah)).to eq :blah
+    end
+
+    it 'returns nil for an empty string' do
+      expect(normalizer.strip_whitespace('')).to be_nil
+    end
+
+    it 'returns nil for a string that is empty after normalization' do
+      expect(normalizer.strip_whitespace("   \n\r ")).to be_nil
+    end
+
+    it 'collapses whitespace into a single whitespace' do
+      expect(normalizer.strip_whitespace("moomin   \n\r moomin  \n\t\r"))
+        .to eq 'moomin moomin'
+    end
+
+    context 'when keeping newlines' do
+      it 'collapses whitespace into a single whitespace keeping \n' do
+        string = "moomin   \n\r\n moomin  \n\t\r"
+
+        expect(normalizer.strip_whitespace(string, keep_newlines: true))
+          .to eq "moomin \n\n moomin"
+      end
+    end
+
+    context 'when value is enumerable' do
+      it 'maps normalization over the values' do
+        values = ["moomi \n\t n  \n ", 'moomin', '   moomin', '']
+
+        expect(normalizer.strip_whitespace(values))
+          .to contain_exactly "moomi n", 'moomin', 'moomin'
+      end
+
+      it 'retains keep_newlines' do
+        values = ["moomi \n\t n  \n ", 'moomin', '   moomin', '']
+
+        expect(normalizer.strip_whitespace(values, keep_newlines: true))
+          .to contain_exactly "moomi \n n", 'moomin', 'moomin'
+      end
+    end
+  end
+end


### PR DESCRIPTION
First refactor to have a reusable & injectable whitespace normalizer. Fix up a few error cases (`NoMethodError`). Then use the normalizer in all object controllers.

Closes #362.