### PR TITLE
Turbolinks fix for batch selection

### DIFF
--- a/app/assets/javascripts/tufts/batch_selection.js
+++ b/app/assets/javascripts/tufts/batch_selection.js
@@ -1,4 +1,9 @@
 var BatchSelection = {
+  resetToAllFieldsOnTurboLinksLoad: function() {
+    document.addEventListener("turbolinks:load", function() {
+      $('#search_field').val('all_fields')
+    })
+  },
   changeSearchFieldOnBatchSelect: function() {
     $('.batch-search-dropdown-js').on('click', function() {
       $('#search_field').val('batch')

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -37,6 +37,7 @@
            <%= link_to t("hyrax.search.form.option.batch"), "#",
              data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.batch") } %>
             <script>
+             BatchSelection.resetToAllFieldsOnTurboLinksLoad()
              BatchSelection.changeSearchFieldOnBatchSelect()
              BatchSelection.changeSearchFieldOnOtherSelect()
             </script>


### PR DESCRIPTION
This fixes an issue where the batch selection remains selected
after navigating away from the page. This happens because
Turbolinks isn't refreshing the page. The change makes sure
that 'all_fields' is selected whenever the page is reloaded
via Turbolinks.

Related to #877