### PR TITLE
Remove trailing whitespace before newlines

### DIFF
--- a/app/lib/tufts/whitespace_normalizer.rb
+++ b/app/lib/tufts/whitespace_normalizer.rb
@@ -21,7 +21,11 @@ module Tufts
     def strip_string(string, keep_newlines: false)
       stripped =
         if keep_newlines
-          string.delete("\r").gsub(/[\n]{2,}/, "\n\n").gsub(/[ \t]+/, " ").strip
+          string.delete("\r")
+                .gsub(/[\n]{2,}/, "\n\n")
+                .gsub(/[ \t]+/, " ")
+                .gsub(/[ \t]$/, '')
+                .strip
         else
           string.gsub(/\s+/, " ").strip
         end

--- a/spec/controllers/contribute_controller_spec.rb
+++ b/spec/controllers/contribute_controller_spec.rb
@@ -178,8 +178,8 @@ describe ContributeController do
       described_class.new.normalize_whitespace(params)
       expect(params["contribution"]["title"]).to eq "Space non normalized title"
       expect(params["contribution"]["creator"]).to eq "Name with Spaces"
-      expect(params["contribution"]["description"]).to eq "A short description \n with wonky spaces\n\n But keep two newlines between paragraphs."
-      expect(params["contribution"]["abstract"]).to eq "A short description \n with wonky spaces\n\n But keep two newlines between paragraphs."
+      expect(params["contribution"]["description"]).to eq "A short description\n with wonky spaces\n\n But keep two newlines between paragraphs."
+      expect(params["contribution"]["abstract"]).to eq "A short description\n with wonky spaces\n\n But keep two newlines between paragraphs."
     end
   end
 end

--- a/spec/controllers/hyrax/audios_controller_spec.rb
+++ b/spec/controllers/hyrax/audios_controller_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Hyrax::AudiosController do
       expect(params["audio"]["accrual_policy"]).to eq nil
       expect(params["audio"]["bibliographic_citation"]).to contain_exactly("bibliographic citation with spaces")
       expect(params["audio"]["rights_holder"]).to contain_exactly("blah spaces")
-      expect(params["audio"]["description"]).to contain_exactly("A short description \n with wonky spaces.\n\nBut keep two newlines between paragraphs.")
-      expect(params["audio"]["abstract"]).to contain_exactly("A short description \n with wonky spaces.\n\nBut keep two newlines between paragraphs.")
+      expect(params["audio"]["description"]).to contain_exactly("A short description\n with wonky spaces.\n\nBut keep two newlines between paragraphs.")
+      expect(params["audio"]["abstract"]).to contain_exactly("A short description\n with wonky spaces.\n\nBut keep two newlines between paragraphs.")
     end
   end
 end

--- a/spec/lib/tufts/import_record_spec.rb
+++ b/spec/lib/tufts/import_record_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Tufts::ImportRecord do
       end
 
       it 'normalized metadata fields' do
-        expect(record.fields.to_a).to include([:abstract, ["Another long description with \n plenty\n of whitespace"]])
+        expect(record.fields.to_a).to include([:abstract, ["Another long description with\n plenty\n of whitespace"]])
       end
     end
   end

--- a/spec/lib/tufts/normalizer_spec.rb
+++ b/spec/lib/tufts/normalizer_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe Tufts::Normalizer do
     it 'edits the params with whitespace normalization' do
       expect { controller.normalize_whitespace(params) }
         .to change { params[:concern] }
-        .to include('string'           => 'moomin', 'description' => "moomin \n papa",
+        .to include('string'           => 'moomin', 'description' => "moomin\n papa",
                     'array_of_strings' => ['moomin', "moomin", "moomin"],
-                    'abstract'         => ['moomin', "moomin", "moomin \n papa"])
+                    'abstract'         => ['moomin', "moomin", "moomin\n papa"])
     end
   end
 
@@ -97,7 +97,7 @@ RSpec.describe Tufts::Normalizer do
 
       it 'turns extended whitespace into a single space' do
         expect(controller.strip_whitespace_keep_newlines("moomi \n\t n  \n "))
-          .to eq "moomi \n n"
+          .to eq "moomi\n n"
       end
     end
 
@@ -115,7 +115,7 @@ RSpec.describe Tufts::Normalizer do
         values = ["moomi \n\t n  \n ", 'moomin', '   moomin']
 
         expect(controller.strip_whitespace_keep_newlines(values))
-          .to contain_exactly "moomi \n n", 'moomin', 'moomin'
+          .to contain_exactly "moomi\n n", 'moomin', 'moomin'
       end
 
       it 'raises an error for non string values' do

--- a/spec/lib/tufts/whitespace_normalizer_spec.rb
+++ b/spec/lib/tufts/whitespace_normalizer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Tufts::WhitespaceNormalizer do
         string = "moomin   \n\n\r\n \t moomin  \n\t\r"
 
         expect(normalizer.strip_whitespace(string, keep_newlines: true))
-          .to eq "moomin \n\n moomin"
+          .to eq "moomin\n\n moomin"
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Tufts::WhitespaceNormalizer do
         values = ["moomi \n\t n  \n ", 'moomin', '   moomin', '', nil, :moomin]
 
         expect(normalizer.strip_whitespace(values, keep_newlines: true))
-          .to contain_exactly "moomi \n n", 'moomin', 'moomin', :moomin
+          .to contain_exactly "moomi\n n", 'moomin', 'moomin', :moomin
       end
     end
   end


### PR DESCRIPTION
One final fix to the whitespace normalizer. We want to destroy trailing
whitespace on each line, not only for the entire string.

Connected to #362.